### PR TITLE
[codex] Add OpenAI Responses WebSocket transport

### DIFF
--- a/Sources/KWWKAI/Context.swift
+++ b/Sources/KWWKAI/Context.swift
@@ -88,6 +88,12 @@ public struct StreamOptions: Sendable {
     /// Providers that lack an analog ignore this.
     public var parallelToolCalls: Bool?
 
+    /// Enables provider/internal diagnostic logging for this stream.
+    public var verbose: Bool?
+
+    /// Optional sink used by providers to surface verbose diagnostics.
+    public var onVerbose: (@Sendable (VerboseEvent) async -> Void)?
+
     public init(
         temperature: Double? = nil,
         maxTokens: Int? = nil,
@@ -102,7 +108,9 @@ public struct StreamOptions: Sendable {
         thinkingBudgets: ThinkingBudgets? = nil,
         cancellation: CancellationHandle? = nil,
         toolChoice: ToolChoice? = nil,
-        parallelToolCalls: Bool? = nil
+        parallelToolCalls: Bool? = nil,
+        verbose: Bool? = nil,
+        onVerbose: (@Sendable (VerboseEvent) async -> Void)? = nil
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
@@ -118,5 +126,16 @@ public struct StreamOptions: Sendable {
         self.cancellation = cancellation
         self.toolChoice = toolChoice
         self.parallelToolCalls = parallelToolCalls
+        self.verbose = verbose
+        self.onVerbose = onVerbose
+    }
+
+    public func emitVerbose(
+        source: String,
+        message: String,
+        metadata: [String: JSONValue] = [:]
+    ) async {
+        guard verbose == true else { return }
+        await onVerbose?(VerboseEvent(source: source, message: message, metadata: metadata))
     }
 }

--- a/Sources/KWWKAI/Events.swift
+++ b/Sources/KWWKAI/Events.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+/// Diagnostic event emitted by providers or other internal components when
+/// verbose mode is enabled. This is UI-only telemetry; providers must avoid
+/// putting secrets or request bodies in these messages.
+public struct VerboseEvent: Codable, Sendable, Hashable {
+    public var timestamp: Int64
+    public var source: String
+    public var message: String
+    public var metadata: [String: JSONValue]
+
+    public init(
+        source: String,
+        message: String,
+        metadata: [String: JSONValue] = [:],
+        timestamp: Int64 = Timestamp.now()
+    ) {
+        self.timestamp = timestamp
+        self.source = source
+        self.message = message
+        self.metadata = metadata
+    }
+}
+
 /// Event emitted by `AssistantMessageStream`. Mirrors pi-ai's
 /// `AssistantMessageEvent` discriminated union.
 public enum AssistantMessageEvent: Sendable, Hashable {

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -20,34 +20,44 @@ import FoundationNetworking
 public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
     public typealias URLBuilder = @Sendable (Model, StreamOptions?, URL) -> URL
     public typealias AuthHeaderBuilder = @Sendable (String) -> [String: String]
+    public typealias WebSocketURLBuilder = @Sendable (URL) -> URL
 
     public let api: String
     public let client: HTTPClient
+    public let webSocketClient: WebSocketClient?
     public let defaultBaseURL: URL
     public let defaultAPIKey: String?
     public let extraHeaders: [String: String]
     public let urlBuilder: URLBuilder
+    public let webSocketURLBuilder: WebSocketURLBuilder
     public let authHeaderBuilder: AuthHeaderBuilder
+    public let maxWebSocketFailures: Int
     /// Request-body fields merged in last (so they override defaults). Use
     /// for vendor quirks like ChatGPT Codex requiring `store: false`.
     public let bodyOverrides: [String: JSONValue]
+    private let sessions = OpenAIResponsesSessionStore()
 
     public init(
         api: String = "openai-responses",
         client: HTTPClient = URLSessionHTTPClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
         defaultBaseURL: URL = URL(string: "https://api.openai.com")!,
         defaultAPIKey: String? = nil,
         extraHeaders: [String: String] = [:],
         bodyOverrides: [String: JSONValue] = [:],
         urlBuilder: URLBuilder? = nil,
+        webSocketURLBuilder: WebSocketURLBuilder? = nil,
+        maxWebSocketFailures: Int = 3,
         authHeaderBuilder: AuthHeaderBuilder? = nil
     ) {
         self.api = api
         self.client = client
+        self.webSocketClient = webSocketClient
         self.defaultBaseURL = defaultBaseURL
         self.defaultAPIKey = defaultAPIKey
         self.extraHeaders = extraHeaders
         self.bodyOverrides = bodyOverrides
+        self.maxWebSocketFailures = max(1, maxWebSocketFailures)
         self.urlBuilder = urlBuilder ?? { model, _, fallback in
             var base = model.baseUrl.isEmpty ? fallback.absoluteString : model.baseUrl
             while base.hasSuffix("/") { base.removeLast() }
@@ -55,6 +65,15 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             // (pi-mono's models.generated.ts does this for OpenAI).
             let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
             return URL(string: "\(versioned)/responses") ?? fallback.appendingPathComponent("v1/responses")
+        }
+        self.webSocketURLBuilder = webSocketURLBuilder ?? { httpURL in
+            var components = URLComponents(url: httpURL, resolvingAgainstBaseURL: false)
+            switch components?.scheme {
+            case "https": components?.scheme = "wss"
+            case "http": components?.scheme = "ws"
+            default: break
+            }
+            return components?.url ?? httpURL
         }
         self.authHeaderBuilder = authHeaderBuilder ?? { key in ["authorization": "Bearer \(key)"] }
     }
@@ -73,9 +92,9 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
     ) async {
         let url = urlBuilder(model, options, defaultBaseURL)
 
-        let body: Data
+        let request: OpenAIResponsesRequest
         do {
-            body = try Self.encodeBody(
+            request = try Self.makeRequest(
                 model: model,
                 context: context,
                 options: options,
@@ -88,19 +107,71 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             return
         }
 
-        var headers: [String: String] = [
-            "content-type": "application/json",
-            "accept": "text/event-stream",
-        ]
-        for (k, v) in extraHeaders { headers[k] = v }
-        if let key = options?.apiKey ?? defaultAPIKey {
-            for (k, v) in authHeaderBuilder(key) { headers[k] = v }
+        let session = sessions.session(for: options?.sessionId)
+        let transport = options?.transport ?? .auto
+        if transport != .sse,
+           let webSocketClient,
+           !session.webSocketDisabled {
+            let wsURL = webSocketURLBuilder(url)
+            await options?.emitVerbose(
+                source: "openai.responses.websocket",
+                message: "attempting WebSocket stream",
+                metadata: ["url": .string(wsURL.absoluteString)]
+            )
+            let wsResult = await runWebSocket(
+                client: webSocketClient,
+                url: wsURL,
+                request: request,
+                out: out,
+                model: model,
+                options: options,
+                session: session
+            )
+            switch wsResult {
+            case .completed:
+                return
+            case .fallbackToHTTP:
+                await options?.emitVerbose(
+                    source: "openai.responses.http",
+                    message: "falling back to HTTP stream"
+                )
+                break
+            case .failedWithoutFallback:
+                return
+            }
+        } else if transport != .sse, session.webSocketDisabled {
+            await options?.emitVerbose(
+                source: "openai.responses.websocket",
+                message: "WebSocket disabled after repeated failures; using HTTP"
+            )
         }
-        for (k, v) in options?.headers ?? [:] { headers[k] = v }
+
+        await runHTTP(
+            url: url,
+            request: request,
+            out: out,
+            model: model,
+            options: options
+        )
+    }
+
+    private func runHTTP(
+        url: URL,
+        request: OpenAIResponsesRequest,
+        out: AssistantMessageStream,
+        model: Model,
+        options: StreamOptions?
+    ) async {
+        let headers = makeHeaders(options: options, accept: "text/event-stream")
+        await options?.emitVerbose(
+            source: "openai.responses.http",
+            message: "starting HTTP stream",
+            metadata: ["url": .string(url.absoluteString)]
+        )
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: body
+                url: url, method: "POST", headers: headers, body: try request.data()
             )
             if response.statusCode >= 400 {
                 // Collect whatever the server wrote (usually a small JSON
@@ -123,7 +194,7 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             }
             let state = OpenAIResponsesState(api: api, provider: model.provider, modelId: model.id)
             state.signal = options?.cancellation
-            try await drive(events: parseSSE(bytes: stream), out: out, state: state)
+            _ = try await drive(events: parseSSE(bytes: stream), out: out, state: state)
         } catch {
             let msg = Self.makeError(api: api, model: model, text: "\(error)")
             out.push(.error(reason: .error, error: msg))
@@ -131,21 +202,250 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
         }
     }
 
-    private func drive(
-        events: AsyncThrowingStream<SSEMessage, Error>,
+    private enum WebSocketRunResult {
+        case completed
+        case fallbackToHTTP
+        case failedWithoutFallback
+    }
+
+    private func runWebSocket(
+        client: WebSocketClient,
+        url: URL,
+        request: OpenAIResponsesRequest,
         out: AssistantMessageStream,
-        state: OpenAIResponsesState
-    ) async throws {
+        model: Model,
+        options: StreamOptions?,
+        session: OpenAIResponsesSessionState
+    ) async -> WebSocketRunResult {
+        var headers = makeHeaders(options: options, accept: nil)
+        // Match Codex's WebSocket transport: the Responses WebSocket beta
+        // header replaces the HTTP/SSE `responses=experimental` beta.
+        mergeHeader(&headers, name: "OpenAI-Beta", value: "responses_websockets=2026-02-06", append: false)
+        let verboseSource = "openai.responses.websocket"
+
+        switch session.beginWebSocketRun() {
+        case .acquired:
+            break
+        case .disabled:
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "WebSocket disabled after repeated failures; using HTTP"
+            )
+            return .fallbackToHTTP
+        case .busy:
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "WebSocket session already has an in-flight response; returning stream error"
+            )
+            let err = Self.makeError(
+                api: api,
+                model: model,
+                text: "OpenAI Responses WebSocket session already has an in-flight response for this sessionId. Use a distinct sessionId for parallel runs."
+            )
+            out.push(.error(reason: .error, error: err))
+            out.end(err)
+            return .failedWithoutFallback
+        }
+        defer { session.endWebSocketRun() }
+
+        var connection: (any WebSocketConnection)?
+        do {
+            if let existing = session.takeConnection() {
+                connection = existing
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "reusing WebSocket connection"
+                )
+            } else {
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "connecting",
+                    metadata: ["url": .string(url.absoluteString)]
+                )
+                connection = try await client.connect(url: url, headers: headers)
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "connected"
+                )
+            }
+            let payload = try session.prepareWebSocketPayload(from: request)
+            try await connection?.send(.text(payload.text))
+            var metadata: [String: JSONValue] = [
+                "input_count": .int(payload.inputCount),
+                "incremental": .bool(payload.previousResponseId != nil),
+            ]
+            if let previousResponseId = payload.previousResponseId {
+                metadata["previous_response_id"] = .string(previousResponseId)
+            }
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "sent response.create",
+                metadata: metadata
+            )
+        } catch {
+            connection?.close()
+            let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "WebSocket setup failed; falling back to HTTP",
+                metadata: [
+                    "disabled": .bool(failure.disabled),
+                    "error": .string("\(error)"),
+                    "failure_count": .int(failure.count),
+                ]
+            )
+            return .fallbackToHTTP
+        }
+        guard let connection else {
+            let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "WebSocket setup failed; falling back to HTTP",
+                metadata: [
+                    "disabled": .bool(failure.disabled),
+                    "error": .string("connection was nil"),
+                    "failure_count": .int(failure.count),
+                ]
+            )
+            return .fallbackToHTTP
+        }
+
+        let state = OpenAIResponsesState(api: api, provider: model.provider, modelId: model.id)
+        state.signal = options?.cancellation
+        let progress = WebSocketStreamProgress()
+        do {
+            let result = try await drive(
+                events: webSocketEvents(from: connection),
+                out: out,
+                state: state,
+                progress: progress,
+                finishOnStreamEnd: false
+            )
+            if result.completed, let responseId = result.message.responseId {
+                session.recordCompletedResponse(
+                    responseId: responseId,
+                    itemsAdded: Self.encodeAssistantOutputItems(result.message)
+                )
+                session.storeConnection(connection)
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "WebSocket response completed; failure count reset",
+                    metadata: ["response_id": .string(responseId)]
+                )
+            } else if result.endedWithoutTerminalEvent {
+                connection.close()
+                let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
+                if !progress.hasReceivedEvent {
+                    await options?.emitVerbose(
+                        source: verboseSource,
+                        message: "WebSocket closed before response event; falling back to HTTP",
+                        metadata: [
+                            "disabled": .bool(failure.disabled),
+                            "failure_count": .int(failure.count),
+                        ]
+                    )
+                    return .fallbackToHTTP
+                }
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "WebSocket closed before completed response; returning stream error",
+                    metadata: [
+                        "disabled": .bool(failure.disabled),
+                        "failure_count": .int(failure.count),
+                    ]
+                )
+                let err = Self.makeError(
+                    api: api,
+                    model: model,
+                    text: "WebSocket stream closed before response.completed"
+                )
+                out.push(.error(reason: .error, error: err))
+                out.end(err)
+                return .failedWithoutFallback
+            } else {
+                connection.close()
+                session.resetWebSocketState(resetFailureCount: progress.hasReceivedEvent)
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "WebSocket closed without completed response",
+                    metadata: ["received_response_event": .bool(progress.hasReceivedEvent)]
+                )
+            }
+            return .completed
+        } catch {
+            connection.close()
+            let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
+            if !progress.hasReceivedEvent {
+                await options?.emitVerbose(
+                    source: verboseSource,
+                    message: "WebSocket failed before response event; falling back to HTTP",
+                    metadata: [
+                        "disabled": .bool(failure.disabled),
+                        "error": .string("\(error)"),
+                        "failure_count": .int(failure.count),
+                    ]
+                )
+                return .fallbackToHTTP
+            }
+            await options?.emitVerbose(
+                source: verboseSource,
+                message: "WebSocket failed after response event; returning stream error",
+                metadata: [
+                    "disabled": .bool(failure.disabled),
+                    "error": .string("\(error)"),
+                    "failure_count": .int(failure.count),
+                ]
+            )
+            let err = Self.makeError(api: api, model: model, text: "WebSocket stream failed: \(error)")
+            out.push(.error(reason: .error, error: err))
+            out.end(err)
+            return .failedWithoutFallback
+        }
+    }
+
+    private func makeHeaders(options: StreamOptions?, accept: String?) -> [String: String] {
+        var headers: [String: String] = ["content-type": "application/json"]
+        if let accept {
+            headers["accept"] = accept
+        }
+        for (k, v) in extraHeaders { mergeHeader(&headers, name: k, value: v, append: false) }
+        if let key = options?.apiKey ?? defaultAPIKey {
+            for (k, v) in authHeaderBuilder(key) {
+                mergeHeader(&headers, name: k, value: v, append: false)
+            }
+        }
+        for (k, v) in options?.headers ?? [:] {
+            mergeHeader(&headers, name: k, value: v, append: false)
+        }
+        return headers
+    }
+
+    private func webSocketEvents(
+        from connection: any WebSocketConnection
+    ) -> WebSocketSSESequence {
+        WebSocketSSESequence(connection: connection)
+    }
+
+    private func drive<S: AsyncSequence>(
+        events: S,
+        out: AssistantMessageStream,
+        state: OpenAIResponsesState,
+        progress: WebSocketStreamProgress? = nil,
+        finishOnStreamEnd: Bool = true
+    ) async throws -> OpenAIResponsesDriveResult where S.Element == SSEMessage {
         var emittedStart = false
         for try await sse in events {
             if state.signal?.isCancelled == true {
                 let aborted = state.asAborted()
                 out.push(.error(reason: .aborted, error: aborted))
                 out.end(aborted)
-                return
+                return OpenAIResponsesDriveResult(message: aborted, completed: false)
             }
             guard case .object(let obj)? = parseJSONObject(sse.data),
                   case .string(let type) = obj["type"] ?? .null else { continue }
+            if type.hasPrefix("response.") {
+                progress?.markReceivedEvent()
+            }
 
             switch type {
             case "response.created":
@@ -272,7 +572,7 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                 let final = state.finalize()
                 out.push(.done(reason: final.stopReason, message: final))
                 out.end(final)
-                return
+                return OpenAIResponsesDriveResult(message: final, completed: true)
 
             case "response.failed", "response.error":
                 let text: String = {
@@ -286,7 +586,18 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                 let err = state.asError(text: text)
                 out.push(.error(reason: .error, error: err))
                 out.end(err)
-                return
+                return OpenAIResponsesDriveResult(message: err, completed: false)
+
+            case "error":
+                let text: String = {
+                    if case .object(let err) = obj["error"] ?? .null,
+                       case .string(let m) = err["message"] ?? .null { return m }
+                    return "OpenAI Responses WebSocket error"
+                }()
+                let err = state.asError(text: text)
+                out.push(.error(reason: .error, error: err))
+                out.end(err)
+                return OpenAIResponsesDriveResult(message: err, completed: false)
 
             default: break
             }
@@ -294,45 +605,50 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
 
         // Stream closed without explicit `response.completed`.
         let final = state.finalize()
-        out.push(.done(reason: final.stopReason, message: final))
-        out.end(final)
+        if finishOnStreamEnd {
+            out.push(.done(reason: final.stopReason, message: final))
+            out.end(final)
+        }
+        return OpenAIResponsesDriveResult(
+            message: final,
+            completed: false,
+            endedWithoutTerminalEvent: true
+        )
     }
 
     // MARK: - Encoding
 
-    private static func encodeBody(
+    private static func makeRequest(
         model: Model, context: Context, options: StreamOptions?,
         bodyOverrides: [String: JSONValue] = [:]
-    ) throws -> Data {
-        var root: [String: Any] = [
-            "model": model.id,
-            "stream": true,
-            "input": encodeInput(context: context),
+    ) throws -> OpenAIResponsesRequest {
+        var root: [String: JSONValue] = [
+            "model": .string(model.id),
+            "stream": .bool(true),
+            "input": .array(encodeInput(context: context)),
         ]
         if let maxTokens = options?.maxTokens ?? (model.maxTokens > 0 ? model.maxTokens : nil) {
-            root["max_output_tokens"] = maxTokens
+            root["max_output_tokens"] = .int(maxTokens)
         }
-        if let temp = options?.temperature { root["temperature"] = temp }
+        if let temp = options?.temperature { root["temperature"] = .double(temp) }
         if let sys = context.systemPrompt, !sys.isEmpty {
-            root["instructions"] = sys
+            root["instructions"] = .string(sys)
         }
         if let tools = context.tools, !tools.isEmpty {
-            root["tools"] = tools.map { tool -> [String: Any] in
-                var entry: [String: Any] = [
-                    "type": "function",
-                    "name": tool.name,
-                    "description": tool.description,
+            root["tools"] = .array(tools.map { tool -> JSONValue in
+                var entry: [String: JSONValue] = [
+                    "type": .string("function"),
+                    "name": .string(tool.name),
+                    "description": .string(tool.description),
                 ]
-                if let params = anyFromJSONValue(tool.parameters) {
-                    entry["parameters"] = params
-                }
-                return entry
-            }
+                entry["parameters"] = tool.parameters
+                return .object(entry)
+            })
             if let choice = encodeToolChoice(options?.toolChoice) {
                 root["tool_choice"] = choice
             }
             if options?.parallelToolCalls == false {
-                root["parallel_tool_calls"] = false
+                root["parallel_tool_calls"] = .bool(false)
             }
         }
         if let reasoning = options?.reasoning {
@@ -342,53 +658,55 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             // requested `effort`, but the reasoning block streams as
             // start → end with no body — so the UI has nothing to show
             // under `[thinking]`.
-            root["reasoning"] = [
-                "effort": reasoning.rawValue,
-                "summary": "auto",
-            ]
+            root["reasoning"] = .object([
+                "effort": .string(reasoning.rawValue),
+                "summary": .string("auto"),
+            ])
         }
-        if let meta = options?.metadata, let any = anyFromJSONValue(.object(meta)) {
-            root["metadata"] = any
+        if let meta = options?.metadata {
+            root["metadata"] = .object(meta)
         }
         // Apply vendor-specific overrides last so they win against defaults.
         for (key, value) in bodyOverrides {
-            if let any = anyFromJSONValue(value) {
-                root[key] = any
-            }
+            root[key] = value
         }
-        return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+        return OpenAIResponsesRequest(fields: root)
     }
 
     /// Convert our Message transcript into OpenAI Responses' `input` array.
     /// Each element is a typed item (`message`, `function_call`, or
     /// `function_call_output`). Assistant messages with tool calls expand
     /// into multiple items.
-    private static func encodeInput(context: Context) -> [[String: Any]] {
-        var out: [[String: Any]] = []
+    private static func encodeInput(context: Context) -> [JSONValue] {
+        var out: [JSONValue] = []
         for message in context.messages {
             switch message {
             case .user(let u):
-                var parts: [[String: Any]] = []
+                var parts: [JSONValue] = []
                 for block in u.content {
                     switch block {
                     case .text(let t):
-                        parts.append(["type": "input_text", "text": t.text])
+                        parts.append(.object(["type": .string("input_text"), "text": .string(t.text)]))
                     case .image(let i):
-                        parts.append([
-                            "type": "input_image",
-                            "image_url": "data:\(i.mimeType);base64,\(i.data)",
-                        ])
+                        parts.append(.object([
+                            "type": .string("input_image"),
+                            "image_url": .string("data:\(i.mimeType);base64,\(i.data)"),
+                        ]))
                     }
                 }
-                out.append(["type": "message", "role": "user", "content": parts])
+                out.append(.object(["type": .string("message"), "role": .string("user"), "content": .array(parts)]))
 
             case .assistant(let a):
-                let textParts: [[String: Any]] = a.content.compactMap { block in
+                let textParts: [JSONValue] = a.content.compactMap { block in
                     guard case .text(let t) = block, !t.text.isEmpty else { return nil }
-                    return ["type": "output_text", "text": t.text]
+                    return .object(["type": .string("output_text"), "text": .string(t.text)])
                 }
                 if !textParts.isEmpty {
-                    out.append(["type": "message", "role": "assistant", "content": textParts])
+                    out.append(.object([
+                        "type": .string("message"),
+                        "role": .string("assistant"),
+                        "content": .array(textParts),
+                    ]))
                 }
                 for block in a.content {
                     if case .toolCall(let tc) = block {
@@ -401,12 +719,12 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                             }
                             return "{}"
                         }()
-                        out.append([
-                            "type": "function_call",
-                            "call_id": tc.id,
-                            "name": tc.name,
-                            "arguments": argsString,
-                        ])
+                        out.append(.object([
+                            "type": .string("function_call"),
+                            "call_id": .string(tc.id),
+                            "name": .string(tc.name),
+                            "arguments": .string(argsString),
+                        ]))
                     }
                 }
 
@@ -414,24 +732,28 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                 let text = tr.content.compactMap { block -> String? in
                     if case .text(let t) = block { return t.text } else { return nil }
                 }.joined(separator: "\n")
-                out.append([
-                    "type": "function_call_output",
-                    "call_id": tr.toolCallId,
-                    "output": text,
-                ])
+                out.append(.object([
+                    "type": .string("function_call_output"),
+                    "call_id": .string(tr.toolCallId),
+                    "output": .string(text),
+                ]))
             }
         }
         return out
     }
 
-    private static func encodeToolChoice(_ choice: ToolChoice?) -> Any? {
+    private static func encodeAssistantOutputItems(_ message: AssistantMessage) -> [JSONValue] {
+        encodeInput(context: Context(messages: [.assistant(message)]))
+    }
+
+    private static func encodeToolChoice(_ choice: ToolChoice?) -> JSONValue? {
         guard let choice else { return nil }
         switch choice {
-        case .auto: return "auto"
-        case .none: return "none"
-        case .required: return "required"
+        case .auto: return .string("auto")
+        case .none: return .string("none")
+        case .required: return .string("required")
         case .tool(let name):
-            return ["type": "function", "name": name]
+            return .object(["type": .string("function"), "name": .string(name)])
         }
     }
 
@@ -456,6 +778,270 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             errorMessage: text,
             timestamp: Timestamp.now()
         )
+    }
+}
+
+private struct OpenAIResponsesDriveResult: Sendable {
+    var message: AssistantMessage
+    var completed: Bool
+    var endedWithoutTerminalEvent = false
+}
+
+private struct WebSocketSSESequence: AsyncSequence, Sendable {
+    typealias Element = SSEMessage
+
+    let connection: any WebSocketConnection
+
+    func makeAsyncIterator() -> Iterator {
+        Iterator(connection: connection)
+    }
+
+    struct Iterator: AsyncIteratorProtocol {
+        let connection: any WebSocketConnection
+
+        mutating func next() async throws -> SSEMessage? {
+            while let message = try await connection.receive() {
+                switch message {
+                case .text(let text):
+                    return SSEMessage(event: "message", data: text, id: nil)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        return SSEMessage(event: "message", data: text, id: nil)
+                    }
+                }
+            }
+            return nil
+        }
+    }
+}
+
+private final class WebSocketStreamProgress: @unchecked Sendable {
+    private let lock = NSLock()
+    private var receivedEvent = false
+
+    var hasReceivedEvent: Bool {
+        lock.withLock { receivedEvent }
+    }
+
+    func markReceivedEvent() {
+        lock.withLock { receivedEvent = true }
+    }
+}
+
+private struct OpenAIResponsesRequest: Sendable, Equatable {
+    var fields: [String: JSONValue]
+
+    var input: [JSONValue] {
+        if case .array(let input) = fields["input"] ?? .null { return input }
+        return []
+    }
+
+    func withoutInput() -> OpenAIResponsesRequest {
+        var copy = self
+        copy.fields["input"] = .array([])
+        return copy
+    }
+
+    func data() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: anyFromJSONValue(.object(fields)) ?? [:],
+            options: [.sortedKeys]
+        )
+    }
+
+    func webSocketPayload(previousResponseId: String? = nil, input: [JSONValue]? = nil) throws -> String {
+        var payload = fields
+        payload["type"] = .string("response.create")
+        if let previousResponseId {
+            payload["previous_response_id"] = .string(previousResponseId)
+        }
+        if let input {
+            payload["input"] = .array(input)
+        }
+        let data = try JSONSerialization.data(
+            withJSONObject: anyFromJSONValue(.object(payload)) ?? [:],
+            options: [.sortedKeys]
+        )
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}
+
+private struct OpenAIResponsesLastResponse: Sendable {
+    var responseId: String
+    var itemsAdded: [JSONValue]
+}
+
+private struct OpenAIResponsesWebSocketFailureStatus: Sendable {
+    var count: Int
+    var disabled: Bool
+}
+
+private struct OpenAIResponsesWebSocketPayload: Sendable {
+    var text: String
+    var previousResponseId: String?
+    var inputCount: Int
+}
+
+private enum OpenAIResponsesWebSocketRunLease: Sendable {
+    case acquired
+    case busy
+    case disabled
+}
+
+private final class OpenAIResponsesSessionStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sessions: [String: OpenAIResponsesSessionState] = [:]
+
+    func session(for sessionId: String?) -> OpenAIResponsesSessionState {
+        guard let sessionId, !sessionId.isEmpty else {
+            return OpenAIResponsesSessionState()
+        }
+        return lock.withLock {
+            if let existing = sessions[sessionId] { return existing }
+            let created = OpenAIResponsesSessionState()
+            sessions[sessionId] = created
+            return created
+        }
+    }
+}
+
+private final class OpenAIResponsesSessionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var connection: (any WebSocketConnection)?
+    private var lastRequest: OpenAIResponsesRequest?
+    private var lastResponse: OpenAIResponsesLastResponse?
+    private var webSocketFailureCount = 0
+    private var disabled = false
+    private var webSocketInFlight = false
+
+    var webSocketDisabled: Bool {
+        lock.withLock { disabled }
+    }
+
+    func beginWebSocketRun() -> OpenAIResponsesWebSocketRunLease {
+        lock.withLock {
+            if disabled { return .disabled }
+            if webSocketInFlight { return .busy }
+            webSocketInFlight = true
+            return .acquired
+        }
+    }
+
+    func endWebSocketRun() {
+        lock.withLock { webSocketInFlight = false }
+    }
+
+    func takeConnection() -> (any WebSocketConnection)? {
+        lock.withLock {
+            let existing = connection
+            connection = nil
+            return existing
+        }
+    }
+
+    func storeConnection(_ next: any WebSocketConnection) {
+        lock.withLock { connection = next }
+    }
+
+    @discardableResult
+    func recordWebSocketFailure(maxFailures: Int) -> OpenAIResponsesWebSocketFailureStatus {
+        let result = lock.withLock { () -> (old: (any WebSocketConnection)?, status: OpenAIResponsesWebSocketFailureStatus) in
+            webSocketFailureCount += 1
+            if webSocketFailureCount >= max(1, maxFailures) {
+                disabled = true
+            }
+            let old = connection
+            connection = nil
+            lastRequest = nil
+            lastResponse = nil
+            return (
+                old,
+                OpenAIResponsesWebSocketFailureStatus(
+                    count: webSocketFailureCount,
+                    disabled: disabled
+                )
+            )
+        }
+        result.old?.close()
+        return result.status
+    }
+
+    func resetWebSocketState(disable: Bool = false, resetFailureCount: Bool = false) {
+        let old = lock.withLock { () -> (any WebSocketConnection)? in
+            if disable { disabled = true }
+            if resetFailureCount { webSocketFailureCount = 0 }
+            let old = connection
+            connection = nil
+            lastRequest = nil
+            lastResponse = nil
+            return old
+        }
+        old?.close()
+    }
+
+    func prepareWebSocketPayload(from request: OpenAIResponsesRequest) throws -> OpenAIResponsesWebSocketPayload {
+        let payload = lock.withLock { () -> (previousResponseId: String?, input: [JSONValue]?) in
+            defer { lastRequest = request }
+            guard let previous = lastRequest,
+                  let response = lastResponse,
+                  !response.responseId.isEmpty,
+                  previous.withoutInput() == request.withoutInput()
+            else {
+                return (nil, nil)
+            }
+
+            let baseline = previous.input + response.itemsAdded
+            let input = request.input
+            guard input.count >= baseline.count,
+                  Array(input.prefix(baseline.count)) == baseline
+            else {
+                return (nil, nil)
+            }
+
+            return (response.responseId, Array(input.dropFirst(baseline.count)))
+        }
+        let text = try request.webSocketPayload(
+            previousResponseId: payload.previousResponseId,
+            input: payload.input
+        )
+        return OpenAIResponsesWebSocketPayload(
+            text: text,
+            previousResponseId: payload.previousResponseId,
+            inputCount: payload.input?.count ?? request.input.count
+        )
+    }
+
+    func recordCompletedResponse(responseId: String, itemsAdded: [JSONValue]) {
+        lock.withLock {
+            webSocketFailureCount = 0
+            lastResponse = OpenAIResponsesLastResponse(
+                responseId: responseId,
+                itemsAdded: itemsAdded
+            )
+        }
+    }
+}
+
+private func mergeHeader(
+    _ headers: inout [String: String],
+    name: String,
+    value: String,
+    append: Bool
+) {
+    if let existingKey = headers.keys.first(where: { $0.caseInsensitiveCompare(name) == .orderedSame }) {
+        if append, !headers[existingKey, default: ""].isEmpty {
+            let existing = headers[existingKey] ?? ""
+            if !existing
+                .split(separator: ",")
+                .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+                .contains(value) {
+                headers[existingKey] = "\(existing), \(value)"
+            }
+        } else {
+            headers[existingKey] = value
+        }
+    } else {
+        headers[name] = value
     }
 }
 

--- a/Sources/KWWKAI/ProviderVariants.swift
+++ b/Sources/KWWKAI/ProviderVariants.swift
@@ -22,12 +22,14 @@ public enum ProviderVariants {
         endpoint: URL,
         apiVersion: String = "2024-10-01-preview",
         apiKey: String? = nil,
-        client: HTTPClient = URLSessionHTTPClient()
+        client: HTTPClient = URLSessionHTTPClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient()
     ) -> OpenAIResponsesProvider {
         let endpointString = endpoint.absoluteString.trimmedSlashes
         return OpenAIResponsesProvider(
             api: "azure-openai-responses",
             client: client,
+            webSocketClient: webSocketClient,
             defaultBaseURL: endpoint,
             defaultAPIKey: apiKey,
             urlBuilder: { model, options, _ in
@@ -112,6 +114,7 @@ public enum ProviderVariants {
         accessToken: String? = nil,
         accountId: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
         originator: String = "kw-cli"
     ) -> OpenAIResponsesProvider {
         var extra: [String: String] = [
@@ -124,6 +127,7 @@ public enum ProviderVariants {
         return OpenAIResponsesProvider(
             api: "chatgpt-codex",
             client: client,
+            webSocketClient: webSocketClient,
             defaultBaseURL: URL(string: "https://chatgpt.com")!,
             defaultAPIKey: accessToken,
             extraHeaders: extra,
@@ -206,6 +210,7 @@ public enum ProviderVariants {
     public static func githubCopilotResponses(
         sessionToken: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
         integrationID: String = "vscode-chat",
         api: String = "openai-responses",
         baseURL: URL = URL(string: "https://api.individual.githubcopilot.com")!
@@ -214,6 +219,7 @@ public enum ProviderVariants {
         return OpenAIResponsesProvider(
             api: api,
             client: client,
+            webSocketClient: webSocketClient,
             defaultBaseURL: baseURL,
             defaultAPIKey: sessionToken,
             extraHeaders: copilotEditorHeaders(integrationID: integrationID),

--- a/Sources/KWWKAI/WebSocketClient.swift
+++ b/Sources/KWWKAI/WebSocketClient.swift
@@ -1,0 +1,68 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum WebSocketMessage: Sendable, Equatable {
+    case text(String)
+    case data(Data)
+}
+
+public protocol WebSocketConnection: Sendable {
+    func send(_ message: WebSocketMessage) async throws
+    func receive() async throws -> WebSocketMessage?
+    func close()
+}
+
+public protocol WebSocketClient: Sendable {
+    func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection
+}
+
+public struct URLSessionWebSocketClient: WebSocketClient {
+    public let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection {
+        var request = URLRequest(url: url)
+        for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
+        let task = session.webSocketTask(with: request)
+        task.resume()
+        return URLSessionWebSocketConnection(task: task)
+    }
+}
+
+private final class URLSessionWebSocketConnection: WebSocketConnection, @unchecked Sendable {
+    private let task: URLSessionWebSocketTask
+
+    init(task: URLSessionWebSocketTask) {
+        self.task = task
+    }
+
+    func send(_ message: WebSocketMessage) async throws {
+        switch message {
+        case .text(let text):
+            try await task.send(.string(text))
+        case .data(let data):
+            try await task.send(.data(data))
+        }
+    }
+
+    func receive() async throws -> WebSocketMessage? {
+        let message = try await task.receive()
+        switch message {
+        case .string(let text):
+            return .text(text)
+        case .data(let data):
+            return .data(data)
+        @unknown default:
+            return nil
+        }
+    }
+
+    func close() {
+        task.cancel(with: .normalClosure, reason: nil)
+    }
+}

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -13,6 +13,7 @@ public struct AgentInitialState: Sendable {
     public var model: Model
     public var thinkingLevel: ThinkingLevel
     public var thinkingDisplay: ThinkingDisplay
+    public var verboseEnabled: Bool
     public var tools: [AgentTool]
     public var messages: [Message]
 
@@ -21,6 +22,7 @@ public struct AgentInitialState: Sendable {
         model: Model,
         thinkingLevel: ThinkingLevel = .off,
         thinkingDisplay: ThinkingDisplay = .collapsed,
+        verboseEnabled: Bool = false,
         tools: [AgentTool] = [],
         messages: [Message] = []
     ) {
@@ -28,6 +30,7 @@ public struct AgentInitialState: Sendable {
         self.model = model
         self.thinkingLevel = thinkingLevel
         self.thinkingDisplay = thinkingDisplay
+        self.verboseEnabled = verboseEnabled
         self.tools = tools
         self.messages = messages
     }
@@ -161,6 +164,7 @@ public final class Agent: @unchecked Sendable {
             model: options.initialState.model,
             thinkingLevel: options.initialState.thinkingLevel,
             thinkingDisplay: options.initialState.thinkingDisplay,
+            verboseEnabled: options.initialState.verboseEnabled,
             tools: options.initialState.tools,
             messages: options.initialState.messages
         )
@@ -376,6 +380,7 @@ extension Agent {
             reasoning: effectiveReasoning,
             thinkingBudgets: thinkingBudgets,
             sessionId: sessionId,
+            verboseEnabled: state.verboseEnabled,
             maxRetryDelayMs: maxRetryDelayMs,
             toolExecution: toolExecution,
             toolChoice: toolChoice,

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -8,6 +8,7 @@ public struct AgentLoopConfig: Sendable {
     public var reasoning: ReasoningLevel?
     public var thinkingBudgets: ThinkingBudgets?
     public var sessionId: String?
+    public var verboseEnabled: Bool
     public var maxRetryDelayMs: Int?
     public var toolExecution: ToolExecutionMode
     public var toolChoice: ToolChoice?
@@ -34,6 +35,7 @@ public struct AgentLoopConfig: Sendable {
         reasoning: ReasoningLevel? = nil,
         thinkingBudgets: ThinkingBudgets? = nil,
         sessionId: String? = nil,
+        verboseEnabled: Bool = false,
         maxRetryDelayMs: Int? = nil,
         toolExecution: ToolExecutionMode = .parallel,
         toolChoice: ToolChoice? = nil,
@@ -54,6 +56,7 @@ public struct AgentLoopConfig: Sendable {
         self.reasoning = reasoning
         self.thinkingBudgets = thinkingBudgets
         self.sessionId = sessionId
+        self.verboseEnabled = verboseEnabled
         self.maxRetryDelayMs = maxRetryDelayMs
         self.toolExecution = toolExecution
         self.toolChoice = toolChoice
@@ -448,7 +451,11 @@ public enum AgentLoop {
             thinkingBudgets: config.thinkingBudgets,
             cancellation: cancellation,
             toolChoice: config.toolChoice,
-            parallelToolCalls: config.parallelToolCalls
+            parallelToolCalls: config.parallelToolCalls,
+            verbose: config.verboseEnabled,
+            onVerbose: { event in
+                await emit(.verbose(event))
+            }
         )
 
         var lastError: Error?

--- a/Sources/KWWKAgent/AgentState.swift
+++ b/Sources/KWWKAgent/AgentState.swift
@@ -14,6 +14,7 @@ public final class AgentState: @unchecked Sendable {
     private var _model: Model
     private var _thinkingLevel: ThinkingLevel
     private var _thinkingDisplay: ThinkingDisplay
+    private var _verboseEnabled: Bool
     private var _tools: [AgentTool]
     private var _messages: [Message]
     private var _isStreaming: Bool = false
@@ -26,6 +27,7 @@ public final class AgentState: @unchecked Sendable {
         model: Model,
         thinkingLevel: ThinkingLevel = .off,
         thinkingDisplay: ThinkingDisplay = .collapsed,
+        verboseEnabled: Bool = false,
         tools: [AgentTool] = [],
         messages: [Message] = []
     ) {
@@ -33,6 +35,7 @@ public final class AgentState: @unchecked Sendable {
         self._model = model
         self._thinkingLevel = thinkingLevel
         self._thinkingDisplay = thinkingDisplay
+        self._verboseEnabled = verboseEnabled
         self._tools = tools
         self._messages = messages
     }
@@ -57,6 +60,11 @@ public final class AgentState: @unchecked Sendable {
     public var thinkingDisplay: ThinkingDisplay {
         get { lock.withLock { _thinkingDisplay } }
         set { lock.withLock { _thinkingDisplay = newValue } }
+    }
+
+    public var verboseEnabled: Bool {
+        get { lock.withLock { _verboseEnabled } }
+        set { lock.withLock { _verboseEnabled = newValue } }
     }
 
     /// Array setter copies to prevent external aliasing. Reads return a
@@ -117,4 +125,3 @@ public final class AgentState: @unchecked Sendable {
         lock.withLock { _errorMessage = message }
     }
 }
-

--- a/Sources/KWWKAgent/AgentTypes.swift
+++ b/Sources/KWWKAgent/AgentTypes.swift
@@ -159,6 +159,9 @@ public enum AgentEvent: Sendable {
     /// produces a fresh `messageStart` + updates.
     case streamRewind
 
+    /// Diagnostic event emitted only when verbose mode is enabled.
+    case verbose(VerboseEvent)
+
     public var type: String {
         switch self {
         case .agentStart: return "agent_start"
@@ -173,6 +176,7 @@ public enum AgentEvent: Sendable {
         case .toolExecutionEnd: return "tool_execution_end"
         case .streamRetry: return "stream_retry"
         case .streamRewind: return "stream_rewind"
+        case .verbose: return "verbose"
         }
     }
 }

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -127,11 +127,14 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         toolSnippets: DefaultToolSnippets.all
     ))
 
-    let agent = Agent(initialState: AgentInitialState(
-        systemPrompt: systemPrompt,
-        model: config.model,
-        tools: tools
-    ))
+    let agent = Agent(
+        initialState: AgentInitialState(
+            systemPrompt: systemPrompt,
+            model: config.model,
+            tools: tools
+        ),
+        sessionId: sessionId
+    )
 
     if let bgManager {
         _ = await agent.attachBackgroundManager(bgManager, sessionId: sessionId)

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -28,6 +28,11 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
         handler: handleThinkingCommand
     ))
     registry.register(SlashCommand(
+        name: "verbose",
+        description: "Toggle verbose provider/internal diagnostics",
+        handler: handleVerboseCommand
+    ))
+    registry.register(SlashCommand(
         name: "help",
         description: "List available slash commands",
         handler: { ctx, _ in
@@ -155,6 +160,42 @@ func adoptFields(from current: Model, into picked: Model) -> Model {
         maxTokens: resolvedMaxTokens,
         headers: current.headers
     )
+}
+
+// MARK: - /verbose
+
+/// `/verbose` toggles verbose provider/internal diagnostics for subsequent
+/// requests. `/verbose on|off|status` sets or reads the mode explicitly.
+@MainActor
+private func handleVerboseCommand(_ ctx: SlashContext, _ args: String) async {
+    let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let previous = ctx.agent.state.verboseEnabled
+
+    let next: Bool?
+    switch trimmed {
+    case "", "toggle":
+        next = !previous
+    case "on", "enable", "enabled", "true", "yes":
+        next = true
+    case "off", "disable", "disabled", "false", "no":
+        next = false
+    case "status":
+        next = nil
+    default:
+        ctx.notify(Style.error("  /verbose: unknown arg '\(args)'. Try /verbose, /verbose on, /verbose off, or /verbose status"))
+        return
+    }
+
+    if let next {
+        ctx.agent.state.verboseEnabled = next
+        if next == previous {
+            ctx.notify(Style.dimmed("  /verbose: already \(next ? "on" : "off")"))
+        } else {
+            ctx.notify(Style.dimmed("  /verbose: \(previous ? "on" : "off") → \(next ? "on" : "off")"))
+        }
+    } else {
+        ctx.notify(Style.dimmed("  /verbose: \(previous ? "on" : "off")"))
+    }
 }
 
 // MARK: - /thinking

--- a/Sources/KWWKCli/TranscriptRenderer.swift
+++ b/Sources/KWWKCli/TranscriptRenderer.swift
@@ -51,6 +51,11 @@ final class TranscriptRenderer {
     /// the live zone). Reset to 0 on every `messageStart(.assistant)`.
     private var streamingCommittedPrefix: Int = 0
 
+    /// Verbose diagnostics that arrived while the assistant body was live.
+    /// They are committed after `messageEnd` so provider logs don't interleave
+    /// with token streaming in the live zone.
+    private var queuedVerboseLines: [String] = []
+
     /// In-flight tool calls, kept in **start order** so we can drain the
     /// front-of-queue when settlements land (out-of-order completions
     /// wait for preceding ones). Each slot carries either a `.running`
@@ -218,6 +223,7 @@ final class TranscriptRenderer {
                 streamingBody = []
                 streamingCommittedPrefix = 0
                 recomputeLive()
+                flushQueuedVerbose()
             case .toolResult, .user:
                 break
             }
@@ -239,7 +245,7 @@ final class TranscriptRenderer {
             recomputeLive()
 
         case .agentEnd:
-            break
+            flushQueuedVerbose()
 
         case .streamRetry(_, let delayMs, _):
             let delayLabel = delayMs >= 1000
@@ -264,7 +270,16 @@ final class TranscriptRenderer {
             }
             streamingBody = []
             streamingCommittedPrefix = 0
+            queuedVerboseLines.removeAll()
             recomputeLive()
+
+        case .verbose(let event):
+            let lines = renderVerbose(event)
+            if streaming {
+                queuedVerboseLines.append(contentsOf: lines)
+            } else {
+                commit(lines)
+            }
 
         default: break
         }
@@ -288,6 +303,12 @@ final class TranscriptRenderer {
             commit(resolved)
             toolSlots.removeFirst()
         }
+    }
+
+    private func flushQueuedVerbose() {
+        guard !queuedVerboseLines.isEmpty else { return }
+        commit(queuedVerboseLines)
+        queuedVerboseLines.removeAll()
     }
 
     /// Rebuild `liveLines` from the current streaming body + any
@@ -483,6 +504,26 @@ final class TranscriptRenderer {
             out.append(styler("  ⎿ … \(hidden) more lines"))
         }
         return out
+    }
+
+    private func renderVerbose(_ event: VerboseEvent) -> [String] {
+        var line = "  verbose"
+        if !event.source.isEmpty {
+            line += " [\(event.source)]"
+        }
+        line += ": \(event.message)"
+        let metadata = formatVerboseMetadata(event.metadata)
+        if !metadata.isEmpty {
+            line += " · \(metadata)"
+        }
+        return ["", Style.dimmed(line)]
+    }
+
+    private func formatVerboseMetadata(_ metadata: [String: JSONValue]) -> String {
+        metadata.keys.sorted().compactMap { key in
+            guard let value = metadata[key] else { return nil }
+            return "\(key)=\(formatValue(value))"
+        }.joined(separator: " ")
     }
 
     private func truncate(_ s: String, to max: Int) -> String {

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -76,7 +76,7 @@ struct OpenAIResponsesTests {
     @Test("streams text + completes with usage")
     func basicText() async throws {
         let client = StubSSEClient(body: Self.textSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "sk-test")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "sk-test")
         let s = provider.stream(
             model: Self.model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]),
@@ -97,7 +97,7 @@ struct OpenAIResponsesTests {
     @Test("streams function_call with incremental arguments")
     func toolUse() async throws {
         let client = StubSSEClient(body: Self.toolUseSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "k")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         let s = provider.stream(
             model: Self.model,
             context: Context(messages: [.user(UserMessage(text: "go"))]),
@@ -120,7 +120,7 @@ struct OpenAIResponsesTests {
     @Test("surfaces reasoning items as thinking blocks")
     func reasoningBlocks() async throws {
         let client = StubSSEClient(body: Self.reasoningSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "k")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         let s = provider.stream(
             model: Self.model,
             context: Context(messages: [.user(UserMessage(text: "think"))]),
@@ -140,7 +140,7 @@ struct OpenAIResponsesTests {
     @Test("encodes input array with instructions + tools")
     func bodyEncoding() async throws {
         let client = StubSSEClient(body: Self.textSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "k")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         _ = provider.stream(
             model: Self.model,
             context: Context(
@@ -177,7 +177,7 @@ struct OpenAIResponsesTests {
     @Test("represents tool_result as function_call_output in the input array")
     func toolResultEncoding() async throws {
         let client = StubSSEClient(body: Self.textSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "k")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         let assistant = AssistantMessage(
             content: [.toolCall(ToolCall(id: "call_1", name: "calc", arguments: ["a": 1]))],
             api: "openai-responses",
@@ -215,7 +215,7 @@ struct OpenAIResponsesTests {
 
         """
         let client = StubSSEClient(body: errorSSE)
-        let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: "k")
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         let s = provider.stream(
             model: Self.model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]),
@@ -225,5 +225,457 @@ struct OpenAIResponsesTests {
         let result = await s.result()
         #expect(result.stopReason == .error)
         #expect(result.errorMessage == "quota exceeded")
+    }
+
+    @Test("defaults to WebSocket and sends response.create")
+    func webSocketDefault() async throws {
+        let http = StubSSEClient(body: Self.textSSE)
+        let connection = StubWebSocketConnection(batches: [Self.webSocketMessages(from: Self.textSSE)])
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+        let verbose = VerboseEventRecorder()
+
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                sessionId: "ws-default",
+                verbose: true,
+                onVerbose: { event in await verbose.append(event) }
+            )
+        )
+        for await _ in s {}
+        let result = await s.result()
+
+        #expect(result.responseId == "resp_1")
+        #expect(ws.connectCount == 1)
+        #expect(http.lastRequest == nil)
+        #expect(ws.lastURL?.absoluteString == "wss://api.openai.com/v1/responses")
+        #expect(ws.lastHeaders["authorization"] == "Bearer k")
+        #expect(ws.lastHeaders["OpenAI-Beta"] == "responses_websockets=2026-02-06")
+
+        let payload = try Self.jsonObject(connection.sentTexts[0])
+        #expect(payload["type"] as? String == "response.create")
+        #expect(payload["previous_response_id"] == nil)
+        let input = payload["input"] as? [[String: Any]]
+        #expect(input?.count == 1)
+
+        let messages = await verbose.messages()
+        #expect(messages.contains("attempting WebSocket stream"))
+        #expect(messages.contains("sent response.create"))
+        #expect(messages.contains("WebSocket response completed; failure count reset"))
+    }
+
+    @Test("reuses previous response id and sends only new input over WebSocket")
+    func webSocketIncrementalInput() async throws {
+        let first = Self.textSSE
+        let second = Self.textSSE.replacingOccurrences(of: "resp_1", with: "resp_2")
+        let connection = StubWebSocketConnection(batches: [
+            Self.webSocketMessages(from: first),
+            Self.webSocketMessages(from: second),
+        ])
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = OpenAIResponsesProvider(
+            client: StubSSEClient(body: ""),
+            webSocketClient: ws,
+            defaultAPIKey: "k"
+        )
+
+        let firstStream = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(sessionId: "ws-incremental")
+        )
+        for await _ in firstStream {}
+        let firstResult = await firstStream.result()
+
+        let secondStream = provider.stream(
+            model: Self.model,
+            context: Context(messages: [
+                .user(UserMessage(text: "hi")),
+                .assistant(firstResult),
+                .user(UserMessage(text: "again")),
+            ]),
+            options: StreamOptions(sessionId: "ws-incremental")
+        )
+        for await _ in secondStream {}
+        let secondResult = await secondStream.result()
+
+        #expect(firstResult.responseId == "resp_1")
+        #expect(secondResult.responseId == "resp_2")
+        #expect(ws.connectCount == 1)
+        #expect(connection.sentTexts.count == 2)
+
+        let payload = try Self.jsonObject(connection.sentTexts[1])
+        #expect(payload["previous_response_id"] as? String == "resp_1")
+        let input = payload["input"] as? [[String: Any]]
+        #expect(input?.count == 1)
+        #expect(input?.first?["role"] as? String == "user")
+        let content = input?.first?["content"] as? [[String: Any]]
+        #expect(content?.first?["text"] as? String == "again")
+    }
+
+    @Test("falls back to HTTP on connect failure and disables WebSocket after the failure budget")
+    func webSocketConnectFailureBudgetFallsBackToHTTP() async throws {
+        let http = StubSSEClient(body: Self.textSSE)
+        let ws = StubWebSocketClient(error: StubWebSocketError.connect)
+        let provider = OpenAIResponsesProvider(
+            client: http,
+            webSocketClient: ws,
+            defaultAPIKey: "k",
+            maxWebSocketFailures: 2
+        )
+        let options = StreamOptions(sessionId: "ws-fallback")
+
+        let first = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: options
+        )
+        for await _ in first {}
+        #expect(await first.result().responseId == "resp_1")
+        #expect(ws.connectCount == 1)
+        #expect(http.lastRequest != nil)
+
+        let second = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "again"))]),
+            options: options
+        )
+        for await _ in second {}
+        #expect(await second.result().responseId == "resp_1")
+        #expect(ws.connectCount == 2)
+
+        let third = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "after disabled"))]),
+            options: options
+        )
+        for await _ in third {}
+        #expect(await third.result().responseId == "resp_1")
+        #expect(ws.connectCount == 2)
+    }
+
+    @Test("falls back to HTTP when WebSocket receive fails before the first event")
+    func webSocketReceiveFailureBeforeFirstEventFallsBackToHTTP() async throws {
+        let http = StubSSEClient(body: Self.textSSE)
+        let connection = StubWebSocketConnection(batches: [[]], receiveError: StubWebSocketError.receive)
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(sessionId: "ws-receive-fallback")
+        )
+        for await _ in s {}
+        let result = await s.result()
+
+        #expect(result.responseId == "resp_1")
+        #expect(ws.connectCount == 1)
+        #expect(http.lastRequest != nil)
+    }
+
+    @Test("reconnects on the next request after a WebSocket stream failure")
+    func webSocketStreamFailureReconnectsNextRequest() async throws {
+        let responseCreated = """
+        {"type":"response.created","response":{"id":"resp_partial","status":"in_progress"}}
+        """
+        let firstConnection = StubWebSocketConnection(
+            batches: [[responseCreated]],
+            receiveError: StubWebSocketError.receive
+        )
+        let secondConnection = StubWebSocketConnection(batches: [Self.webSocketMessages(from: Self.textSSE)])
+        let ws = StubWebSocketClient(connections: [firstConnection, secondConnection])
+        let http = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+        let options = StreamOptions(sessionId: "ws-reconnect-after-stream-error")
+
+        let first = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: options
+        )
+        for await _ in first {}
+        let firstResult = await first.result()
+        #expect(firstResult.stopReason == .error)
+        #expect(firstResult.errorMessage?.contains("WebSocket stream failed") == true)
+        #expect(http.lastRequest == nil)
+        #expect(ws.connectCount == 1)
+
+        let second = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: options
+        )
+        for await _ in second {}
+        #expect(await second.result().responseId == "resp_1")
+        #expect(ws.connectCount == 2)
+        #expect(http.lastRequest == nil)
+    }
+
+    @Test("returns a stream error when WebSocket closes before response.completed after events")
+    func webSocketCloseAfterEventsBeforeCompletedReturnsError() async throws {
+        let responseCreated = """
+        {"type":"response.created","response":{"id":"resp_partial","status":"in_progress"}}
+        """
+        let connection = StubWebSocketConnection(batches: [[responseCreated]])
+        let ws = StubWebSocketClient(connection: connection)
+        let http = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(sessionId: "ws-close-after-events")
+        )
+        for await _ in s {}
+        let result = await s.result()
+
+        #expect(result.stopReason == .error)
+        #expect(result.errorMessage?.contains("closed before response.completed") == true)
+        #expect(ws.connectCount == 1)
+        #expect(http.lastRequest == nil)
+    }
+
+    @Test("returns an error instead of multiplexing a busy WebSocket session")
+    func webSocketBusySessionReturnsError() async throws {
+        let http = StubSSEClient(body: Self.textSSE.replacingOccurrences(of: "resp_1", with: "resp_http"))
+        let connection = StubWebSocketConnection(
+            batches: [Self.webSocketMessages(from: Self.textSSE)],
+            firstReceiveDelayNanoseconds: 300_000_000
+        )
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+        let options = StreamOptions(sessionId: "ws-busy-session")
+
+        let first = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "first"))]),
+            options: options
+        )
+        #expect(await Self.waitUntil { connection.sentTexts.count == 1 })
+
+        let second = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "second"))]),
+            options: options
+        )
+        for await _ in second {}
+        let secondResult = await second.result()
+
+        for await _ in first {}
+        let firstResult = await first.result()
+
+        #expect(firstResult.responseId == "resp_1")
+        #expect(secondResult.stopReason == .error)
+        #expect(secondResult.errorMessage?.contains("in-flight response") == true)
+        #expect(ws.connectCount == 1)
+        #expect(connection.sentTexts.count == 1)
+        #expect(http.lastRequest == nil)
+    }
+
+    @Test("successful WebSocket responses reset the failure budget")
+    func webSocketSuccessResetsFailureBudget() async throws {
+        let failingFirst = StubWebSocketConnection(batches: [[]], receiveError: StubWebSocketError.receive)
+        let succeedingThenFailingSecond = StubWebSocketConnection(
+            batches: [Self.webSocketMessages(from: Self.textSSE)],
+            sendErrors: [nil, StubWebSocketError.send]
+        )
+        let succeedingFourth = StubWebSocketConnection(batches: [Self.webSocketMessages(from: Self.textSSE)])
+        let ws = StubWebSocketClient(connections: [
+            failingFirst,
+            succeedingThenFailingSecond,
+            succeedingFourth,
+        ])
+        let http = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAIResponsesProvider(
+            client: http,
+            webSocketClient: ws,
+            defaultAPIKey: "k",
+            maxWebSocketFailures: 2
+        )
+        let options = StreamOptions(sessionId: "ws-budget-reset")
+
+        let first = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "first"))]),
+            options: options
+        )
+        for await _ in first {}
+        #expect(await first.result().responseId == "resp_1")
+        #expect(http.lastRequest != nil)
+
+        let second = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "second"))]),
+            options: options
+        )
+        for await _ in second {}
+        #expect(await second.result().responseId == "resp_1")
+
+        let third = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "third"))]),
+            options: options
+        )
+        for await _ in third {}
+        #expect(await third.result().responseId == "resp_1")
+
+        let fourth = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "fourth"))]),
+            options: options
+        )
+        for await _ in fourth {}
+        #expect(await fourth.result().responseId == "resp_1")
+        #expect(ws.connectCount == 3)
+    }
+
+    private static func webSocketMessages(from sse: String) -> [String] {
+        sse.components(separatedBy: "\n\n").compactMap { block in
+            let dataLines = block.split(separator: "\n").compactMap { line -> String? in
+                let text = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard text.hasPrefix("data:") else { return nil }
+                return String(text.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+            }
+            return dataLines.isEmpty ? nil : dataLines.joined(separator: "\n")
+        }
+    }
+
+    private static func jsonObject(_ text: String) throws -> [String: Any] {
+        let data = Data(text.utf8)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func waitUntil(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        _ predicate: @escaping @Sendable () -> Bool
+    ) async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if predicate() { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return predicate()
+    }
+}
+
+enum StubWebSocketError: Error {
+    case connect
+    case receive
+    case send
+}
+
+actor VerboseEventRecorder {
+    private var events: [VerboseEvent] = []
+
+    func append(_ event: VerboseEvent) {
+        events.append(event)
+    }
+
+    func messages() -> [String] {
+        events.map(\.message)
+    }
+}
+
+final class StubWebSocketClient: WebSocketClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var connections: [StubWebSocketConnection]
+    private let error: Error?
+    private var _connectCount = 0
+    private var _lastURL: URL?
+    private var _lastHeaders: [String: String] = [:]
+
+    init(connection: StubWebSocketConnection = StubWebSocketConnection(batches: []), error: Error? = nil) {
+        self.connections = [connection]
+        self.error = error
+    }
+
+    init(connections: [StubWebSocketConnection]) {
+        self.connections = connections
+        self.error = nil
+    }
+
+    var connectCount: Int { lock.withLock { _connectCount } }
+    var lastURL: URL? { lock.withLock { _lastURL } }
+    var lastHeaders: [String: String] { lock.withLock { _lastHeaders } }
+
+    func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection {
+        try lock.withLock {
+            _connectCount += 1
+            _lastURL = url
+            _lastHeaders = headers
+            if let error { throw error }
+            if connections.count > 1 {
+                return connections.removeFirst()
+            }
+            return connections.first ?? StubWebSocketConnection(batches: [])
+        }
+    }
+}
+
+final class StubWebSocketConnection: WebSocketConnection, @unchecked Sendable {
+    private let lock = NSLock()
+    private var batches: [[String]]
+    private var receiveError: Error?
+    private var sendErrors: [Error?]
+    private var firstReceiveDelayNanoseconds: UInt64
+    private var pending: [WebSocketMessage] = []
+    private var _sentTexts: [String] = []
+    private var _closed = false
+
+    init(
+        batches: [[String]],
+        receiveError: Error? = nil,
+        sendErrors: [Error?] = [],
+        firstReceiveDelayNanoseconds: UInt64 = 0
+    ) {
+        self.batches = batches
+        self.receiveError = receiveError
+        self.sendErrors = sendErrors
+        self.firstReceiveDelayNanoseconds = firstReceiveDelayNanoseconds
+    }
+
+    var sentTexts: [String] { lock.withLock { _sentTexts } }
+    var closed: Bool { lock.withLock { _closed } }
+
+    func send(_ message: WebSocketMessage) async throws {
+        try lock.withLock {
+            if !sendErrors.isEmpty, let error = sendErrors.removeFirst() {
+                throw error
+            }
+            if case .text(let text) = message {
+                _sentTexts.append(text)
+            }
+            if !batches.isEmpty {
+                pending.append(contentsOf: batches.removeFirst().map(WebSocketMessage.text))
+            }
+        }
+    }
+
+    func receive() async throws -> WebSocketMessage? {
+        let delay = lock.withLock { () -> UInt64 in
+            let delay = firstReceiveDelayNanoseconds
+            firstReceiveDelayNanoseconds = 0
+            return delay
+        }
+        if delay > 0 {
+            try await Task.sleep(nanoseconds: delay)
+        }
+        return try lock.withLock { () throws -> WebSocketMessage? in
+            if !pending.isEmpty {
+                return pending.removeFirst()
+            }
+            if let error = receiveError {
+                receiveError = nil
+                throw error
+            }
+            return nil
+        }
+    }
+
+    func close() {
+        lock.withLock { _closed = true }
     }
 }

--- a/Tests/KWWKAITests/ProviderVariantsTests.swift
+++ b/Tests/KWWKAITests/ProviderVariantsTests.swift
@@ -39,7 +39,7 @@ struct ProviderVariantsTests {
         _ = provider.stream(
             model: model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]),
-            options: nil
+            options: StreamOptions(transport: .sse)
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
         let u = client.lastRequest?.url.absoluteString ?? ""
@@ -62,7 +62,7 @@ struct ProviderVariantsTests {
         _ = provider.stream(
             model: model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]),
-            options: StreamOptions(metadata: ["deployment": .string("gpt4o-prod")])
+            options: StreamOptions(transport: .sse, metadata: ["deployment": .string("gpt4o-prod")])
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
         let u = client.lastRequest?.url.absoluteString ?? ""
@@ -206,7 +206,7 @@ struct ProviderVariantsTests {
         _ = provider.stream(
             model: model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]),
-            options: nil
+            options: StreamOptions(transport: .sse)
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
         let u = client.lastRequest?.url.absoluteString ?? ""
@@ -214,5 +214,53 @@ struct ProviderVariantsTests {
         #expect(client.lastRequest?.headers["authorization"] == "Bearer codex-bearer")
         #expect(client.lastRequest?.headers["chatgpt-account-id"] == "acct-xyz")
         #expect(client.lastRequest?.headers["openai-beta"] == "responses=experimental")
+    }
+
+    @Test("ChatGPT Codex defaults to WebSocket and uses WebSocket beta")
+    func codexWebSocketDefault() async throws {
+        let http = StubSSEClient(body: Self.openaiResponsesSSE)
+        let connection = StubWebSocketConnection(batches: [Self.webSocketMessages(from: Self.openaiResponsesSSE)])
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = ProviderVariants.chatgptCodex(
+            accessToken: "codex-bearer",
+            accountId: "acct-xyz",
+            client: http,
+            webSocketClient: ws
+        )
+        let model = Model(id: "gpt-5-codex", name: "gpt-5-codex", api: "chatgpt-codex", provider: "chatgpt-codex")
+
+        let s = provider.stream(
+            model: model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(sessionId: "codex-ws")
+        )
+        for await _ in s {}
+
+        #expect(await s.result().responseId == "r")
+        #expect(http.lastRequest == nil)
+        #expect(ws.lastURL?.absoluteString == "wss://chatgpt.com/backend-api/codex/responses")
+        #expect(ws.lastHeaders["authorization"] == "Bearer codex-bearer")
+        #expect(ws.lastHeaders["chatgpt-account-id"] == "acct-xyz")
+        #expect(ws.lastHeaders["openai-beta"] == "responses_websockets=2026-02-06")
+
+        let payload = try Self.jsonObject(connection.sentTexts[0])
+        #expect(payload["type"] as? String == "response.create")
+        #expect(payload["store"] as? Bool == false)
+    }
+
+    private static func webSocketMessages(from sse: String) -> [String] {
+        sse.components(separatedBy: "\n\n").compactMap { block in
+            let dataLines = block.split(separator: "\n").compactMap { line -> String? in
+                let text = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard text.hasPrefix("data:") else { return nil }
+                return String(text.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+            }
+            return dataLines.isEmpty ? nil : dataLines.joined(separator: "\n")
+        }
+    }
+
+    private static func jsonObject(_ text: String) throws -> [String: Any] {
+        let data = Data(text.utf8)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }

--- a/Tests/KWWKAgentTests/AgentTests.swift
+++ b/Tests/KWWKAgentTests/AgentTests.swift
@@ -51,6 +51,7 @@ struct AgentInitTests {
         let agent = Agent(initialState: AgentInitialState(model: registration.getModel()))
         #expect(agent.state.systemPrompt == "")
         #expect(agent.state.thinkingLevel == .off)
+        #expect(agent.state.verboseEnabled == false)
         #expect(agent.state.tools.isEmpty)
         #expect(agent.state.messages.isEmpty)
         #expect(agent.state.isStreaming == false)
@@ -101,6 +102,21 @@ struct AgentInitTests {
         agent.state.messages = messages
         messages.append(.user(UserMessage(text: "again")))
         #expect(agent.state.messages.count == 1)
+    }
+
+    @Test("coding agent carries configured session id into stream options")
+    func codingAgentKeepsSessionId() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let agent = await makeCodingAgent(CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: FileManager.default.temporaryDirectory.path,
+            tools: [],
+            sessionId: "stable-session"
+        ))
+
+        #expect(agent.sessionId == "stable-session")
     }
 }
 
@@ -317,6 +333,55 @@ struct AgentIntegrationTests {
             Issue.record("expected assistant message with thinking block")
         }
     }
+
+    @Test("bridges StreamOptions verbose callback into AgentEvent.verbose")
+    func bridgesVerboseEvents() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let streamFn: StreamFn = { model, _, options in
+            await options?.emitVerbose(
+                source: "test.provider",
+                message: "connected",
+                metadata: ["attempt": .int(1)]
+            )
+            let message = AssistantMessage(
+                content: [.text(TextContent(text: "ok"))],
+                api: model.api,
+                provider: model.provider,
+                model: model.id
+            )
+            let stream = AssistantMessageStream()
+            stream.push(.start(partial: message))
+            stream.push(.textStart(contentIndex: 0, partial: message))
+            stream.push(.textDelta(contentIndex: 0, delta: "ok", partial: message))
+            stream.push(.textEnd(contentIndex: 0, content: "ok", partial: message))
+            stream.push(.done(reason: .stop, message: message))
+            stream.end(message)
+            return stream
+        }
+        let agent = Agent(
+            initialState: AgentInitialState(
+                model: registration.getModel(),
+                verboseEnabled: true
+            ),
+            streamFn: streamFn
+        )
+        let recorder = VerboseEventLog()
+        _ = agent.subscribe { event, _ in
+            if case .verbose(let verbose) = event {
+                await recorder.append(verbose)
+            }
+        }
+
+        try await agent.prompt("hi")
+
+        let events = await recorder.values()
+        #expect(events.count == 1)
+        #expect(events.first?.source == "test.provider")
+        #expect(events.first?.message == "connected")
+        #expect(events.first?.metadata["attempt"] == .int(1))
+    }
 }
 
 @Suite("Agent.continue")
@@ -454,6 +519,12 @@ actor EventLog {
     var log: [String] = []
     func append(_ s: String) { log.append(s) }
     func values() -> [String] { log }
+}
+
+actor VerboseEventLog {
+    var log: [VerboseEvent] = []
+    func append(_ event: VerboseEvent) { log.append(event) }
+    func values() -> [VerboseEvent] { log }
 }
 
 actor AsyncBarrier {

--- a/Tests/KWWKCliTests/SlashCommandTests.swift
+++ b/Tests/KWWKCliTests/SlashCommandTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Testing
+@testable import KWWKAI
+@testable import KWWKAgent
 @testable import KWWKCli
 
 @Suite("SlashInput.parse")
@@ -41,4 +43,63 @@ struct SlashInputParseTests {
     func middleSlashIsPrompt() {
         #expect(SlashInput.parse("a/b") == .prompt(text: "a/b"))
     }
+}
+
+@Suite("/verbose command")
+struct VerboseCommandTests {
+
+    @MainActor
+    @Test("toggles verbose mode and reports status")
+    func togglesVerboseMode() async {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+
+        let agent = Agent(initialState: AgentInitialState(model: faux.getModel()))
+        let notifier = SlashNotifyRecorder()
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-verbose-\(UUID().uuidString.prefix(8))")
+        try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let ctx = SlashContext(
+            agent: agent,
+            modal: ModalHost(
+                layout: CodingLayout(statusRows: 1),
+                restoreTranscript: {},
+                requestRender: {}
+            ),
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: "sess",
+            notifyBlock: { lines in for line in lines { notifier.append(line) } },
+            commitScrollback: { _ in },
+            refreshTranscript: {}
+        )
+        let registry = SlashCommandRegistry()
+        registerBuiltinSlashCommands(registry)
+
+        #expect(agent.state.verboseEnabled == false)
+        await registry.find("verbose")?.handler(ctx, "")
+        #expect(agent.state.verboseEnabled == true)
+        #expect(notifier.joined.contains("off"))
+        #expect(notifier.joined.contains("on"))
+
+        notifier.clear()
+        await registry.find("verbose")?.handler(ctx, "status")
+        #expect(agent.state.verboseEnabled == true)
+        #expect(notifier.joined.contains("/verbose: on"))
+
+        notifier.clear()
+        await registry.find("verbose")?.handler(ctx, "off")
+        #expect(agent.state.verboseEnabled == false)
+        #expect(notifier.joined.contains("on"))
+        #expect(notifier.joined.contains("off"))
+    }
+}
+
+@MainActor
+private final class SlashNotifyRecorder {
+    private(set) var lines: [String] = []
+    func append(_ s: String) { lines.append(s) }
+    func clear() { lines.removeAll() }
+    var joined: String { lines.joined(separator: "\n") }
 }

--- a/Tests/KWWKCliTests/TranscriptCommitTests.swift
+++ b/Tests/KWWKCliTests/TranscriptCommitTests.swift
@@ -102,6 +102,75 @@ struct TranscriptCommitTests {
     }
 
     @MainActor
+    @Test("verbose events queue while assistant output is streaming")
+    func verboseQueuesDuringStreaming() {
+        let r = TranscriptRenderer()
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        r.apply(.verbose(VerboseEvent(
+            source: "openai.responses.websocket",
+            message: "connected",
+            metadata: ["input_count": .int(1)]
+        )))
+
+        #expect(r.drainCommits().isEmpty)
+        #expect(!r.liveLines.contains(where: { $0.contains("connected") }))
+
+        r.apply(.messageEnd(message: .assistant(stubAssistant("hello"))))
+        let commits = r.drainCommits()
+        let assistantIdx = commits.firstIndex(where: { $0.contains("hello") })
+        let verboseIdx = commits.firstIndex(where: { $0.contains("verbose [openai.responses.websocket]: connected") })
+
+        #expect(assistantIdx != nil)
+        #expect(verboseIdx != nil)
+        if let assistantIdx, let verboseIdx {
+            #expect(assistantIdx < verboseIdx)
+        }
+        #expect(commits.contains(where: { $0.contains("input_count=1") }))
+    }
+
+    @MainActor
+    @Test("streamRewind drops verbose events queued for the failed attempt")
+    func streamRewindDropsQueuedVerbose() {
+        let r = TranscriptRenderer()
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        r.apply(.verbose(VerboseEvent(
+            source: "openai.responses.websocket",
+            message: "failed attempt log",
+            metadata: [:]
+        )))
+
+        r.apply(.streamRewind)
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        r.apply(.verbose(VerboseEvent(
+            source: "openai.responses.websocket",
+            message: "retry attempt log",
+            metadata: [:]
+        )))
+        r.apply(.messageEnd(message: .assistant(stubAssistant("hello"))))
+
+        let commits = r.drainCommits()
+        #expect(!commits.contains(where: { $0.contains("failed attempt log") }))
+        #expect(commits.contains(where: { $0.contains("retry attempt log") }))
+    }
+
+    @MainActor
+    @Test("agentEnd flushes queued verbose even if streaming did not close cleanly")
+    func agentEndFlushesQueuedVerboseWhileStreaming() {
+        let r = TranscriptRenderer()
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        r.apply(.verbose(VerboseEvent(
+            source: "openai.responses.websocket",
+            message: "stream teardown log",
+            metadata: [:]
+        )))
+
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+
+        let commits = r.drainCommits()
+        #expect(commits.contains(where: { $0.contains("stream teardown log") }))
+    }
+
+    @MainActor
     @Test("tool execution commits on end with header + result preview")
     func toolCommitsOnEnd() {
         let r = TranscriptRenderer()


### PR DESCRIPTION
## Summary

Adds WebSocket transport support for the OpenAI Responses provider and ChatGPT Codex OAuth path. WebSocket is attempted by default, with HTTP fallback before any response event, stream errors after a response has begun, and a per-session failure budget that disables WebSocket after repeated failures.

This also adds verbose diagnostics that providers can emit into the CLI/TUI through `/verbose`, including queueing verbose messages while assistant output is streaming.

## Details

- Added a WebSocket client abstraction and default URLSession-backed implementation.
- Reworked `OpenAIResponsesProvider` to support `response.create` over WebSocket, connection reuse by `sessionId`, `previous_response_id` incremental input, failure accounting, and busy-session errors instead of multiplexing.
- Updated ChatGPT Codex provider defaults to use the Codex WebSocket endpoint and the WebSocket beta header.
- Added `/verbose`, verbose events, agent event bridging, and TUI transcript rendering/queueing for verbose logs.
- Fixed TUI coding agent construction so the stable session id reaches stream options.

## Validation

- `git diff --check`
- `swift test --filter 'OpenAIResponsesTests|TranscriptCommitTests|ProviderVariantsTests|VerboseCommandTests|AgentInitTests'`

## Notes

A full `swift test` was not run in this final pass; earlier full-suite attempts had an unrelated OAuth callback server shutdown issue.