### PR TITLE
CLI: add --model and --context-1m global flags

### DIFF
--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -41,7 +41,18 @@ enum AuthResolveError: Error, LocalizedError {
 ///
 /// Registers the chosen provider on `APIRegistry.shared` as a side effect so
 /// the returned model can be used immediately.
-func resolveAgentAuth() async throws -> ResolvedAuth {
+///
+/// `modelOverride` (optional) replaces the provider's hardcoded default model
+/// id — catalog metadata is still resolved from `ModelsCatalog`, falling back
+/// to sane defaults if the id is unknown.
+///
+/// `context1m` opts the Anthropic OAuth provider into the 1M-context beta
+/// (adds `context-1m-2025-08-07` to the `anthropic-beta` header and bumps
+/// `contextWindow` to 1M). It is silently ignored by other providers.
+func resolveAgentAuth(
+    modelOverride: String? = nil,
+    context1m: Bool = false
+) async throws -> ResolvedAuth {
     let store = OAuthStore()
     let all = await store.all()
 
@@ -51,19 +62,22 @@ func resolveAgentAuth() async throws -> ResolvedAuth {
     if let providerId = pickStoredProvider(from: all), let creds = all[providerId] {
         switch providerId {
         case "openai-codex":
-            return await registerCodex(store: store, creds: creds)
+            return await registerCodex(store: store, creds: creds, modelOverride: modelOverride)
         case "anthropic":
-            return await registerAnthropicOAuth(store: store, creds: creds)
+            return await registerAnthropicOAuth(
+                store: store, creds: creds,
+                modelOverride: modelOverride, context1m: context1m
+            )
         case "anthropic-api-key":
-            return await registerAnthropicAPIKey(creds: creds)
+            return await registerAnthropicAPIKey(creds: creds, modelOverride: modelOverride)
         case "openai-api-key":
-            return await registerOpenAIAPIKey(creds: creds)
+            return await registerOpenAIAPIKey(creds: creds, modelOverride: modelOverride)
         case "openai-compatible":
-            return try await registerOpenAICompatible(creds: creds)
+            return try await registerOpenAICompatible(creds: creds, modelOverride: modelOverride)
         case "google-api-key":
-            return await registerGoogleAPIKey(creds: creds)
+            return await registerGoogleAPIKey(creds: creds, modelOverride: modelOverride)
         case "github-copilot":
-            return await registerGitHubCopilot(store: store, creds: creds)
+            return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride)
         case "google-gemini-cli", "google-antigravity":
             throw AuthResolveError.unsupportedProvider(providerId)
         default:
@@ -97,7 +111,8 @@ private func pickStoredProvider(from all: [String: OAuthCredentials]) -> String?
 
 private func registerCodex(
     store: OAuthStore,
-    creds: OAuthCredentials
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     // Grab a fresh token if expired. If the refresh fails we still register
@@ -117,10 +132,11 @@ private func registerCodex(
         originator: "kwwk"
     ))
 
-    let catalogEntry = ModelsCatalog.model(provider: "openai-codex", id: "gpt-5.4")
+    let modelId = modelOverride ?? "gpt-5.4"
+    let catalogEntry = ModelsCatalog.model(provider: "openai-codex", id: modelId)
     let model = Model(
-        id: "gpt-5.4",
-        name: catalogEntry?.name ?? "gpt-5.4",
+        id: modelId,
+        name: catalogEntry?.name ?? modelId,
         api: "chatgpt-codex",
         provider: "chatgpt-codex",
         baseUrl: "https://chatgpt.com",
@@ -139,7 +155,7 @@ private func registerCodex(
 
     return ResolvedAuth(
         model: model,
-        modelLabel: "gpt-5.4 · ChatGPT Codex",
+        modelLabel: "\(modelId) · ChatGPT Codex",
         apiKeyResolver: resolver
     )
 }
@@ -148,15 +164,30 @@ private func registerCodex(
 
 private func registerAnthropicOAuth(
     store: OAuthStore,
-    creds: OAuthCredentials
+    creds: OAuthCredentials,
+    modelOverride: String? = nil,
+    context1m: Bool = false
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     _ = try? await manager.apiKey(for: "anthropic")
 
-    await APIRegistry.shared.register(ProviderVariants.anthropicOAuth(accessToken: nil))
+    // Opt into the 1M-context beta when requested. Sent alongside the OAuth
+    // beta as a single comma-separated `anthropic-beta` header value, which
+    // is the wire format the Messages API expects. Requires the account to
+    // have long-context billing enabled — without that, every request 401s
+    // with `"Extra usage is required for long context requests."` even on
+    // small prompts.
+    let beta = context1m
+        ? "oauth-2025-04-20,context-1m-2025-08-07"
+        : "oauth-2025-04-20"
+    await APIRegistry.shared.register(ProviderVariants.anthropicOAuth(
+        accessToken: nil,
+        beta: beta
+    ))
 
-    let modelId = "claude-sonnet-4-5-20250929"
+    let modelId = modelOverride ?? "claude-sonnet-4-5-20250929"
     let catalog = ModelsCatalog.model(provider: "anthropic", id: modelId)
+    let defaultContext = context1m ? 1_000_000 : 200_000
     let model = Model(
         id: modelId,
         name: catalog?.name ?? modelId,
@@ -165,7 +196,7 @@ private func registerAnthropicOAuth(
         baseUrl: "https://api.anthropic.com",
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text, .image],
-        contextWindow: catalog?.contextWindow ?? 200_000,
+        contextWindow: context1m ? 1_000_000 : (catalog?.contextWindow ?? defaultContext),
         maxTokens: catalog?.maxTokens ?? 8192
     )
 
@@ -173,9 +204,10 @@ private func registerAnthropicOAuth(
         try? await manager.apiKey(for: "anthropic")
     }
 
+    let suffix = context1m ? " · Anthropic OAuth (1M ctx)" : " · Anthropic OAuth"
     return ResolvedAuth(
         model: model,
-        modelLabel: "\(modelId) · Anthropic OAuth",
+        modelLabel: "\(modelId)\(suffix)",
         apiKeyResolver: resolver
     )
 }
@@ -184,7 +216,8 @@ private func registerAnthropicOAuth(
 
 private func registerGitHubCopilot(
     store: OAuthStore,
-    creds: OAuthCredentials
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     // Prime the session token — Copilot's `refresh` is actually a PAT →
@@ -232,8 +265,8 @@ private func registerGitHubCopilot(
 
     // Default to `gpt-4.1` — generally available on all Copilot tiers, no
     // policy-enable dependency. Users can /model to Claude/GPT-5/etc after
-    // login-time policy-enable has run.
-    let defaultId = "gpt-4.1"
+    // login-time policy-enable has run, or set `--model` at launch.
+    let defaultId = modelOverride ?? "gpt-4.1"
     let fallback = Model(
         id: defaultId,
         name: defaultId,
@@ -282,11 +315,14 @@ private func registerGitHubCopilot(
 
 // MARK: - Anthropic API key (login form)
 
-private func registerAnthropicAPIKey(creds: OAuthCredentials) async -> ResolvedAuth {
+private func registerAnthropicAPIKey(
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
+) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://api.anthropic.com"
     await APIRegistry.shared.register(AnthropicProvider(defaultAPIKey: creds.access))
 
-    let modelId = "claude-sonnet-4-5-20250929"
+    let modelId = modelOverride ?? "claude-sonnet-4-5-20250929"
     let catalog = ModelsCatalog.model(provider: "anthropic", id: modelId)
     let model = Model(
         id: modelId,
@@ -308,11 +344,14 @@ private func registerAnthropicAPIKey(creds: OAuthCredentials) async -> ResolvedA
 
 // MARK: - OpenAI API key (login form)
 
-private func registerOpenAIAPIKey(creds: OAuthCredentials) async -> ResolvedAuth {
+private func registerOpenAIAPIKey(
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
+) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://api.openai.com"
     await APIRegistry.shared.register(OpenAIResponsesProvider(defaultAPIKey: creds.access))
 
-    let modelId = "gpt-5"
+    let modelId = modelOverride ?? "gpt-5"
     let catalog = ModelsCatalog.model(provider: "openai", id: modelId)
     let model = Model(
         id: modelId,
@@ -334,11 +373,14 @@ private func registerOpenAIAPIKey(creds: OAuthCredentials) async -> ResolvedAuth
 
 // MARK: - Google AI Studio (Gemini direct, login form)
 
-private func registerGoogleAPIKey(creds: OAuthCredentials) async -> ResolvedAuth {
+private func registerGoogleAPIKey(
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
+) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://generativelanguage.googleapis.com"
     await APIRegistry.shared.register(GoogleGeminiProvider(defaultAPIKey: creds.access))
 
-    let modelId = "gemini-2.5-pro"
+    let modelId = modelOverride ?? "gemini-2.5-pro"
     let catalog = ModelsCatalog.model(provider: "google", id: modelId)
     let model = Model(
         id: modelId,
@@ -363,11 +405,15 @@ private func registerGoogleAPIKey(creds: OAuthCredentials) async -> ResolvedAuth
 
 // MARK: - OpenAI-compatible (login form)
 
-private func registerOpenAICompatible(creds: OAuthCredentials) async throws -> ResolvedAuth {
+private func registerOpenAICompatible(
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
+) async throws -> ResolvedAuth {
     guard let baseURL = stringExtra(creds, "baseUrl"), !baseURL.isEmpty else {
         throw AuthResolveError.unsupportedProvider("openai-compatible (missing baseUrl)")
     }
-    guard let modelId = stringExtra(creds, "defaultModel"), !modelId.isEmpty else {
+    let storedModel = stringExtra(creds, "defaultModel")
+    guard let modelId = modelOverride ?? storedModel, !modelId.isEmpty else {
         throw AuthResolveError.unsupportedProvider("openai-compatible (missing defaultModel)")
     }
     await APIRegistry.shared.register(OpenAICompletionsProvider(defaultAPIKey: creds.access))

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -28,9 +28,11 @@ func runHeadlessInternal(
     cwd: String,
     tools: CodingTools,
     thinkingLevel: ThinkingLevel = .medium,
-    autoCompactThreshold: Double? = 0.75
+    autoCompactThreshold: Double? = 0.75,
+    modelOverride: String? = nil,
+    context1m: Bool = false
 ) async throws -> Int32 {
-    let resolved = try await resolveAgentAuth()
+    let resolved = try await resolveAgentAuth(modelOverride: modelOverride, context1m: context1m)
 
     let bgManager = BackgroundTaskManager()
     let sessionId = UUID().uuidString

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -27,9 +27,11 @@ public enum KWWK {
         cwd: String? = nil,
         tools: CodingTools = .all,
         autoCompactThreshold: Double? = 0.75,
-        thinkingLevel: ThinkingLevel = .medium
+        thinkingLevel: ThinkingLevel = .medium,
+        modelOverride: String? = nil,
+        context1m: Bool = false
     ) async throws {
-        let resolved = try await resolveAgentAuth()
+        let resolved = try await resolveAgentAuth(modelOverride: modelOverride, context1m: context1m)
         let workDir = cwd ?? FileManager.default.currentDirectoryPath
         try await runCodingTUIInternal(
             model: resolved.model,
@@ -72,14 +74,18 @@ public enum KWWK {
         prompt: String,
         cwd: String? = nil,
         tools: CodingTools = .all,
-        thinkingLevel: ThinkingLevel = .medium
+        thinkingLevel: ThinkingLevel = .medium,
+        modelOverride: String? = nil,
+        context1m: Bool = false
     ) async throws -> Int32 {
         let workDir = cwd ?? FileManager.default.currentDirectoryPath
         return try await runHeadlessInternal(
             prompt: prompt,
             cwd: workDir,
             tools: tools,
-            thinkingLevel: thinkingLevel
+            thinkingLevel: thinkingLevel,
+            modelOverride: modelOverride,
+            context1m: context1m
         )
     }
 }

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -14,24 +14,46 @@ import KWWKCli
 ///   kwwk -p <prompt>        → one-shot, non-interactive run (stdout = reply)
 ///   kwwk --help             → usage
 ///
-/// `--thinking <off|minimal|low|medium|high|xhigh>` is a global flag that
-/// applies to both the TUI and headless modes. Default is `medium`.
+/// Global flags (apply to both TUI and headless `-p`):
+///   `--thinking <off|minimal|low|medium|high|xhigh>` — reasoning effort, default `medium`.
+///   `--model <id>`     — override the resolved provider's default model id
+///                        (e.g. `--model claude-opus-4-5`). Catalog metadata
+///                        is looked up by id; unknown ids fall back to sane
+///                        defaults for `contextWindow` / `maxTokens`.
+///   `--context-1m`     — opt into Anthropic's 1M-context beta. Adds
+///                        `context-1m-2025-08-07` to the `anthropic-beta`
+///                        header and bumps `contextWindow` to 1_000_000.
+///                        Requires the account to have long-context billing
+///                        enabled. Ignored for non-Anthropic providers.
 @main
 struct KwwkCLI {
     static func main() async {
         var args = Array(CommandLine.arguments.dropFirst())
         let thinkingLevel: ThinkingLevel
         (args, thinkingLevel) = extractThinking(args)
+        let modelOverride: String?
+        (args, modelOverride) = extractStringFlag(args, "--model")
+        let context1m: Bool
+        (args, context1m) = extractBoolFlag(args, "--context-1m")
 
         let subcommand = args.first
 
         switch subcommand {
         case nil:
-            await runOrExit { try await KWWK.runCodingTUI(thinkingLevel: thinkingLevel) }
+            await runOrExit { try await KWWK.runCodingTUI(
+                thinkingLevel: thinkingLevel,
+                modelOverride: modelOverride,
+                context1m: context1m
+            ) }
         case "login":
             await runOrExit { try await KWWK.runLogin() }
         case "-p", "--print":
-            await runPrint(rest: Array(args.dropFirst()), thinkingLevel: thinkingLevel)
+            await runPrint(
+                rest: Array(args.dropFirst()),
+                thinkingLevel: thinkingLevel,
+                modelOverride: modelOverride,
+                context1m: context1m
+            )
         case "-h", "--help":
             printUsage()
         default:
@@ -55,6 +77,10 @@ struct KwwkCLI {
         global options:
           --thinking <level>          reasoning effort: off, minimal, low,
                                       medium (default), high, xhigh
+          --model <id>                override the provider's default model id
+                                      (e.g. --model claude-opus-4-5)
+          --context-1m                opt into Anthropic 1M-context beta
+                                      (long-context billing must be on)
 
         Credentials are read from the OAuth store at ~/.kwwk/oauth.json.
         Run `kwwk login` once to register a provider (OAuth subscription
@@ -87,6 +113,42 @@ struct KwwkCLI {
         return (out, level)
     }
 
+    /// Pull `<flag> <value>` out of argv and return the remaining args plus
+    /// the (optional) value. Missing flag → `nil`. Flag without a value →
+    /// usage error.
+    static func extractStringFlag(_ argv: [String], _ flag: String) -> ([String], String?) {
+        var out: [String] = []
+        var value: String? = nil
+        var i = 0
+        while i < argv.count {
+            if argv[i] == flag {
+                guard i + 1 < argv.count else {
+                    FileHandle.standardError.write(Data(
+                        "kwwk: \(flag) needs an argument\n".utf8
+                    ))
+                    Foundation.exit(2)
+                }
+                value = argv[i + 1]
+                i += 2
+            } else {
+                out.append(argv[i])
+                i += 1
+            }
+        }
+        return (out, value)
+    }
+
+    /// Pull a boolean `<flag>` out of argv. Returns `(remaining, true)` if
+    /// present, `(argv, false)` if not.
+    static func extractBoolFlag(_ argv: [String], _ flag: String) -> ([String], Bool) {
+        var out: [String] = []
+        var seen = false
+        for arg in argv {
+            if arg == flag { seen = true } else { out.append(arg) }
+        }
+        return (out, seen)
+    }
+
     /// Handle `-p` / `--print`. Everything after the flag is joined into
     /// the prompt; if nothing is supplied (or the token is a bare `-`),
     /// the prompt is read from stdin until EOF.
@@ -96,7 +158,12 @@ struct KwwkCLI {
     /// missing credentials, stream error) still print a one-line message
     /// to stderr so a non-zero exit isn't mysterious. Exit codes: 2 = bad
     /// invocation, 1 = runtime/auth failure, 0 = success.
-    static func runPrint(rest: [String], thinkingLevel: ThinkingLevel) async {
+    static func runPrint(
+        rest: [String],
+        thinkingLevel: ThinkingLevel,
+        modelOverride: String?,
+        context1m: Bool
+    ) async {
         let prompt: String
         if rest.isEmpty || rest == ["-"] {
             // Use fd 0 directly instead of `fileno(stdin)` — on Linux
@@ -122,7 +189,12 @@ struct KwwkCLI {
         }
 
         do {
-            let code = try await KWWK.runHeadless(prompt: prompt, thinkingLevel: thinkingLevel)
+            let code = try await KWWK.runHeadless(
+                prompt: prompt,
+                thinkingLevel: thinkingLevel,
+                modelOverride: modelOverride,
+                context1m: context1m
+            )
             Foundation.exit(code)
         } catch {
             let msg = (error as? LocalizedError)?.errorDescription ?? "\(error)"


### PR DESCRIPTION
Both apply to the TUI (`kwwk`) and headless (`kwwk -p`) modes, alongside the existing --thinking flag.

  --model <id>     Override the resolved provider's default model id
                   (e.g. `--model claude-opus-4-5`, `--model gpt-5.4`).
                   Catalog metadata is looked up by id; unknown ids fall
                   back to the per-provider sane defaults for
                   contextWindow / maxTokens.

  --context-1m     Opt the Anthropic OAuth provider into the 1M-context
                   beta. Adds `context-1m-2025-08-07` to `anthropic-beta`
                   and bumps `contextWindow` to 1_000_000. Requires the
                   account to have long-context billing enabled
                   (otherwise the API responds with `"Extra usage is
                   required for long context requests."`). Silently
                   ignored by non-Anthropic providers.

Plumbing:
- `KwwkCLI.main` extracts both flags via two new helpers, `extractStringFlag` and `extractBoolFlag`.
- `KWWK.runCodingTUI` and `KWWK.runHeadless` accept new optional `modelOverride: String?` and `context1m: Bool` parameters and forward them to `resolveAgentAuth`.
- `resolveAgentAuth` accepts the same and routes them to each `register*` provider function. All providers honor `modelOverride`; only `registerAnthropicOAuth` consumes `context1m`.