### PR TITLE
[codex] Add subagent session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,107 @@ for message in agent.state.messages {
 }
 ```
 
+### Subagents
+
+`CodingAgentConfig.subagents` defaults to an empty array. When it is
+empty, `makeCodingAgent` does not register the `agent` tool. Add
+subagent definitions explicitly when you want model-driven delegation:
+
+```swift
+let reviewer = SubagentDefinition(
+    name: "reviewer",
+    description: "Use for code quality, security, maintainability, and test coverage review.",
+    prompt: """
+    You are a senior code reviewer. Review code carefully, do not edit files,
+    and report findings with file paths, severity, and concrete evidence.
+    """,
+    tools: .readOnly,
+    model: .inherit
+)
+
+let bg = BackgroundTaskManager()
+let agent = await makeCodingAgent(CodingAgentConfig(
+    model: Models.claudeSonnet45,
+    cwd: FileManager.default.currentDirectoryPath,
+    tools: .all,
+    backgroundManager: bg,
+    subagents: [reviewer]
+))
+
+try await agent.prompt("Use the reviewer subagent to review Sources/KWWKAgent.")
+```
+
+For the same built-ins that the CLI uses, SDK users can opt in without
+copying prompts:
+
+```swift
+let agent = await makeCodingAgent(CodingAgentConfig(
+    model: Models.claudeSonnet45,
+    cwd: FileManager.default.currentDirectoryPath,
+    tools: .all,
+    backgroundManager: BackgroundTaskManager()
+).withBuiltinSubagents([.general, .explore, .plan]))
+```
+
+SDK users can also run a subagent directly:
+
+```swift
+let runner = SubagentRunner(
+    cwd: FileManager.default.currentDirectoryPath,
+    subagents: [.plan()],
+    parentModel: Models.claudeSonnet45
+)
+let result = try await runner.run(
+    type: "Plan",
+    prompt: "Plan how to simplify Sources/KWWKAgent/SubagentTool.swift."
+)
+```
+
+Subagents are fresh-context agents: they do not inherit the parent
+transcript. The parent model must put the relevant files, errors, goals,
+and constraints into the `agent` tool's `prompt`. Subagents inherit the
+parent model, thinking level, retry delay, and API key resolver, but they
+do not inherit parent hooks such as `betweenTurns`, `transformContext`,
+`convertToLlm`, `userPromptSubmit`, or tool-call hooks.
+
+Each subagent run gets its own child session id. Tools inside that
+subagent, including background-capable tools such as Bash, are scoped to
+the child session. While the child agent is running, background task
+notifications are attached to that child session. When the subagent
+finishes or is cancelled, the generic background-task session is closed:
+still-running tasks in that child session are killed and queued
+notifications for that child session are discarded. If the parent starts
+the subagent itself with `run_in_background`, that top-level subagent job
+remains parent-visible so `wait_task` and completion notifications still
+work.
+
+In the interactive TUI, foreground subagent tool calls update their
+in-flight display with the child agent's token usage as it runs. When a
+provider does not stream exact usage until the end of the turn, the live
+counter falls back to an approximate output-token estimate and is
+replaced by provider-reported usage once available.
+
+Subagent tools also emit structured runtime events through
+`AgentEvent.runtimeEvent(.subagent(...))`: started, tool update,
+background started, completed, and failed. The terminal
+`AgentRunSummary.subagents` array records each foreground child run's
+usage, cost, turns, duration, status, model, and child session id.
+Background subagents are recorded when the parent-visible background task
+is started; their completion is delivered through the existing
+background-task notification flow.
+
+The interactive `kwwk` CLI enables a small built-in set by default:
+`general`, `Explore`, and `Plan`. `general` has wildcard tools by
+default and is used when the model omits `subagent_type`. `Explore` and
+`Plan` are read-only specialists. Use `--no-subagents` to disable them
+or `--subagents general,Explore` to enable only a subset. The SDK does
+not enable those automatically.
+
+When an SDK application is done with an agent session, call
+`await agent.closeSession()` to release provider-owned resources keyed by
+that session id. For OpenAI Responses WebSocket transport, this closes the
+stored WebSocket connection for the session.
+
 ### Streaming events
 
 Subscribe before prompting to observe tokens, tool calls, and the final

--- a/Sources/KWWKAI/APIRegistry.swift
+++ b/Sources/KWWKAI/APIRegistry.swift
@@ -8,6 +8,14 @@ public protocol APIProvider: Sendable {
     func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream
 }
 
+/// Optional provider lifecycle hook for resources keyed by
+/// `StreamOptions.sessionId` (for example, persistent WebSocket
+/// connections). Providers that do not keep per-session resources do not need
+/// to conform.
+public protocol APIProviderSessionLifecycle: Sendable {
+    func closeSession(sessionId: String) async
+}
+
 /// A globally addressable registry of `APIProvider` instances, keyed by
 /// `api` string. Registrations can be tagged with an opaque `sourceId` so
 /// groups of providers can be removed together.
@@ -43,6 +51,15 @@ public actor APIRegistry {
             providers.removeValue(forKey: api)
         }
     }
+
+    public func closeSession(sessionId: String) async {
+        guard !sessionId.isEmpty else { return }
+        let snapshot = Array(providers.values)
+        for provider in snapshot {
+            guard let lifecycle = provider as? APIProviderSessionLifecycle else { continue }
+            await lifecycle.closeSession(sessionId: sessionId)
+        }
+    }
 }
 
 public enum ProviderNotFoundError: Error, Equatable {
@@ -64,4 +81,12 @@ public func complete(model: Model, context: Context, options: StreamOptions? = n
     // Drain events so producers aren't blocked waiting for consumption.
     for await _ in s {}
     return await s.result()
+}
+
+/// Close provider-owned resources associated with a session id across every
+/// registered provider. This is intentionally provider-scoped: higher layers
+/// remain responsible for their own session-scoped resources such as
+/// background tasks.
+public func closeProviderSession(sessionId: String) async {
+    await APIRegistry.shared.closeSession(sessionId: sessionId)
 }

--- a/Sources/KWWKAI/Cancellation.swift
+++ b/Sources/KWWKAI/Cancellation.swift
@@ -6,11 +6,23 @@ import Foundation
 /// can be cancelled from the outside. Swift has `Task.isCancelled`, but it
 /// only applies to the calling task — so we model an external handle that can
 /// be awaited and queried by producers and consumers alike.
+public struct CancellationRegistration: Sendable {
+    private let cancelHandler: @Sendable () -> Void
+
+    init(_ cancelHandler: @escaping @Sendable () -> Void) {
+        self.cancelHandler = cancelHandler
+    }
+
+    public func cancel() {
+        cancelHandler()
+    }
+}
+
 public final class CancellationHandle: @unchecked Sendable {
     private let lock = NSLock()
     private var _isCancelled = false
     private var _reason: String?
-    private var listeners: [@Sendable (String?) -> Void] = []
+    private var listeners: [(id: UUID, handler: @Sendable (String?) -> Void)] = []
 
     public init() {}
 
@@ -36,7 +48,7 @@ public final class CancellationHandle: @unchecked Sendable {
         }
         _isCancelled = true
         _reason = reason
-        callbacks = listeners
+        callbacks = listeners.map(\.handler)
         listeners.removeAll()
         lock.unlock()
         for cb in callbacks {
@@ -46,15 +58,26 @@ public final class CancellationHandle: @unchecked Sendable {
 
     /// Register a callback that fires exactly once when the handle is cancelled.
     /// If already cancelled, fires synchronously.
-    public func onCancel(_ handler: @Sendable @escaping (String?) -> Void) {
+    @discardableResult
+    public func onCancel(_ handler: @Sendable @escaping (String?) -> Void) -> CancellationRegistration {
+        let id = UUID()
         lock.lock()
         if _isCancelled {
             let r = _reason
             lock.unlock()
             handler(r)
-            return
+            return CancellationRegistration {}
         }
-        listeners.append(handler)
+        listeners.append((id: id, handler: handler))
+        lock.unlock()
+        return CancellationRegistration { [weak self] in
+            self?.removeListener(id)
+        }
+    }
+
+    private func removeListener(_ id: UUID) {
+        lock.lock()
+        listeners.removeAll { $0.id == id }
         lock.unlock()
     }
 

--- a/Sources/KWWKAI/OAuthCallbackServer.swift
+++ b/Sources/KWWKAI/OAuthCallbackServer.swift
@@ -38,8 +38,10 @@ public final class OAuthCallbackServer: @unchecked Sendable {
     deinit {
         // Best-effort cleanup — the login flow calls `stop()` or `cancel()`
         // explicitly, but a leak-safe deinit prevents a zombie event loop
-        // when callers drop the server without finishing the flow.
-        try? group.syncShutdownGracefully()
+        // when callers drop the server without finishing the flow. Deinit can
+        // run on the NIO event loop that just closed the callback channel, so
+        // use the asynchronous shutdown API instead of blocking that thread.
+        group.shutdownGracefully { _ in }
     }
 
     public var redirectURI: String {

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -17,7 +17,7 @@ import FoundationNetworking
 ///  - Output items are typed (`message`, `function_call`, `reasoning`) and
 ///    carry `output_index` + `content_index` for nested content.
 ///  - `parallel_tool_calls` is a top-level boolean.
-public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
+public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifecycle, @unchecked Sendable {
     public typealias URLBuilder = @Sendable (Model, StreamOptions?, URL) -> URL
     public typealias AuthHeaderBuilder = @Sendable (String) -> [String: String]
     public typealias WebSocketURLBuilder = @Sendable (URL) -> URL
@@ -82,6 +82,10 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
         let out = AssistantMessageStream()
         Task.detached { await self.run(out: out, model: model, context: context, options: options) }
         return out
+    }
+
+    public func closeSession(sessionId: String) async {
+        sessions.closeSession(sessionId: sessionId)
     }
 
     private func run(
@@ -249,6 +253,8 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
         defer { session.endWebSocketRun() }
 
         var connection: (any WebSocketConnection)?
+        var cancellationRegistration: CancellationRegistration?
+        defer { cancellationRegistration?.cancel() }
         do {
             if let existing = session.takeConnection() {
                 connection = existing
@@ -268,6 +274,10 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                     message: "connected"
                 )
             }
+            if let connection {
+                session.storeConnection(connection)
+                cancellationRegistration = options?.cancellation?.onCancel { _ in connection.close() }
+            }
             let payload = try session.prepareWebSocketPayload(from: request)
             try await connection?.send(.text(payload.text))
             var metadata: [String: JSONValue] = [
@@ -283,7 +293,6 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                 metadata: metadata
             )
         } catch {
-            connection?.close()
             let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
             await options?.emitVerbose(
                 source: verboseSource,
@@ -333,7 +342,6 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                     metadata: ["response_id": .string(responseId)]
                 )
             } else if result.endedWithoutTerminalEvent {
-                connection.close()
                 let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
                 if !progress.hasReceivedEvent {
                     await options?.emitVerbose(
@@ -363,7 +371,6 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
                 out.end(err)
                 return .failedWithoutFallback
             } else {
-                connection.close()
                 session.resetWebSocketState(resetFailureCount: progress.hasReceivedEvent)
                 await options?.emitVerbose(
                     source: verboseSource,
@@ -373,7 +380,6 @@ public final class OpenAIResponsesProvider: APIProvider, @unchecked Sendable {
             }
             return .completed
         } catch {
-            connection.close()
             let failure = session.recordWebSocketFailure(maxFailures: maxWebSocketFailures)
             if !progress.hasReceivedEvent {
                 await options?.emitVerbose(
@@ -903,6 +909,12 @@ private final class OpenAIResponsesSessionStore: @unchecked Sendable {
             return created
         }
     }
+
+    func closeSession(sessionId: String) {
+        guard !sessionId.isEmpty else { return }
+        let session = lock.withLock { sessions.removeValue(forKey: sessionId) }
+        session?.close()
+    }
 }
 
 private final class OpenAIResponsesSessionState: @unchecked Sendable {
@@ -913,14 +925,19 @@ private final class OpenAIResponsesSessionState: @unchecked Sendable {
     private var webSocketFailureCount = 0
     private var disabled = false
     private var webSocketInFlight = false
+    private var closed = false
+
+    deinit {
+        close()
+    }
 
     var webSocketDisabled: Bool {
-        lock.withLock { disabled }
+        lock.withLock { disabled || closed }
     }
 
     func beginWebSocketRun() -> OpenAIResponsesWebSocketRunLease {
         lock.withLock {
-            if disabled { return .disabled }
+            if disabled || closed { return .disabled }
             if webSocketInFlight { return .busy }
             webSocketInFlight = true
             return .acquired
@@ -940,7 +957,14 @@ private final class OpenAIResponsesSessionState: @unchecked Sendable {
     }
 
     func storeConnection(_ next: any WebSocketConnection) {
-        lock.withLock { connection = next }
+        let shouldClose = lock.withLock { () -> Bool in
+            guard !closed else { return true }
+            connection = next
+            return false
+        }
+        if shouldClose {
+            next.close()
+        }
     }
 
     @discardableResult
@@ -970,6 +994,20 @@ private final class OpenAIResponsesSessionState: @unchecked Sendable {
         let old = lock.withLock { () -> (any WebSocketConnection)? in
             if disable { disabled = true }
             if resetFailureCount { webSocketFailureCount = 0 }
+            let old = connection
+            connection = nil
+            lastRequest = nil
+            lastResponse = nil
+            return old
+        }
+        old?.close()
+    }
+
+    func close() {
+        let old = lock.withLock { () -> (any WebSocketConnection)? in
+            closed = true
+            disabled = true
+            webSocketInFlight = false
             let old = connection
             connection = nil
             lastRequest = nil

--- a/Sources/KWWKAgent/Agent+Session.swift
+++ b/Sources/KWWKAgent/Agent+Session.swift
@@ -1,0 +1,14 @@
+import Foundation
+import KWWKAI
+
+extension Agent {
+    /// Close provider-owned resources associated with this agent's session id.
+    ///
+    /// This does not mutate the transcript and does not kill background
+    /// tasks; callers that own session-scoped task managers should close those
+    /// resources separately.
+    public func closeSession() async {
+        guard let sessionId, !sessionId.isEmpty else { return }
+        await KWWKAI.closeProviderSession(sessionId: sessionId)
+    }
+}

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -345,6 +345,9 @@ public enum AgentLoop {
                     )
                     for result in toolResults {
                         currentContext.messages.append(.toolResult(result))
+                        if let subagent = subagentRunSummary(from: result) {
+                            summary.subagents.append(subagent)
+                        }
                     }
                 }
 
@@ -794,6 +797,9 @@ public enum AgentLoop {
                 args: call.arguments,
                 partialResult: partial
             ))
+            for runtimeEvent in partial.runtimeEvents ?? [] {
+                emitBox.launchUpdate(.runtimeEvent(runtimeEvent))
+            }
         }
         do {
             let result = try await prepared.tool.execute(prepared.call.id, prepared.args, cancellation, onUpdate)
@@ -806,6 +812,16 @@ public enum AgentLoop {
                 message = "aborted by user"
             } else {
                 message = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            }
+            if let structured = error as? StructuredToolExecutionError {
+                return ExecutedOutcome(
+                    result: errorToolResult(
+                        message,
+                        details: structured.details,
+                        runtimeEvents: structured.runtimeEvents
+                    ),
+                    isError: true
+                )
             }
             return ExecutedOutcome(result: errorToolResult(message), isError: true)
         }
@@ -846,6 +862,9 @@ public enum AgentLoop {
             result: final,
             isError: isError
         ))
+        for runtimeEvent in final.runtimeEvents ?? [] {
+            await emit(.runtimeEvent(runtimeEvent))
+        }
         let message = ToolResultMessage(
             toolCallId: call.id,
             toolName: call.name,
@@ -858,8 +877,91 @@ public enum AgentLoop {
         return message
     }
 
-    private static func errorToolResult(_ text: String) -> AgentToolResult {
-        AgentToolResult(content: [.text(TextContent(text: text))], details: nil)
+    private static func errorToolResult(
+        _ text: String,
+        details: JSONValue? = nil,
+        runtimeEvents: [AgentRuntimeEvent]? = nil
+    ) -> AgentToolResult {
+        AgentToolResult(
+            content: [.text(TextContent(text: text))],
+            details: details,
+            runtimeEvents: runtimeEvents
+        )
+    }
+
+    private static func subagentRunSummary(from result: ToolResultMessage) -> SubagentRunSummary? {
+        guard result.toolName == "agent",
+              case .object(let details) = result.details ?? .null,
+              let subagentType = stringValue(details["subagent_type"]) else {
+            return nil
+        }
+        let statusRaw = stringValue(details["status"]) ?? (result.isError ? "failed" : "")
+        let status: SubagentRunStatus
+        switch statusRaw {
+        case "completed":
+            status = .completed
+        case "background_started":
+            status = .backgroundStarted
+        case "failed":
+            status = .failed
+        default:
+            status = result.isError ? .failed : .completed
+        }
+        return SubagentRunSummary(
+            subagentType: subagentType,
+            childSessionId: stringValue(details["child_session_id"]),
+            description: stringValue(details["description"]),
+            status: status,
+            model: stringValue(details["model"]),
+            stopReason: stringValue(details["stop_reason"]).flatMap(StopReason.init(rawValue:)),
+            usage: usageValue(details["usage"]),
+            turns: intValue(details["turns"]),
+            cost: costValue(details["cost"]),
+            durationMs: intValue(details["duration_ms"]),
+            backgroundTaskId: stringValue(details["task_id"]),
+            outputFile: stringValue(details["output_file"]),
+            errorMessage: stringValue(details["error_message"])
+        )
+    }
+
+    private static func stringValue(_ value: JSONValue?) -> String? {
+        guard case .string(let string) = value ?? .null else { return nil }
+        return string
+    }
+
+    private static func intValue(_ value: JSONValue?) -> Int? {
+        guard case .int(let int) = value ?? .null else { return nil }
+        return int
+    }
+
+    private static func doubleValue(_ value: JSONValue?) -> Double? {
+        switch value ?? .null {
+        case .double(let double): return double
+        case .int(let int): return Double(int)
+        default: return nil
+        }
+    }
+
+    private static func usageValue(_ value: JSONValue?) -> Usage? {
+        guard case .object(let object) = value ?? .null else { return nil }
+        return Usage(
+            input: intValue(object["input"]) ?? 0,
+            output: intValue(object["output"]) ?? 0,
+            cacheRead: intValue(object["cache_read"]) ?? 0,
+            cacheWrite: intValue(object["cache_write"]) ?? 0,
+            totalTokens: intValue(object["total_tokens"]) ?? 0
+        )
+    }
+
+    private static func costValue(_ value: JSONValue?) -> Cost? {
+        guard case .object(let object) = value ?? .null else { return nil }
+        return Cost(
+            input: doubleValue(object["input"]) ?? 0,
+            output: doubleValue(object["output"]) ?? 0,
+            cacheRead: doubleValue(object["cache_read"]) ?? 0,
+            cacheWrite: doubleValue(object["cache_write"]) ?? 0,
+            total: doubleValue(object["total"]) ?? 0
+        )
     }
 }
 

--- a/Sources/KWWKAgent/AgentTypes.swift
+++ b/Sources/KWWKAgent/AgentTypes.swift
@@ -33,6 +33,11 @@ public typealias StreamFn = @Sendable (Model, Context, StreamOptions?) async thr
 public struct AgentToolResult: Sendable, Hashable {
     public var content: [ToolResultBlock]
     public var details: JSONValue?
+    /// Structured runtime events produced by the tool. The agent loop
+    /// forwards these as `AgentEvent.runtimeEvent` after the corresponding
+    /// tool update/end event. They are process-local telemetry; providers
+    /// never see them.
+    public var runtimeEvents: [AgentRuntimeEvent]?
     /// Optional UI-only display lines. When non-nil, the TUI renderer
     /// prefers these over its default truncated preview of `content`.
     /// Tools use this to summarize noisy output for the user (e.g.
@@ -46,15 +51,91 @@ public struct AgentToolResult: Sendable, Hashable {
     public init(
         content: [ToolResultBlock],
         details: JSONValue? = nil,
+        runtimeEvents: [AgentRuntimeEvent]? = nil,
         uiDisplay: [String]? = nil
     ) {
         self.content = content
         self.details = details
+        self.runtimeEvents = runtimeEvents
         self.uiDisplay = uiDisplay
     }
 }
 
 public typealias AgentToolUpdate = @Sendable (AgentToolResult) -> Void
+
+public enum SubagentLifecycleKind: String, Sendable, Hashable {
+    case started = "subagent_started"
+    case toolUpdate = "subagent_tool_update"
+    case backgroundStarted = "subagent_background_started"
+    case completed = "subagent_completed"
+    case failed = "subagent_failed"
+}
+
+public struct SubagentLifecycleEvent: Sendable, Hashable {
+    public var kind: SubagentLifecycleKind
+    public var toolCallId: String?
+    public var subagentType: String
+    public var childSessionId: String
+    public var description: String?
+    public var model: String?
+    public var stopReason: StopReason?
+    public var usage: Usage?
+    public var usageEstimated: Bool
+    public var turns: Int?
+    public var cost: Cost?
+    public var durationMs: Int?
+    public var backgroundTaskId: String?
+    public var outputFile: String?
+    public var message: String?
+    public var errorMessage: String?
+
+    public init(
+        kind: SubagentLifecycleKind,
+        toolCallId: String? = nil,
+        subagentType: String,
+        childSessionId: String,
+        description: String? = nil,
+        model: String? = nil,
+        stopReason: StopReason? = nil,
+        usage: Usage? = nil,
+        usageEstimated: Bool = false,
+        turns: Int? = nil,
+        cost: Cost? = nil,
+        durationMs: Int? = nil,
+        backgroundTaskId: String? = nil,
+        outputFile: String? = nil,
+        message: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.kind = kind
+        self.toolCallId = toolCallId
+        self.subagentType = subagentType
+        self.childSessionId = childSessionId
+        self.description = description
+        self.model = model
+        self.stopReason = stopReason
+        self.usage = usage
+        self.usageEstimated = usageEstimated
+        self.turns = turns
+        self.cost = cost
+        self.durationMs = durationMs
+        self.backgroundTaskId = backgroundTaskId
+        self.outputFile = outputFile
+        self.message = message
+        self.errorMessage = errorMessage
+    }
+}
+
+public enum AgentRuntimeEvent: Sendable, Hashable {
+    case subagent(SubagentLifecycleEvent)
+
+    public var type: String {
+        switch self {
+        case .subagent(let event):
+            return event.kind.rawValue
+        }
+    }
+}
 
 /// Tool executed by the agent. Throwing from `execute` is how tools report
 /// failures — the agent loop will turn the error into an error tool result.
@@ -113,19 +194,77 @@ public struct AgentRunSummary: Sendable {
     /// or the provider's native reason. Nil if the run emitted no
     /// assistant messages at all.
     public var finalStopReason: StopReason?
+    /// Subagent invocations observed during this run. Foreground subagents
+    /// carry final usage; background subagents are recorded at spawn time and
+    /// report completion through background-task notifications.
+    public var subagents: [SubagentRunSummary]
 
     public init(
         turns: Int = 0,
         usage: Usage = Usage(),
         cost: Cost = Cost(),
         durationMs: Int = 0,
-        finalStopReason: StopReason? = nil
+        finalStopReason: StopReason? = nil,
+        subagents: [SubagentRunSummary] = []
     ) {
         self.turns = turns
         self.usage = usage
         self.cost = cost
         self.durationMs = durationMs
         self.finalStopReason = finalStopReason
+        self.subagents = subagents
+    }
+}
+
+public enum SubagentRunStatus: String, Sendable, Hashable {
+    case completed
+    case backgroundStarted = "background_started"
+    case failed
+}
+
+public struct SubagentRunSummary: Sendable, Hashable {
+    public var subagentType: String
+    public var childSessionId: String?
+    public var description: String?
+    public var status: SubagentRunStatus
+    public var model: String?
+    public var stopReason: StopReason?
+    public var usage: Usage?
+    public var turns: Int?
+    public var cost: Cost?
+    public var durationMs: Int?
+    public var backgroundTaskId: String?
+    public var outputFile: String?
+    public var errorMessage: String?
+
+    public init(
+        subagentType: String,
+        childSessionId: String? = nil,
+        description: String? = nil,
+        status: SubagentRunStatus,
+        model: String? = nil,
+        stopReason: StopReason? = nil,
+        usage: Usage? = nil,
+        turns: Int? = nil,
+        cost: Cost? = nil,
+        durationMs: Int? = nil,
+        backgroundTaskId: String? = nil,
+        outputFile: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.subagentType = subagentType
+        self.childSessionId = childSessionId
+        self.description = description
+        self.status = status
+        self.model = model
+        self.stopReason = stopReason
+        self.usage = usage
+        self.turns = turns
+        self.cost = cost
+        self.durationMs = durationMs
+        self.backgroundTaskId = backgroundTaskId
+        self.outputFile = outputFile
+        self.errorMessage = errorMessage
     }
 }
 
@@ -144,6 +283,7 @@ public enum AgentEvent: Sendable {
     case toolExecutionStart(toolCallId: String, toolName: String, args: JSONValue)
     case toolExecutionUpdate(toolCallId: String, toolName: String, args: JSONValue, partialResult: AgentToolResult)
     case toolExecutionEnd(toolCallId: String, toolName: String, result: AgentToolResult, isError: Bool)
+    case runtimeEvent(AgentRuntimeEvent)
 
     /// Emitted just before the agent loop sleeps to back off after a
     /// retryable stream failure. `attempt` is zero-indexed and counts the
@@ -174,10 +314,29 @@ public enum AgentEvent: Sendable {
         case .toolExecutionStart: return "tool_execution_start"
         case .toolExecutionUpdate: return "tool_execution_update"
         case .toolExecutionEnd: return "tool_execution_end"
+        case .runtimeEvent(let event): return event.type
         case .streamRetry: return "stream_retry"
         case .streamRewind: return "stream_rewind"
         case .verbose: return "verbose"
         }
+    }
+}
+
+internal struct StructuredToolExecutionError: LocalizedError, @unchecked Sendable {
+    let message: String
+    let details: JSONValue?
+    let runtimeEvents: [AgentRuntimeEvent]?
+
+    var errorDescription: String? { message }
+
+    init(
+        message: String,
+        details: JSONValue? = nil,
+        runtimeEvents: [AgentRuntimeEvent]? = nil
+    ) {
+        self.message = message
+        self.details = details
+        self.runtimeEvents = runtimeEvents
     }
 }
 

--- a/Sources/KWWKAgent/BackgroundTaskManager.swift
+++ b/Sources/KWWKAgent/BackgroundTaskManager.swift
@@ -203,6 +203,18 @@ public actor BackgroundTaskManager {
         for id in ids { try? kill(id) }
     }
 
+    /// Close a logical session owned by a higher-level runtime.
+    ///
+    /// This is intentionally generic: the manager does not know whether the
+    /// session belongs to a CLI run, a subagent, a test harness, or another
+    /// caller. Closing a session cancels any still-running tasks in that
+    /// session and discards queued notifications for that session, because
+    /// the owner is going away and can no longer consume them.
+    public func closeSession(sessionId: String) {
+        killAll(sessionId: sessionId)
+        _ = drainNotifications(sessionId: sessionId)
+    }
+
     /// Snapshot of one task (running or terminal).
     public func get(_ taskId: String) -> BackgroundTaskSnapshot? {
         tasks[taskId].map { snapshot(id: taskId, entry: $0) }

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -49,7 +49,11 @@ public struct CodingAgentConfig: Sendable {
     /// agent's notification bridge (so `<task-notification>` user messages
     /// appear at turn boundaries).
     public var backgroundManager: BackgroundTaskManager?
+    /// Programmatic subagents available to the model through the `agent` tool.
+    /// When empty, no `agent` tool is registered.
+    public var subagents: [SubagentDefinition]
     public var sessionId: String
+    public var apiKeyResolver: (@Sendable (String) async -> String?)?
     /// Soft foreground timeout for bash commands. The command auto-moves to
     /// the background on this deadline when a `backgroundManager` is attached.
     public var bashDefaultTimeoutSeconds: Int
@@ -61,7 +65,9 @@ public struct CodingAgentConfig: Sendable {
         tools: CodingTools = .all,
         systemPrompt: String? = nil,
         backgroundManager: BackgroundTaskManager? = nil,
+        subagents: [SubagentDefinition] = [],
         sessionId: String = UUID().uuidString,
+        apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600
     ) {
@@ -70,9 +76,27 @@ public struct CodingAgentConfig: Sendable {
         self.tools = tools
         self.systemPrompt = systemPrompt
         self.backgroundManager = backgroundManager
+        self.subagents = subagents
         self.sessionId = sessionId
+        self.apiKeyResolver = apiKeyResolver
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+    }
+}
+
+public extension CodingAgentConfig {
+    func withBuiltinSubagents(
+        _ selection: BuiltinSubagentSelection = .all
+    ) -> CodingAgentConfig {
+        var copy = self
+        copy.subagents = SubagentDefinition.builtins(for: copy.tools, selection: selection)
+        return copy
+    }
+
+    mutating func useBuiltinSubagents(
+        _ selection: BuiltinSubagentSelection = .all
+    ) {
+        subagents = SubagentDefinition.builtins(for: tools, selection: selection)
     }
 }
 
@@ -95,30 +119,31 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
     let bgManager = config.backgroundManager
     let sessionId = config.sessionId
 
-    var tools: [AgentTool] = []
-    if config.tools.contains(.read)  { tools.append(createReadTool(cwd: cwd)) }
-    if config.tools.contains(.write) { tools.append(createWriteTool(cwd: cwd)) }
-    if config.tools.contains(.edit)  { tools.append(createEditTool(cwd: cwd)) }
-    if config.tools.contains(.bash) {
-        tools.append(createBashTool(cwd: cwd, options: BashToolOptions(
-            defaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
-            maxTimeoutSeconds: config.bashMaxTimeoutSeconds,
-            manager: bgManager,
+    var tools = await buildCodingToolList(
+        cwd: cwd,
+        selected: config.tools,
+        backgroundManager: bgManager,
+        sessionId: sessionId,
+        bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
+        bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds
+    )
+    let subagentParent = SubagentParentBox(
+        fallbackModel: config.model,
+        fallbackThinkingLevel: .off,
+        fallbackThinkingBudgets: nil,
+        fallbackMaxRetryDelayMs: nil,
+        fallbackAPIKeyResolver: config.apiKeyResolver
+    )
+    if !config.subagents.isEmpty {
+        tools.append(_createAgentTool(
+            cwd: cwd,
+            subagents: config.subagents,
+            backgroundManager: bgManager,
             sessionId: sessionId,
-            autoBackgroundOnTimeout: true
-        )))
-    }
-    if config.tools.contains(.grep) { tools.append(createGrepTool(cwd: cwd)) }
-    if config.tools.contains(.find) { tools.append(createFindTool(cwd: cwd)) }
-    if config.tools.contains(.ls)   { tools.append(createLSTool(cwd: cwd)) }
-    if config.tools.contains(.taskStatus), let bgManager {
-        tools.append(createTaskStatusTool(manager: bgManager, sessionId: sessionId))
-    }
-    if config.tools.contains(.waitTask), let bgManager {
-        tools.append(createWaitTaskTool(manager: bgManager, sessionId: sessionId))
-    }
-    if config.tools.contains(.tmux), let tmuxTool = await createTmuxTool(bgManager: bgManager, sessionId: sessionId) {
-        tools.append(tmuxTool)
+            parentSnapshot: { subagentParent.snapshot() },
+            bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
+            bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds
+        ))
     }
 
     let systemPrompt = config.systemPrompt ?? buildSystemPrompt(SystemPromptOptions(
@@ -127,18 +152,57 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         toolSnippets: DefaultToolSnippets.all
     ))
 
-    let agent = Agent(
+    let agent = Agent(options: AgentOptions(
         initialState: AgentInitialState(
             systemPrompt: systemPrompt,
             model: config.model,
             tools: tools
         ),
-        sessionId: sessionId
-    )
+        sessionId: sessionId,
+        apiKeyResolver: config.apiKeyResolver
+    ))
+    subagentParent.attach(agent)
 
     if let bgManager {
         _ = await agent.attachBackgroundManager(bgManager, sessionId: sessionId)
     }
 
     return agent
+}
+
+internal func buildCodingToolList(
+    cwd: String,
+    selected: CodingTools,
+    backgroundManager: BackgroundTaskManager?,
+    sessionId: String?,
+    bashDefaultTimeoutSeconds: Int = 120,
+    bashMaxTimeoutSeconds: Int = 600
+) async -> [AgentTool] {
+    var tools: [AgentTool] = []
+    if selected.contains(.read)  { tools.append(createReadTool(cwd: cwd)) }
+    if selected.contains(.write) { tools.append(createWriteTool(cwd: cwd)) }
+    if selected.contains(.edit)  { tools.append(createEditTool(cwd: cwd)) }
+    if selected.contains(.bash) {
+        tools.append(createBashTool(cwd: cwd, options: BashToolOptions(
+            defaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+            maxTimeoutSeconds: bashMaxTimeoutSeconds,
+            manager: backgroundManager,
+            sessionId: sessionId,
+            autoBackgroundOnTimeout: true
+        )))
+    }
+    if selected.contains(.grep) { tools.append(createGrepTool(cwd: cwd)) }
+    if selected.contains(.find) { tools.append(createFindTool(cwd: cwd)) }
+    if selected.contains(.ls)   { tools.append(createLSTool(cwd: cwd)) }
+    if selected.contains(.taskStatus), let backgroundManager {
+        tools.append(createTaskStatusTool(manager: backgroundManager, sessionId: sessionId))
+    }
+    if selected.contains(.waitTask), let backgroundManager {
+        tools.append(createWaitTaskTool(manager: backgroundManager, sessionId: sessionId))
+    }
+    if selected.contains(.tmux),
+       let tmuxTool = await createTmuxTool(bgManager: backgroundManager, sessionId: sessionId) {
+        tools.append(tmuxTool)
+    }
+    return tools
 }

--- a/Sources/KWWKAgent/CodingTools.swift
+++ b/Sources/KWWKAgent/CodingTools.swift
@@ -5,6 +5,7 @@ public enum CodingToolError: Error, Equatable, LocalizedError {
     case notImplemented
     case fileNotFound(String)
     case invalidArgument(String)
+    case runtime(String)
     case textNotFound(String)
     case multipleMatches(count: Int)
     case offsetOutOfRange(offset: Int, totalLines: Int)
@@ -18,6 +19,8 @@ public enum CodingToolError: Error, Equatable, LocalizedError {
         case .fileNotFound(let path):
             return "file not found: \(path)"
         case .invalidArgument(let message):
+            return message
+        case .runtime(let message):
             return message
         case .textNotFound(let message):
             return message

--- a/Sources/KWWKAgent/SubagentDefinition.swift
+++ b/Sources/KWWKAgent/SubagentDefinition.swift
@@ -1,0 +1,250 @@
+import Foundation
+import KWWKAI
+
+/// Model selection for a subagent.
+public enum SubagentModel: Sendable {
+    case inherit
+    case override(Model)
+}
+
+/// Programmatic definition for a fresh-context subagent.
+///
+/// `description` is routing metadata shown to the parent model. `prompt` is
+/// appended to the child agent's system prompt and should define role,
+/// boundaries, process, and output format.
+public struct SubagentDefinition: Sendable {
+    public var name: String
+    public var description: String
+    public var prompt: String
+    public var tools: CodingTools?
+    public var model: SubagentModel
+    public var runInBackgroundByDefault: Bool
+
+    public init(
+        name: String,
+        description: String,
+        prompt: String,
+        tools: CodingTools? = nil,
+        model: SubagentModel = .inherit,
+        runInBackgroundByDefault: Bool = false
+    ) {
+        self.name = name
+        self.description = description
+        self.prompt = prompt
+        self.tools = tools
+        self.model = model
+        self.runInBackgroundByDefault = runInBackgroundByDefault
+    }
+}
+
+/// Built-in subagent set used by convenience helpers and the CLI.
+public struct BuiltinSubagentSelection: OptionSet, Sendable, Hashable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let none: BuiltinSubagentSelection = []
+    public static let general = BuiltinSubagentSelection(rawValue: 1 << 0)
+    public static let explore = BuiltinSubagentSelection(rawValue: 1 << 1)
+    public static let plan = BuiltinSubagentSelection(rawValue: 1 << 2)
+    public static let all: BuiltinSubagentSelection = [
+        .general,
+        .explore,
+        .plan,
+    ]
+
+    public static func named(_ raw: String) -> BuiltinSubagentSelection? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "", "none", "off", "false", "0":
+            return BuiltinSubagentSelection.none
+        case "all", "default", "defaults":
+            return .all
+        case "general", "general-purpose":
+            return .general
+        case "explore":
+            return .explore
+        case "plan":
+            return .plan
+        default:
+            return nil
+        }
+    }
+
+    public static func parseList(_ raw: String) -> BuiltinSubagentSelection? {
+        let parts = raw
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !parts.isEmpty else { return BuiltinSubagentSelection.none }
+        var selection: BuiltinSubagentSelection = .none
+        for part in parts {
+            guard let value = named(part) else { return nil }
+            if value == .all { return .all }
+            selection.insert(value)
+        }
+        return selection
+    }
+
+    public static let validNames = "general, Explore, Plan, all, none"
+}
+
+public extension SubagentDefinition {
+    static func general(
+        tools: CodingTools? = nil
+    ) -> SubagentDefinition {
+        SubagentDefinition(
+            name: "general",
+            description: "Use for broad code research, multi-step work, and tasks that do not need a narrower specialist.",
+            prompt: """
+            You are a general-purpose coding agent.
+
+            Strengths:
+            - Searching for code, configurations, and patterns across large codebases.
+            - Analyzing multiple files to understand architecture and behavior.
+            - Executing multi-step implementation or investigation tasks.
+
+            Guidelines:
+            - Complete the assigned task fully, without unnecessary extra work.
+            - Search broadly when you do not know where something lives; read specific files when paths are known.
+            - Prefer editing existing files over creating new files when code changes are requested.
+            - Do not create documentation files unless explicitly requested.
+
+            Output:
+            - Return a concise report covering what you did and any key findings.
+            - Include important file paths, commands, or risks when relevant.
+            """,
+            tools: tools
+        )
+    }
+
+    static func explore(
+        tools: CodingTools = .readOnly
+    ) -> SubagentDefinition {
+        SubagentDefinition(
+            name: "Explore",
+            description: "Use for read-only codebase exploration, file discovery, and call-chain analysis.",
+            prompt: """
+            You are a read-only code exploration specialist.
+
+            Responsibilities:
+            - Find relevant files, symbols, call paths, and existing patterns.
+            - Read only the files needed to answer the assigned question.
+            - Do not edit, create, delete, or move files.
+            - Do not run destructive commands.
+            - Prefer direct evidence from the repository over broad guesses.
+
+            Output:
+            - Start with the direct answer or concise summary.
+            - Include important file paths, symbols, and why they matter.
+            - Use line references when they are available and useful.
+            - Mention uncertainty when evidence is incomplete.
+            """,
+            tools: tools.intersection(.readOnly)
+        )
+    }
+
+    static func plan(
+        tools: CodingTools = .readOnly
+    ) -> SubagentDefinition {
+        SubagentDefinition(
+            name: "Plan",
+            description: "Use for read-only implementation planning before code changes.",
+            prompt: """
+            You are a read-only implementation planner.
+
+            Responsibilities:
+            - Inspect the relevant code and infer the smallest coherent implementation path.
+            - Do not edit, create, delete, or move files.
+            - Do not present code changes as already made.
+            - Focus on sequencing, risk, and verification.
+
+            Output:
+            - Proposed approach.
+            - Critical files for implementation.
+            - Test or verification plan.
+            - Rollback or compatibility risks when relevant.
+            - Open questions only if they block execution.
+            """,
+            tools: tools.intersection(.readOnly)
+        )
+    }
+
+    static func codeReviewer(
+        tools: CodingTools = .readOnly
+    ) -> SubagentDefinition {
+        SubagentDefinition(
+            name: "code-reviewer",
+            description: "Use for read-only bug, risk, maintainability, and test coverage review.",
+            prompt: """
+            You are a senior code reviewer.
+
+            Responsibilities:
+            - Review for correctness, security, maintainability, and missing tests.
+            - Do not edit, create, delete, or move files.
+            - Prefer concrete findings over style commentary.
+
+            Output:
+            - Findings first, ordered by severity.
+            - Include file paths, symbols, or line references as evidence.
+            - Explain the user-visible impact for each real bug.
+            - If no issues are found, say so and call out residual risk or test gaps.
+            """,
+            tools: tools.intersection(.readOnly)
+        )
+    }
+
+    static func testRunner(
+        tools: CodingTools = [.read, .grep, .find, .ls, .bash]
+    ) -> SubagentDefinition {
+        var safeTools = tools.intersection(.readOnly)
+        if tools.contains(.bash) { safeTools.insert(.bash) }
+        if tools.contains(.taskStatus) { safeTools.insert(.taskStatus) }
+        if tools.contains(.waitTask) { safeTools.insert(.waitTask) }
+        return SubagentDefinition(
+            name: "test-runner",
+            description: "Use for running tests and analyzing test or build failures.",
+            prompt: """
+            You are a test-running specialist.
+
+            Responsibilities:
+            - Inspect project files to identify the appropriate test or build command before running it.
+            - Run focused tests when possible.
+            - Analyze failures and report likely causes.
+            - Do not edit, create, delete, or move files.
+            - Do not run destructive commands.
+            - Prefer non-interactive commands and bounded timeouts.
+
+            Output:
+            - Command(s) run.
+            - Result summary.
+            - Failure analysis with relevant log excerpts.
+            - Recommended next steps.
+            """,
+            tools: safeTools
+        )
+    }
+
+    static func builtins(
+        for tools: CodingTools,
+        selection: BuiltinSubagentSelection = .all
+    ) -> [SubagentDefinition] {
+        guard selection != .none else { return [] }
+        let readOnly = tools.intersection(.readOnly)
+
+        var agents: [SubagentDefinition] = []
+        if selection.contains(.general) {
+            agents.append(.general())
+        }
+        if selection.contains(.explore) {
+            guard !readOnly.isEmpty else { return agents }
+            agents.append(.explore(tools: readOnly))
+        }
+        if selection.contains(.plan) {
+            guard !readOnly.isEmpty else { return agents }
+            agents.append(.plan(tools: readOnly))
+        }
+        return agents
+    }
+}

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -1,0 +1,1235 @@
+import Foundation
+import KWWKAI
+
+public func createAgentTool(
+    cwd: String,
+    subagents: [SubagentDefinition],
+    parentModel: Model,
+    parentThinkingLevel: ThinkingLevel = .off,
+    parentThinkingBudgets: ThinkingBudgets? = nil,
+    parentMaxRetryDelayMs: Int? = nil,
+    backgroundManager: BackgroundTaskManager? = nil,
+    sessionId: String? = nil,
+    apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+    bashDefaultTimeoutSeconds: Int = 120,
+    bashMaxTimeoutSeconds: Int = 600
+) -> AgentTool {
+    let snapshot = SubagentParentSnapshot(
+        model: parentModel,
+        thinkingLevel: parentThinkingLevel,
+        thinkingBudgets: parentThinkingBudgets,
+        maxRetryDelayMs: parentMaxRetryDelayMs,
+        apiKeyResolver: apiKeyResolver
+    )
+    return _createAgentTool(
+        cwd: cwd,
+        subagents: subagents,
+        backgroundManager: backgroundManager,
+        sessionId: sessionId,
+        parentSnapshot: { snapshot },
+        bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+    )
+}
+
+public func createAgentTool(
+    cwd: String,
+    subagents: [SubagentDefinition],
+    parentAgent: Agent,
+    backgroundManager: BackgroundTaskManager? = nil,
+    sessionId: String? = nil,
+    fallbackAPIKeyResolver: (@Sendable (String) async -> String?)? = nil,
+    bashDefaultTimeoutSeconds: Int = 120,
+    bashMaxTimeoutSeconds: Int = 600
+) -> AgentTool {
+    let parentBox = SubagentParentBox(
+        fallbackModel: parentAgent.state.model,
+        fallbackThinkingLevel: parentAgent.state.thinkingLevel,
+        fallbackThinkingBudgets: parentAgent.thinkingBudgets,
+        fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
+        fallbackAPIKeyResolver: parentAgent.apiKeyResolver ?? fallbackAPIKeyResolver
+    )
+    parentBox.attach(parentAgent)
+    return _createAgentTool(
+        cwd: cwd,
+        subagents: subagents,
+        backgroundManager: backgroundManager,
+        sessionId: sessionId,
+        parentSnapshot: { parentBox.snapshot() },
+        bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+    )
+}
+
+internal struct SubagentParentSnapshot: Sendable {
+    var model: Model
+    var thinkingLevel: ThinkingLevel
+    var thinkingBudgets: ThinkingBudgets?
+    var maxRetryDelayMs: Int?
+    var apiKeyResolver: (@Sendable (String) async -> String?)?
+}
+
+internal final class SubagentParentBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private weak var agent: Agent?
+    private let fallbackModel: Model
+    private let fallbackThinkingLevel: ThinkingLevel
+    private let fallbackThinkingBudgets: ThinkingBudgets?
+    private let fallbackMaxRetryDelayMs: Int?
+    private let fallbackAPIKeyResolver: (@Sendable (String) async -> String?)?
+
+    init(
+        fallbackModel: Model,
+        fallbackThinkingLevel: ThinkingLevel,
+        fallbackThinkingBudgets: ThinkingBudgets?,
+        fallbackMaxRetryDelayMs: Int?,
+        fallbackAPIKeyResolver: (@Sendable (String) async -> String?)?
+    ) {
+        self.fallbackModel = fallbackModel
+        self.fallbackThinkingLevel = fallbackThinkingLevel
+        self.fallbackThinkingBudgets = fallbackThinkingBudgets
+        self.fallbackMaxRetryDelayMs = fallbackMaxRetryDelayMs
+        self.fallbackAPIKeyResolver = fallbackAPIKeyResolver
+    }
+
+    func attach(_ agent: Agent) {
+        lock.withLock { self.agent = agent }
+    }
+
+    func snapshot() -> SubagentParentSnapshot {
+        lock.withLock {
+            guard let agent else {
+                return SubagentParentSnapshot(
+                    model: fallbackModel,
+                    thinkingLevel: fallbackThinkingLevel,
+                    thinkingBudgets: fallbackThinkingBudgets,
+                    maxRetryDelayMs: fallbackMaxRetryDelayMs,
+                    apiKeyResolver: fallbackAPIKeyResolver
+                )
+            }
+            return SubagentParentSnapshot(
+                model: agent.state.model,
+                thinkingLevel: agent.state.thinkingLevel,
+                thinkingBudgets: agent.thinkingBudgets,
+                maxRetryDelayMs: agent.maxRetryDelayMs,
+                apiKeyResolver: agent.apiKeyResolver ?? fallbackAPIKeyResolver
+            )
+        }
+    }
+}
+
+internal func _createAgentTool(
+    cwd: String,
+    subagents: [SubagentDefinition],
+    backgroundManager: BackgroundTaskManager?,
+    sessionId: String?,
+    parentSnapshot: @escaping @Sendable () -> SubagentParentSnapshot,
+    bashDefaultTimeoutSeconds: Int = 120,
+    bashMaxTimeoutSeconds: Int = 600
+) -> AgentTool {
+    let registry = SubagentRegistry(subagents)
+    let parameters: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "description": .object([
+                "type": .string("string"),
+                "description": .string("A short 3-5 word description of the task."),
+            ]),
+            "prompt": .object([
+                "type": .string("string"),
+                "description": .string("Complete task instructions for the subagent. Fresh subagents do not inherit the parent transcript."),
+            ]),
+            "subagent_type": .object([
+                "type": .string("string"),
+                "enum": .array(registry.names.map { .string($0) }),
+                "description": .string("The specialized subagent to run. Omit to use the general subagent when configured."),
+            ]),
+            "model": .object([
+                "type": .string("string"),
+                "description": .string("Optional model id override. Omit to use the subagent definition's model or inherit the parent model."),
+            ]),
+            "run_in_background": .object([
+                "type": .string("boolean"),
+                "description": .string("Run this independent subagent in the background. You will be notified when it completes."),
+            ]),
+        ]),
+        "required": .array([.string("description"), .string("prompt")]),
+    ])
+
+    return AgentTool(
+        name: "agent",
+        label: "agent",
+        description: buildAgentToolDescription(registry: registry),
+        parameters: parameters,
+        execute: { toolCallId, args, cancellation, onUpdate in
+            try cancellation?.throwIfCancelled()
+            let input = try parseAgentToolInput(args)
+            let requestedType = input.subagentType ?? SubagentRegistry.defaultFallbackName
+            guard let definition = registry.definition(named: requestedType) else {
+                if input.subagentType == nil {
+                    throw CodingToolError.invalidArgument(
+                        "agent: `subagent_type` was omitted but no '\(SubagentRegistry.defaultFallbackName)' subagent is configured. Available subagents: \(registry.names.joined(separator: ", "))"
+                    )
+                }
+                throw CodingToolError.invalidArgument(
+                    "agent: unknown subagent_type '\(requestedType)'. Available subagents: \(registry.names.joined(separator: ", "))"
+                )
+            }
+
+            let childSessionId = makeSubagentSessionId(parent: sessionId, name: definition.name)
+            let runner = SubagentInvocationRunner(
+                cwd: cwd,
+                definition: definition,
+                taskPrompt: input.prompt,
+                modelOverride: input.modelOverride,
+                parentSnapshot: parentSnapshot,
+                backgroundManager: backgroundManager,
+                childSessionId: childSessionId,
+                bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+                bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+            )
+            let shouldRunBackground = input.runInBackground ?? definition.runInBackgroundByDefault
+            if shouldRunBackground {
+                guard let backgroundManager else {
+                    throw CodingToolError.invalidArgument("agent: run_in_background requires a BackgroundTaskManager")
+                }
+                let bgRunner = SubagentBackgroundRunner(
+                    runner: runner,
+                    subagentType: definition.name,
+                    description: input.description
+                )
+                let (taskId, outputFile) = await backgroundManager.spawn(
+                    runner: bgRunner,
+                    sessionId: sessionId
+                )
+                let body = """
+                Started subagent \(definition.name) in the background.
+                task_id: \(taskId)
+                output_file: \(outputFile.path)
+                """
+                let display = "agent \(definition.name) background · \(taskId) · \(outputFile.path)"
+                return AgentToolResult(
+                    content: [.text(TextContent(text: body))],
+                    details: .object([
+                        "status": .string("background_started"),
+                        "task_id": .string(taskId),
+                        "output_file": .string(outputFile.path),
+                        "subagent_type": .string(definition.name),
+                        "child_session_id": .string(childSessionId),
+                        "description": .string(input.description),
+                    ]),
+                    runtimeEvents: [
+                        .subagent(SubagentLifecycleEvent(
+                            kind: .backgroundStarted,
+                            toolCallId: toolCallId,
+                            subagentType: definition.name,
+                            childSessionId: childSessionId,
+                            description: input.description,
+                            backgroundTaskId: taskId,
+                            outputFile: outputFile.path,
+                            message: "started in background"
+                        )),
+                    ],
+                    uiDisplay: [display]
+                )
+            }
+
+            onUpdate?(AgentToolResult(
+                content: [.text(TextContent(text: "Starting subagent \(definition.name)..."))],
+                details: .object([
+                    "status": .string("starting"),
+                    "subagent_type": .string(definition.name),
+                    "child_session_id": .string(childSessionId),
+                    "description": .string(input.description),
+                ]),
+                runtimeEvents: [
+                    .subagent(SubagentLifecycleEvent(
+                        kind: .started,
+                        toolCallId: toolCallId,
+                        subagentType: definition.name,
+                        childSessionId: childSessionId,
+                        description: input.description,
+                        message: "starting"
+                    )),
+                ],
+                uiDisplay: ["agent \(definition.name) starting · 0 tokens"]
+            ))
+            let result: SubagentResult
+            do {
+                result = try await runner.run(
+                    cancellation: cancellation,
+                    onUpdate: onUpdate,
+                    toolCallId: toolCallId
+                )
+            } catch {
+                let message = subagentErrorMessage(error)
+                throw StructuredToolExecutionError(
+                    message: message,
+                    details: subagentFailureDetails(
+                        definition: definition,
+                        input: input,
+                        childSessionId: childSessionId,
+                        message: message
+                    ),
+                    runtimeEvents: [
+                        .subagent(SubagentLifecycleEvent(
+                            kind: .failed,
+                            toolCallId: toolCallId,
+                            subagentType: definition.name,
+                            childSessionId: childSessionId,
+                            description: input.description,
+                            errorMessage: message
+                        )),
+                    ]
+                )
+            }
+            let body = """
+            Subagent \(definition.name) completed.
+
+            \(result.text)
+            """
+            return AgentToolResult(
+                content: [.text(TextContent(text: body))],
+                details: .object([
+                    "status": .string("completed"),
+                    "subagent_type": .string(definition.name),
+                    "description": .string(input.description),
+                    "child_session_id": .string(childSessionId),
+                    "model": .string(result.model.id),
+                    "stop_reason": .string(result.stopReason.rawValue),
+                    "usage": usageDetails(result.usage),
+                    "turns": .int(result.turns),
+                    "cost": costDetails(result.cost),
+                    "duration_ms": .int(result.durationMs),
+                ]),
+                runtimeEvents: [
+                    .subagent(SubagentLifecycleEvent(
+                        kind: .completed,
+                        toolCallId: toolCallId,
+                        subagentType: definition.name,
+                        childSessionId: childSessionId,
+                        description: input.description,
+                        model: result.model.id,
+                        stopReason: result.stopReason,
+                        usage: result.usage,
+                        turns: result.turns,
+                        cost: result.cost,
+                        durationMs: result.durationMs,
+                        message: shortSubagentSummary(result.text)
+                    )),
+                ],
+                uiDisplay: ["agent \(definition.name) completed · \(formatUsage(result.usage))"]
+            )
+        }
+    )
+}
+
+private struct SubagentRegistry: Sendable {
+    static let defaultFallbackName = "general"
+
+    let names: [String]
+    private let definitions: [String: SubagentDefinition]
+
+    init(_ subagents: [SubagentDefinition]) {
+        var names: [String] = []
+        var definitions: [String: SubagentDefinition] = [:]
+        for definition in subagents {
+            let name = definition.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else { continue }
+            if definitions[name] == nil {
+                names.append(name)
+            }
+            definitions[name] = definition
+        }
+        self.names = names
+        self.definitions = definitions
+    }
+
+    func definition(named name: String) -> SubagentDefinition? {
+        definitions[name]
+    }
+}
+
+private struct AgentToolInput {
+    var description: String
+    var prompt: String
+    var subagentType: String?
+    var modelOverride: String?
+    var runInBackground: Bool?
+}
+
+private func parseAgentToolInput(_ args: JSONValue) throws -> AgentToolInput {
+    guard case .object(let obj) = args else {
+        throw CodingToolError.invalidArgument("agent: expected object input")
+    }
+    guard case .string(let description) = obj["description"] ?? .null,
+          !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw CodingToolError.invalidArgument("agent: `description` is required")
+    }
+    guard case .string(let prompt) = obj["prompt"] ?? .null,
+          !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw CodingToolError.invalidArgument("agent: `prompt` is required")
+    }
+    let subagentType: String? = {
+        switch obj["subagent_type"] ?? .null {
+        case .null:
+            return nil
+        case .string(let raw):
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        default:
+            return nil
+        }
+    }()
+    let modelOverride: String? = {
+        guard case .string(let raw) = obj["model"] ?? .null else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }()
+    let runInBackground: Bool? = {
+        guard case .bool(let value) = obj["run_in_background"] ?? .null else { return nil }
+        return value
+    }()
+    return AgentToolInput(
+        description: description,
+        prompt: prompt,
+        subagentType: subagentType,
+        modelOverride: modelOverride,
+        runInBackground: runInBackground
+    )
+}
+
+private enum SubagentPromptBuilder {
+    static func agentToolDescription(registry: SubagentRegistry) -> String {
+        let agents = registry.names.map { name -> String in
+            guard let definition = registry.definition(named: name) else { return "- \(name)" }
+            return "- \(name): \(definition.description) (Tools: \(subagentToolsDescription(definition.tools)))"
+        }.joined(separator: "\n")
+
+        return """
+        Launch a fresh-context subagent for a specialized task.
+
+        Available subagents:
+        \(agents.isEmpty ? "(none)" : agents)
+
+        Usage notes:
+        - Omit `subagent_type` to use `general` when it is available; otherwise set it to one of the available subagents.
+        - Always include a short `description` summarizing the work.
+        - The subagent does not inherit the parent transcript. Put all necessary file paths, errors, goals, and constraints in `prompt`.
+        - The subagent's output is returned only to you as this tool result; summarize it for the user when relevant.
+        - Background tasks started by the subagent's own tools are scoped to the subagent and are killed when that subagent ends.
+        - Use foreground mode by default when you need the result before continuing.
+        - Use `run_in_background` only for independent work. You will be notified when it completes; do not poll in a loop.
+        - Subagents cannot spawn other subagents.
+        """
+    }
+
+    static func systemPrompt(
+        definition: SubagentDefinition,
+        cwd: String,
+        tools: [AgentTool]
+    ) -> String {
+        let instructions = """
+
+        # Subagent Instructions
+
+        You are running as the `\(definition.name)` subagent.
+
+        \(definition.prompt)
+
+        Any background tasks you start are scoped to your subagent lifecycle and will be killed when you finish. If their output matters, wait for them before giving your final answer.
+
+        You cannot spawn other subagents. Complete the assigned task yourself with the tools available to you.
+        """
+        return buildSystemPrompt(SystemPromptOptions(
+            cwd: cwd,
+            selectedToolNames: tools.map { $0.name },
+            toolSnippets: DefaultToolSnippets.all,
+            appendSystemPrompt: instructions
+        ))
+    }
+}
+
+private func buildAgentToolDescription(registry: SubagentRegistry) -> String {
+    SubagentPromptBuilder.agentToolDescription(registry: registry)
+}
+
+private func subagentToolsDescription(_ tools: CodingTools?) -> String {
+    guard let tools else { return "All tools" }
+    var names: [String] = []
+    if tools.contains(.read) { names.append("read") }
+    if tools.contains(.write) { names.append("write") }
+    if tools.contains(.edit) { names.append("edit") }
+    if tools.contains(.bash) { names.append("bash") }
+    if tools.contains(.grep) { names.append("grep") }
+    if tools.contains(.find) { names.append("find") }
+    if tools.contains(.ls) { names.append("ls") }
+    if tools.contains(.taskStatus) { names.append("task_status") }
+    if tools.contains(.waitTask) { names.append("wait_task") }
+    if tools.contains(.tmux) { names.append("tmux") }
+    return names.isEmpty ? "None" : names.joined(separator: ", ")
+}
+
+public struct SubagentResult: Sendable {
+    public var text: String
+    public var model: Model
+    public var stopReason: StopReason
+    public var usage: Usage
+    public var turns: Int
+    public var cost: Cost
+    public var durationMs: Int
+
+    public init(
+        text: String,
+        model: Model,
+        stopReason: StopReason,
+        usage: Usage,
+        turns: Int = 0,
+        cost: Cost = Cost(),
+        durationMs: Int = 0
+    ) {
+        self.text = text
+        self.model = model
+        self.stopReason = stopReason
+        self.usage = usage
+        self.turns = turns
+        self.cost = cost
+        self.durationMs = durationMs
+    }
+}
+
+public struct StartedSubagentTask: Sendable {
+    public var taskId: String
+    public var outputFile: URL
+    public var childSessionId: String
+    public var subagentType: String
+    public var description: String
+
+    public init(
+        taskId: String,
+        outputFile: URL,
+        childSessionId: String,
+        subagentType: String,
+        description: String
+    ) {
+        self.taskId = taskId
+        self.outputFile = outputFile
+        self.childSessionId = childSessionId
+        self.subagentType = subagentType
+        self.description = description
+    }
+}
+
+/// SDK-facing runner for invoking configured subagents directly, without
+/// asking a parent model to call the `agent` tool.
+public struct SubagentRunner: Sendable {
+    private var cwd: String
+    private var subagents: [SubagentDefinition]
+    private var backgroundManager: BackgroundTaskManager?
+    private var parentSessionId: String?
+    private var parentSnapshot: @Sendable () -> SubagentParentSnapshot
+    private var bashDefaultTimeoutSeconds: Int
+    private var bashMaxTimeoutSeconds: Int
+
+    public init(
+        cwd: String,
+        subagents: [SubagentDefinition],
+        parentModel: Model,
+        parentThinkingLevel: ThinkingLevel = .off,
+        parentThinkingBudgets: ThinkingBudgets? = nil,
+        parentMaxRetryDelayMs: Int? = nil,
+        backgroundManager: BackgroundTaskManager? = nil,
+        sessionId: String? = nil,
+        apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        bashDefaultTimeoutSeconds: Int = 120,
+        bashMaxTimeoutSeconds: Int = 600
+    ) {
+        let snapshot = SubagentParentSnapshot(
+            model: parentModel,
+            thinkingLevel: parentThinkingLevel,
+            thinkingBudgets: parentThinkingBudgets,
+            maxRetryDelayMs: parentMaxRetryDelayMs,
+            apiKeyResolver: apiKeyResolver
+        )
+        self.cwd = cwd
+        self.subagents = subagents
+        self.backgroundManager = backgroundManager
+        self.parentSessionId = sessionId
+        self.parentSnapshot = { snapshot }
+        self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
+        self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+    }
+
+    public init(
+        cwd: String,
+        subagents: [SubagentDefinition],
+        parentAgent: Agent,
+        backgroundManager: BackgroundTaskManager? = nil,
+        sessionId: String? = nil,
+        fallbackAPIKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        bashDefaultTimeoutSeconds: Int = 120,
+        bashMaxTimeoutSeconds: Int = 600
+    ) {
+        let parentBox = SubagentParentBox(
+            fallbackModel: parentAgent.state.model,
+            fallbackThinkingLevel: parentAgent.state.thinkingLevel,
+            fallbackThinkingBudgets: parentAgent.thinkingBudgets,
+            fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
+            fallbackAPIKeyResolver: parentAgent.apiKeyResolver ?? fallbackAPIKeyResolver
+        )
+        parentBox.attach(parentAgent)
+        self.cwd = cwd
+        self.subagents = subagents
+        self.backgroundManager = backgroundManager
+        self.parentSessionId = sessionId ?? parentAgent.sessionId
+        self.parentSnapshot = { parentBox.snapshot() }
+        self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
+        self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+    }
+
+    public func run(
+        type: String,
+        prompt: String,
+        modelOverride: String? = nil,
+        cancellation: CancellationHandle? = nil,
+        onUpdate: AgentToolUpdate? = nil
+    ) async throws -> SubagentResult {
+        let definition = try definition(named: type)
+        let runner = makeInvocationRunner(
+            definition: definition,
+            prompt: prompt,
+            modelOverride: modelOverride
+        )
+        return try await runner.run(cancellation: cancellation, onUpdate: onUpdate)
+    }
+
+    public func startBackground(
+        type: String,
+        prompt: String,
+        description: String,
+        modelOverride: String? = nil
+    ) async throws -> StartedSubagentTask {
+        guard let backgroundManager else {
+            throw CodingToolError.invalidArgument("SubagentRunner.startBackground requires a BackgroundTaskManager")
+        }
+        let definition = try definition(named: type)
+        let runner = makeInvocationRunner(
+            definition: definition,
+            prompt: prompt,
+            modelOverride: modelOverride
+        )
+        let bgRunner = SubagentBackgroundRunner(
+            runner: runner,
+            subagentType: definition.name,
+            description: description
+        )
+        let (taskId, outputFile) = await backgroundManager.spawn(
+            runner: bgRunner,
+            sessionId: parentSessionId
+        )
+        return StartedSubagentTask(
+            taskId: taskId,
+            outputFile: outputFile,
+            childSessionId: runner.childSessionId,
+            subagentType: definition.name,
+            description: description
+        )
+    }
+
+    private func definition(named rawName: String) throws -> SubagentDefinition {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let definition = subagents.first(where: { $0.name == trimmed }) {
+            return definition
+        }
+        let names = subagents
+            .map(\.name)
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: ", ")
+        throw CodingToolError.invalidArgument(
+            "subagent: unknown type '\(rawName)'. Available subagents: \(names)"
+        )
+    }
+
+    private func makeInvocationRunner(
+        definition: SubagentDefinition,
+        prompt: String,
+        modelOverride: String?
+    ) -> SubagentInvocationRunner {
+        SubagentInvocationRunner(
+            cwd: cwd,
+            definition: definition,
+            taskPrompt: prompt,
+            modelOverride: modelOverride,
+            parentSnapshot: parentSnapshot,
+            backgroundManager: backgroundManager,
+            childSessionId: makeSubagentSessionId(parent: parentSessionId, name: definition.name),
+            bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+        )
+    }
+}
+
+private struct SubagentUsageSnapshot: Sendable, Equatable {
+    var usage: Usage
+    var estimated: Bool
+}
+
+private actor SubagentProgressEmitter {
+    private let subagentName: String
+    private let childSessionId: String
+    private let toolCallId: String?
+    private let onUpdate: AgentToolUpdate?
+    private var completedUsage = Usage()
+    private var lastSnapshot: SubagentUsageSnapshot?
+
+    init(
+        subagentName: String,
+        childSessionId: String,
+        toolCallId: String?,
+        onUpdate: AgentToolUpdate?
+    ) {
+        self.subagentName = subagentName
+        self.childSessionId = childSessionId
+        self.toolCallId = toolCallId
+        self.onUpdate = onUpdate
+    }
+
+    func observe(_ event: AgentEvent) {
+        guard let onUpdate else { return }
+        let snapshot: SubagentUsageSnapshot?
+        switch event {
+        case .messageUpdate(let assistant, _):
+            let live = liveUsage(for: assistant)
+            snapshot = SubagentUsageSnapshot(
+                usage: addUsage(completedUsage, live.usage),
+                estimated: live.estimated
+            )
+
+        case .messageEnd(let message):
+            guard case .assistant(let assistant) = message else { return }
+            completedUsage = addUsage(completedUsage, finalizedUsage(for: assistant))
+            snapshot = SubagentUsageSnapshot(usage: completedUsage, estimated: false)
+
+        case .agentEnd(_, let summary):
+            completedUsage = summary.usage
+            snapshot = SubagentUsageSnapshot(usage: completedUsage, estimated: false)
+
+        default:
+            return
+        }
+
+        guard let snapshot, snapshot != lastSnapshot else { return }
+        lastSnapshot = snapshot
+        onUpdate(subagentProgressResult(
+            subagentName: subagentName,
+            childSessionId: childSessionId,
+            toolCallId: toolCallId,
+            snapshot: snapshot
+        ))
+    }
+}
+
+private actor SubagentSummaryCapture {
+    private var summary: AgentRunSummary?
+
+    func observe(_ event: AgentEvent) {
+        guard case .agentEnd(_, let summary) = event else { return }
+        self.summary = summary
+    }
+
+    func snapshot() -> AgentRunSummary? {
+        summary
+    }
+}
+
+private struct SubagentInvocationRunner: Sendable {
+    var cwd: String
+    var definition: SubagentDefinition
+    var taskPrompt: String
+    var modelOverride: String?
+    var parentSnapshot: @Sendable () -> SubagentParentSnapshot
+    var backgroundManager: BackgroundTaskManager?
+    var childSessionId: String
+    var bashDefaultTimeoutSeconds: Int
+    var bashMaxTimeoutSeconds: Int
+
+    func run(
+        cancellation: CancellationHandle?,
+        onUpdate: AgentToolUpdate?,
+        toolCallId: String? = nil
+    ) async throws -> SubagentResult {
+        do {
+            let result = try await runChild(
+                cancellation: cancellation,
+                onUpdate: onUpdate,
+                toolCallId: toolCallId
+            )
+            await closeChildSession()
+            return result
+        } catch {
+            await closeChildSession()
+            throw error
+        }
+    }
+
+    private func runChild(
+        cancellation: CancellationHandle?,
+        onUpdate: AgentToolUpdate?,
+        toolCallId: String?
+    ) async throws -> SubagentResult {
+        try cancellation?.throwIfCancelled()
+        let parent = parentSnapshot()
+        let model = resolveSubagentModel(
+            parent: parent.model,
+            definitionModel: definition.model,
+            toolOverride: modelOverride
+        )
+        let selectedTools = definition.tools ?? .all
+        let tools = await buildCodingToolList(
+            cwd: cwd,
+            selected: selectedTools,
+            backgroundManager: backgroundManager,
+            sessionId: childSessionId,
+            bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+        )
+        let systemPrompt = buildSubagentSystemPrompt(
+            definition: definition,
+            cwd: cwd,
+            tools: tools
+        )
+        let child = Agent(options: AgentOptions(
+            initialState: AgentInitialState(
+                systemPrompt: systemPrompt,
+                model: model,
+                thinkingLevel: parent.thinkingLevel,
+                tools: tools
+            ),
+            sessionId: childSessionId,
+            thinkingBudgets: parent.thinkingBudgets,
+            maxRetryDelayMs: parent.maxRetryDelayMs,
+            apiKeyResolver: parent.apiKeyResolver
+        ))
+        let progress = SubagentProgressEmitter(
+            subagentName: definition.name,
+            childSessionId: childSessionId,
+            toolCallId: toolCallId,
+            onUpdate: onUpdate
+        )
+        let summaryCapture = SubagentSummaryCapture()
+        let unsubscribeProgress = child.subscribe { event, _ in
+            await progress.observe(event)
+            await summaryCapture.observe(event)
+        }
+        let detachBackground: (@Sendable () async -> Void)?
+        if let backgroundManager {
+            detachBackground = await child.attachBackgroundManager(
+                backgroundManager,
+                sessionId: childSessionId
+            )
+        } else {
+            detachBackground = nil
+        }
+        let cancelRegistration = cancellation?.onCancel { _ in child.abort() }
+        do {
+            try await child.prompt(taskPrompt)
+        } catch {
+            cancelRegistration?.cancel()
+            unsubscribeProgress()
+            if let detachBackground {
+                await detachBackground()
+            }
+            throw error
+        }
+        cancelRegistration?.cancel()
+        unsubscribeProgress()
+        if let detachBackground {
+            await detachBackground()
+        }
+        if cancellation?.isCancelled ?? false {
+            throw CodingToolError.aborted
+        }
+        let childSummary = await summaryCapture.snapshot()
+        return try extractSubagentResult(
+            messages: child.state.messages,
+            model: model,
+            summary: childSummary
+        )
+    }
+
+    private func closeChildSession() async {
+        await KWWKAI.closeProviderSession(sessionId: childSessionId)
+        guard let backgroundManager else { return }
+        await backgroundManager.closeSession(sessionId: childSessionId)
+    }
+}
+
+private struct SubagentBackgroundRunner: BackgroundTaskRunner {
+    var runner: SubagentInvocationRunner
+    var subagentType: String
+    var description: String
+
+    var spec: BackgroundTaskSpec {
+        BackgroundTaskSpec(
+            kind: "agent",
+            label: "agent:\(subagentType)",
+            description: description
+        )
+    }
+
+    func run(
+        taskId: String,
+        outputFile: URL,
+        cancellation: CancellationHandle,
+        onDone: @escaping @Sendable (BackgroundTaskOutcome) -> Void
+    ) {
+        Task.detached {
+            do {
+                let result = try await runner.run(cancellation: cancellation, onUpdate: nil)
+                let outputBytes = try writeSubagentOutput(result.text, to: outputFile)
+                onDone(BackgroundTaskOutcome(
+                    success: true,
+                    summary: "completed",
+                    details: .object([
+                        "status": .string("completed"),
+                        "subagent_type": .string(subagentType),
+                        "child_session_id": .string(runner.childSessionId),
+                        "model": .string(result.model.id),
+                        "stop_reason": .string(result.stopReason.rawValue),
+                        "usage": usageDetails(result.usage),
+                        "turns": .int(result.turns),
+                        "cost": costDetails(result.cost),
+                        "duration_ms": .int(result.durationMs),
+                        "output_bytes": .int(outputBytes),
+                    ])
+                ))
+            } catch {
+                let message = subagentErrorMessage(error)
+                let outputBytes = try? writeSubagentOutput(
+                    "Subagent \(subagentType) failed: \(message)\n",
+                    to: outputFile
+                )
+                onDone(BackgroundTaskOutcome(
+                    success: false,
+                    summary: cancellation.isCancelled ? "aborted" : "failed",
+                    details: .object([
+                        "status": .string("failed"),
+                        "subagent_type": .string(subagentType),
+                        "child_session_id": .string(runner.childSessionId),
+                        "error_message": .string(message),
+                        "output_bytes": .int(outputBytes ?? 0),
+                    ]),
+                    errorMessage: message
+                ))
+            }
+        }
+    }
+}
+
+private func buildSubagentSystemPrompt(
+    definition: SubagentDefinition,
+    cwd: String,
+    tools: [AgentTool]
+) -> String {
+    SubagentPromptBuilder.systemPrompt(definition: definition, cwd: cwd, tools: tools)
+}
+
+private func resolveSubagentModel(
+    parent: Model,
+    definitionModel: SubagentModel,
+    toolOverride: String?
+) -> Model {
+    if let toolOverride {
+        return resolveModelString(toolOverride, parent: parent)
+    }
+    switch definitionModel {
+    case .inherit:
+        return parent
+    case .override(let model):
+        return model
+    }
+}
+
+private func resolveModelString(_ raw: String, parent: Model) -> Model {
+    let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if value.isEmpty || value.lowercased() == "inherit" {
+        return parent
+    }
+    if let sameProvider = ModelsCatalog.model(provider: parent.provider, id: value) {
+        return adoptRuntimeFields(from: parent, into: sameProvider)
+    }
+    if let anyProvider = ModelsCatalog.all.first(where: { $0.id == value }) {
+        return anyProvider
+    }
+    var fallback = parent
+    fallback.id = value
+    fallback.name = value
+    return fallback
+}
+
+private func adoptRuntimeFields(from current: Model, into picked: Model) -> Model {
+    var rebuilt = picked
+    rebuilt.api = current.api
+    rebuilt.provider = current.provider
+    rebuilt.baseUrl = current.baseUrl
+    rebuilt.headers = current.headers
+    return rebuilt
+}
+
+private func makeSubagentSessionId(parent: String?, name: String) -> String {
+    let safeName = name.replacingOccurrences(of: " ", with: "-")
+    if let parent, !parent.isEmpty {
+        return "\(parent):subagent:\(safeName):\(UUID().uuidString)"
+    }
+    return "subagent:\(safeName):\(UUID().uuidString)"
+}
+
+private func subagentProgressResult(
+    subagentName: String,
+    childSessionId: String,
+    toolCallId: String?,
+    snapshot: SubagentUsageSnapshot
+) -> AgentToolResult {
+    let label = "agent \(subagentName) running · \(formatUsage(snapshot.usage, estimated: snapshot.estimated))"
+    return AgentToolResult(
+        content: [.text(TextContent(text: label))],
+        details: .object([
+            "status": .string("running"),
+            "subagent_type": .string(subagentName),
+            "child_session_id": .string(childSessionId),
+            "usage": usageDetails(snapshot.usage),
+            "estimated": .bool(snapshot.estimated),
+        ]),
+        runtimeEvents: [
+            .subagent(SubagentLifecycleEvent(
+                kind: .toolUpdate,
+                toolCallId: toolCallId,
+                subagentType: subagentName,
+                childSessionId: childSessionId,
+                usage: snapshot.usage,
+                usageEstimated: snapshot.estimated,
+                message: label
+            )),
+        ],
+        uiDisplay: [label]
+    )
+}
+
+private func liveUsage(for assistant: AssistantMessage) -> SubagentUsageSnapshot {
+    let usage = normalizedUsage(assistant.usage)
+    if hasUsage(usage) {
+        return SubagentUsageSnapshot(usage: usage, estimated: false)
+    }
+    let estimatedOutput = estimateTokens(assistantOutputText(assistant))
+    guard estimatedOutput > 0 else {
+        return SubagentUsageSnapshot(usage: Usage(), estimated: false)
+    }
+    return SubagentUsageSnapshot(
+        usage: Usage(output: estimatedOutput, totalTokens: estimatedOutput),
+        estimated: true
+    )
+}
+
+private func finalizedUsage(for assistant: AssistantMessage) -> Usage {
+    let usage = normalizedUsage(assistant.usage)
+    if hasUsage(usage) { return usage }
+    let estimatedOutput = estimateTokens(assistantOutputText(assistant))
+    return Usage(output: estimatedOutput, totalTokens: estimatedOutput)
+}
+
+private func aggregateAssistantUsage(messages: [Message]) -> Usage {
+    messages.reduce(into: Usage()) { partial, message in
+        guard case .assistant(let assistant) = message else { return }
+        partial = addUsage(partial, finalizedUsage(for: assistant))
+    }
+}
+
+private func normalizedUsage(_ usage: Usage) -> Usage {
+    var out = usage
+    if out.totalTokens == 0 {
+        out.totalTokens = out.input + out.output + out.cacheRead + out.cacheWrite
+    }
+    return out
+}
+
+private func hasUsage(_ usage: Usage) -> Bool {
+    usage.input > 0
+        || usage.output > 0
+        || usage.cacheRead > 0
+        || usage.cacheWrite > 0
+        || usage.totalTokens > 0
+}
+
+private func addUsage(_ lhs: Usage, _ rhs: Usage) -> Usage {
+    Usage(
+        input: lhs.input + rhs.input,
+        output: lhs.output + rhs.output,
+        cacheRead: lhs.cacheRead + rhs.cacheRead,
+        cacheWrite: lhs.cacheWrite + rhs.cacheWrite,
+        totalTokens: normalizedUsage(lhs).totalTokens + normalizedUsage(rhs).totalTokens
+    )
+}
+
+private func assistantOutputText(_ assistant: AssistantMessage) -> String {
+    assistant.content.compactMap { block -> String? in
+        switch block {
+        case .text(let text):
+            return text.text
+        case .thinking(let thinking):
+            return thinking.thinking
+        case .toolCall(let call):
+            return call.name
+        }
+    }.joined(separator: "\n")
+}
+
+private func estimateTokens(_ text: String) -> Int {
+    guard !text.isEmpty else { return 0 }
+    return Int((Double(text.utf8.count) / 4.0).rounded(.up))
+}
+
+private func usageDetails(_ usage: Usage) -> JSONValue {
+    let normalized = normalizedUsage(usage)
+    return .object([
+        "input": .int(normalized.input),
+        "output": .int(normalized.output),
+        "cache_read": .int(normalized.cacheRead),
+        "cache_write": .int(normalized.cacheWrite),
+        "total_tokens": .int(normalized.totalTokens),
+    ])
+}
+
+private func costDetails(_ cost: Cost) -> JSONValue {
+    .object([
+        "input": .double(cost.input),
+        "output": .double(cost.output),
+        "cache_read": .double(cost.cacheRead),
+        "cache_write": .double(cost.cacheWrite),
+        "total": .double(cost.total),
+    ])
+}
+
+private func formatUsage(_ usage: Usage, estimated: Bool = false) -> String {
+    let normalized = normalizedUsage(usage)
+    let prefix = estimated ? "~" : ""
+    if normalized.input == 0, normalized.cacheRead == 0, normalized.cacheWrite == 0 {
+        return "\(prefix)\(normalized.totalTokens) tokens"
+    }
+    var parts = [
+        "in \(normalized.input)",
+        "out \(normalized.output)",
+    ]
+    if normalized.cacheRead > 0 { parts.append("cache \(normalized.cacheRead)") }
+    if normalized.cacheWrite > 0 { parts.append("cache write \(normalized.cacheWrite)") }
+    return "\(prefix)\(normalized.totalTokens) tokens (\(parts.joined(separator: " · ")))"
+}
+
+private func extractSubagentResult(
+    messages: [Message],
+    model: Model,
+    summary: AgentRunSummary?
+) throws -> SubagentResult {
+    guard let final = messages.reversed().compactMap({ message -> AssistantMessage? in
+        if case .assistant(let assistant) = message { return assistant }
+        return nil
+    }).first else {
+        throw CodingToolError.runtime("agent: subagent produced no assistant message")
+    }
+    if final.stopReason == .aborted {
+        throw CodingToolError.aborted
+    }
+    if final.stopReason == .error {
+        let message = final.errorMessage ?? "subagent stopped with error"
+        if message.hasPrefix("Maximum turn limit") {
+            throw CodingToolError.runtime("agent: subagent reached maxTurns before producing final text: \(message)")
+        }
+        throw CodingToolError.runtime("agent: \(message)")
+    }
+    if let error = final.errorMessage, !error.isEmpty {
+        throw CodingToolError.runtime("agent: \(error)")
+    }
+    if final.stopReason == .toolUse {
+        throw CodingToolError.runtime("agent: subagent stopped for tool use without a final answer")
+    }
+    if final.stopReason == .length {
+        throw CodingToolError.runtime("agent: subagent hit the model length limit before producing final text")
+    }
+    let text = final.content.compactMap { block -> String? in
+        if case .text(let text) = block { return text.text }
+        return nil
+    }.joined()
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        throw CodingToolError.runtime(
+            "agent: subagent produced no final text (stop_reason=\(final.stopReason.rawValue))"
+        )
+    }
+    return SubagentResult(
+        text: trimmed,
+        model: model,
+        stopReason: final.stopReason,
+        usage: summary?.usage ?? aggregateAssistantUsage(messages: messages),
+        turns: summary?.turns ?? 0,
+        cost: summary?.cost ?? Cost(),
+        durationMs: summary?.durationMs ?? 0
+    )
+}
+
+private func writeSubagentOutput(
+    _ text: String,
+    to url: URL
+) throws -> Int {
+    let data = Data(text.utf8)
+    try data.write(to: url, options: [])
+    return data.count
+}
+
+private func subagentErrorMessage(_ error: Error) -> String {
+    if error is CancellationError || (error as? CodingToolError) == .aborted {
+        return "aborted by user"
+    }
+    return (error as? LocalizedError)?.errorDescription ?? "\(error)"
+}
+
+private func subagentFailureDetails(
+    definition: SubagentDefinition,
+    input: AgentToolInput,
+    childSessionId: String,
+    message: String
+) -> JSONValue {
+    .object([
+        "status": .string("failed"),
+        "failure_kind": .string(subagentFailureKind(message)),
+        "subagent_type": .string(definition.name),
+        "description": .string(input.description),
+        "child_session_id": .string(childSessionId),
+        "error_message": .string(message),
+    ])
+}
+
+private func subagentFailureKind(_ message: String) -> String {
+    let lower = message.lowercased()
+    if lower.contains("maxturns") || lower.contains("maximum turn limit") {
+        return "max_turns"
+    }
+    if lower.contains("timed out") {
+        return "timeout"
+    }
+    if lower.contains("aborted") {
+        return "aborted"
+    }
+    if lower.contains("no final text") || lower.contains("without a final answer") {
+        return "no_final_text"
+    }
+    return "runtime"
+}
+
+private func shortSubagentSummary(_ text: String, limit: Int = 240) -> String {
+    let oneLine = text
+        .split(whereSeparator: \.isNewline)
+        .map(String.init)
+        .first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        ?? text
+    let trimmed = oneLine.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.count <= limit ? trimmed : String(trimmed.prefix(limit)) + "..."
+}

--- a/Sources/KWWKCli/BuiltinSubagents.swift
+++ b/Sources/KWWKCli/BuiltinSubagents.swift
@@ -1,0 +1,9 @@
+import Foundation
+import KWWKAgent
+
+func defaultCLISubagents(
+    for tools: CodingTools,
+    selection: BuiltinSubagentSelection = .all
+) -> [SubagentDefinition] {
+    SubagentDefinition.builtins(for: tools, selection: selection)
+}

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -12,6 +12,7 @@ func runCodingTUIInternal(
     modelLabel: String,
     cwd: String,
     tools: CodingTools,
+    builtinSubagents: BuiltinSubagentSelection = .all,
     apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
     autoCompactThreshold: Double? = 0.75,
     thinkingLevel: ThinkingLevel = .medium
@@ -24,13 +25,10 @@ func runCodingTUIInternal(
         cwd: cwd,
         tools: tools,
         backgroundManager: bgManager,
-        sessionId: sessionId
+        subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
+        sessionId: sessionId,
+        apiKeyResolver: apiKeyResolver
     ))
-    // Wire the OAuth resolver (Codex) so access tokens refresh on every
-    // stream request. Nil for static api-key providers like Anthropic.
-    if let apiKeyResolver {
-        agent.apiKeyResolver = apiKeyResolver
-    }
     // Turn on extended thinking by default — otherwise reasoning-capable
     // providers never produce `[thinking]` blocks. The level is a user
     // intent: the agent loop filters it to `nil` when the live model
@@ -539,14 +537,23 @@ func runCodingTUIInternal(
     }
     defer { pollTask.cancel() }
 
-    try await runner.run()
+    let shutdown: @MainActor @Sendable () async -> Void = {
+        // Kill any still-running background tasks, close provider-held
+        // session resources, and tear down the isolated tmux socket so we
+        // don't leak processes after the user exits.
+        pollTask.cancel()
+        await agent.abortAndKillBackgroundTasks()
+        await agent.closeSession()
+        await TmuxSessionManager.shared.teardown()
+    }
 
-    // Shutdown cleanup: kill any still-running background tasks and
-    // tear down the isolated tmux socket so we don't leak processes
-    // after the user exits.
-    pollTask.cancel()
-    await agent.abortAndKillBackgroundTasks()
-    await TmuxSessionManager.shared.teardown()
+    do {
+        try await runner.run()
+    } catch {
+        await shutdown()
+        throw error
+    }
+    await shutdown()
 }
 
 // MARK: - Helpers

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -27,6 +27,7 @@ func runHeadlessInternal(
     prompt text: String,
     cwd: String,
     tools: CodingTools,
+    builtinSubagents: BuiltinSubagentSelection = .all,
     thinkingLevel: ThinkingLevel = .medium,
     autoCompactThreshold: Double? = 0.75,
     modelOverride: String? = nil,
@@ -41,11 +42,10 @@ func runHeadlessInternal(
         cwd: cwd,
         tools: tools,
         backgroundManager: bgManager,
-        sessionId: sessionId
+        subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
+        sessionId: sessionId,
+        apiKeyResolver: resolved.apiKeyResolver
     ))
-    if let apiKeyResolver = resolved.apiKeyResolver {
-        agent.apiKeyResolver = apiKeyResolver
-    }
     agent.state.thinkingLevel = thinkingLevel
 
     // Auto-compact: watch per-turn usage and summarize the transcript
@@ -120,12 +120,14 @@ func runHeadlessInternal(
     do {
         try await agent.prompt(text)
     } catch {
+        await agent.closeSession()
         let msg = (error as? LocalizedError)?.errorDescription ?? "\(error)"
         writeStderr("kwwk: \(msg)\n")
         return 1
     }
 
     let stop = box.lock.withLock { box.finalStopReason }
+    await agent.closeSession()
     return stop == .stop ? 0 : 1
 }
 

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -26,6 +26,7 @@ public enum KWWK {
     public static func runCodingTUI(
         cwd: String? = nil,
         tools: CodingTools = .all,
+        builtinSubagents: BuiltinSubagentSelection = .all,
         autoCompactThreshold: Double? = 0.75,
         thinkingLevel: ThinkingLevel = .medium,
         modelOverride: String? = nil,
@@ -38,6 +39,7 @@ public enum KWWK {
             modelLabel: resolved.modelLabel,
             cwd: workDir,
             tools: tools,
+            builtinSubagents: builtinSubagents,
             apiKeyResolver: resolved.apiKeyResolver,
             autoCompactThreshold: autoCompactThreshold,
             thinkingLevel: thinkingLevel
@@ -74,6 +76,7 @@ public enum KWWK {
         prompt: String,
         cwd: String? = nil,
         tools: CodingTools = .all,
+        builtinSubagents: BuiltinSubagentSelection = .all,
         thinkingLevel: ThinkingLevel = .medium,
         modelOverride: String? = nil,
         context1m: Bool = false
@@ -83,10 +86,10 @@ public enum KWWK {
             prompt: prompt,
             cwd: workDir,
             tools: tools,
+            builtinSubagents: builtinSubagents,
             thinkingLevel: thinkingLevel,
             modelOverride: modelOverride,
             context1m: context1m
         )
     }
 }
-

--- a/Sources/KWWKCli/TranscriptRenderer.swift
+++ b/Sources/KWWKCli/TranscriptRenderer.swift
@@ -66,6 +66,7 @@ final class TranscriptRenderer {
         let id: String
         let name: String
         let args: JSONValue
+        var partial: AgentToolResult?
         var resolution: [String]?   // nil = running
     }
 
@@ -140,6 +141,8 @@ final class TranscriptRenderer {
             n += 1  // header
             if let resolved = slot.resolution {
                 n += max(0, resolved.count - 2)  // body (skip leading blank + header)
+            } else if let partial = slot.partial {
+                n += formatToolResult(partial, isError: false).count
             } else {
                 n += 1  // "running…"
             }
@@ -229,7 +232,12 @@ final class TranscriptRenderer {
             }
 
         case .toolExecutionStart(let id, let name, let args):
-            toolSlots.append(ToolSlot(id: id, name: name, args: args, resolution: nil))
+            toolSlots.append(ToolSlot(id: id, name: name, args: args, partial: nil, resolution: nil))
+            recomputeLive()
+
+        case .toolExecutionUpdate(let id, _, _, let partialResult):
+            guard let idx = toolSlots.firstIndex(where: { $0.id == id }) else { break }
+            toolSlots[idx].partial = partialResult
             recomputeLive()
 
         case .toolExecutionEnd(let id, _, let result, let isError):
@@ -340,6 +348,8 @@ final class TranscriptRenderer {
                 // two from the resolved payload and keep only the body.
                 let body = resolved.dropFirst(2)
                 out.append(contentsOf: body)
+            } else if let partial = slot.partial {
+                out.append(contentsOf: formatToolResult(partial, isError: false))
             } else {
                 out.append(Style.dimmed("  ⎿  running…"))
             }

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -25,6 +25,9 @@ import KWWKCli
 ///                        header and bumps `contextWindow` to 1_000_000.
 ///                        Requires the account to have long-context billing
 ///                        enabled. Ignored for non-Anthropic providers.
+///   `--subagents <list>` — comma-separated built-in subagents to enable:
+///                        general, Explore, Plan, all, none.
+///   `--no-subagents`    — disable built-in CLI subagents.
 @main
 struct KwwkCLI {
     static func main() async {
@@ -35,12 +38,15 @@ struct KwwkCLI {
         (args, modelOverride) = extractStringFlag(args, "--model")
         let context1m: Bool
         (args, context1m) = extractBoolFlag(args, "--context-1m")
+        let builtinSubagents: BuiltinSubagentSelection
+        (args, builtinSubagents) = extractBuiltinSubagents(args)
 
         let subcommand = args.first
 
         switch subcommand {
         case nil:
             await runOrExit { try await KWWK.runCodingTUI(
+                builtinSubagents: builtinSubagents,
                 thinkingLevel: thinkingLevel,
                 modelOverride: modelOverride,
                 context1m: context1m
@@ -52,7 +58,8 @@ struct KwwkCLI {
                 rest: Array(args.dropFirst()),
                 thinkingLevel: thinkingLevel,
                 modelOverride: modelOverride,
-                context1m: context1m
+                context1m: context1m,
+                builtinSubagents: builtinSubagents
             )
         case "-h", "--help":
             printUsage()
@@ -81,6 +88,9 @@ struct KwwkCLI {
                                       (e.g. --model claude-opus-4-5)
           --context-1m                opt into Anthropic 1M-context beta
                                       (long-context billing must be on)
+          --subagents <list>          built-in subagents to enable:
+                                      general,Explore,Plan,all, or none
+          --no-subagents              disable built-in CLI subagents
 
         Credentials are read from the OAuth store at ~/.kwwk/oauth.json.
         Run `kwwk login` once to register a provider (OAuth subscription
@@ -149,6 +159,41 @@ struct KwwkCLI {
         return (out, seen)
     }
 
+    /// Pull built-in subagent selection flags out of argv. `--subagents`
+    /// accepts a comma-separated list; `--no-subagents` is equivalent to
+    /// `--subagents none`. If both are present, the later flag wins.
+    static func extractBuiltinSubagents(_ argv: [String]) -> ([String], BuiltinSubagentSelection) {
+        var out: [String] = []
+        var selection: BuiltinSubagentSelection = .all
+        var i = 0
+        while i < argv.count {
+            switch argv[i] {
+            case "--no-subagents":
+                selection = .none
+                i += 1
+            case "--subagents":
+                guard i + 1 < argv.count else {
+                    FileHandle.standardError.write(Data(
+                        "kwwk: --subagents needs one of: \(BuiltinSubagentSelection.validNames)\n".utf8
+                    ))
+                    Foundation.exit(2)
+                }
+                guard let parsed = BuiltinSubagentSelection.parseList(argv[i + 1]) else {
+                    FileHandle.standardError.write(Data(
+                        "kwwk: --subagents needs one of: \(BuiltinSubagentSelection.validNames)\n".utf8
+                    ))
+                    Foundation.exit(2)
+                }
+                selection = parsed
+                i += 2
+            default:
+                out.append(argv[i])
+                i += 1
+            }
+        }
+        return (out, selection)
+    }
+
     /// Handle `-p` / `--print`. Everything after the flag is joined into
     /// the prompt; if nothing is supplied (or the token is a bare `-`),
     /// the prompt is read from stdin until EOF.
@@ -162,7 +207,8 @@ struct KwwkCLI {
         rest: [String],
         thinkingLevel: ThinkingLevel,
         modelOverride: String?,
-        context1m: Bool
+        context1m: Bool,
+        builtinSubagents: BuiltinSubagentSelection
     ) async {
         let prompt: String
         if rest.isEmpty || rest == ["-"] {
@@ -191,6 +237,7 @@ struct KwwkCLI {
         do {
             let code = try await KWWK.runHeadless(
                 prompt: prompt,
+                builtinSubagents: builtinSubagents,
                 thinkingLevel: thinkingLevel,
                 modelOverride: modelOverride,
                 context1m: context1m

--- a/Tests/KWWKAITests/FauxProviderTests.swift
+++ b/Tests/KWWKAITests/FauxProviderTests.swift
@@ -16,6 +16,21 @@ struct FauxProviderTests {
 
     // MARK: - registration & simple completion
 
+    @Test("cancellation listener registration can be removed")
+    func cancellationRegistrationCanBeRemoved() {
+        let cancellation = CancellationHandle()
+        final class Box: @unchecked Sendable {
+            var count = 0
+        }
+        let box = Box()
+        let registration = cancellation.onCancel { _ in box.count += 1 }
+        registration.cancel()
+
+        cancellation.cancel(reason: "test")
+
+        #expect(box.count == 0)
+    }
+
     @Test("registers a custom provider and estimates usage")
     func registersAndEstimatesUsage() async throws {
         let registration = await registerFauxProvider()
@@ -613,5 +628,40 @@ struct APIRegistryTests {
                 context: Context(messages: [.user(UserMessage(text: "hi"))])
             )
         }
+    }
+
+    @Test("closeProviderSession notifies lifecycle-aware providers")
+    func closeProviderSessionNotifiesLifecycleProvider() async {
+        let provider = LifecycleTrackingProvider(api: "lifecycle-\(UUID().uuidString)")
+        let sourceId = "lifecycle-test-\(UUID().uuidString)"
+        await APIRegistry.shared.register(provider, sourceId: sourceId)
+
+        let sessionId = "session-\(UUID().uuidString)"
+        await closeProviderSession(sessionId: sessionId)
+
+        #expect(provider.closedSessions.contains(sessionId))
+        await APIRegistry.shared.unregisterSource(sourceId)
+    }
+}
+
+private final class LifecycleTrackingProvider: APIProvider, APIProviderSessionLifecycle, @unchecked Sendable {
+    let api: String
+    private let lock = NSLock()
+    private var sessions: [String] = []
+
+    init(api: String) {
+        self.api = api
+    }
+
+    var closedSessions: [String] {
+        lock.withLock { sessions }
+    }
+
+    func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream {
+        AssistantMessageStream()
+    }
+
+    func closeSession(sessionId: String) async {
+        lock.withLock { sessions.append(sessionId) }
     }
 }

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -266,6 +266,26 @@ struct OpenAIResponsesTests {
         #expect(messages.contains("WebSocket response completed; failure count reset"))
     }
 
+    @Test("closeSession closes stored WebSocket connection")
+    func closeSessionClosesStoredWebSocketConnection() async throws {
+        let http = StubSSEClient(body: Self.textSSE)
+        let connection = StubWebSocketConnection(batches: [Self.webSocketMessages(from: Self.textSSE)])
+        let ws = StubWebSocketClient(connection: connection)
+        let provider = OpenAIResponsesProvider(client: http, webSocketClient: ws, defaultAPIKey: "k")
+
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(sessionId: "ws-close-session")
+        )
+        for await _ in s {}
+        _ = await s.result()
+
+        #expect(connection.closed == false)
+        await provider.closeSession(sessionId: "ws-close-session")
+        #expect(connection.closed == true)
+    }
+
     @Test("reuses previous response id and sends only new input over WebSocket")
     func webSocketIncrementalInput() async throws {
         let first = Self.textSSE

--- a/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
+++ b/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
@@ -131,6 +131,24 @@ struct BackgroundTaskManagerTests {
         #expect(notif.messageText().contains("<task-notification>"))
     }
 
+    @Test("closeSession kills running tasks and drains notifications for that session")
+    func closeSessionKillsAndDrains() async {
+        let outputDir = makeOutputDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let (closedTaskId, _) = await manager.spawn(runner: ForeverRunner(), sessionId: "child")
+        let (otherTaskId, _) = await manager.spawn(runner: ForeverRunner(), sessionId: "parent")
+        defer { Task { await manager.killAll(sessionId: nil) } }
+
+        await manager.closeSession(sessionId: "child")
+
+        let closedTask = await manager.get(closedTaskId)
+        let otherTask = await manager.get(otherTaskId)
+        #expect(closedTask?.status == .killed)
+        #expect(otherTask?.status == .running)
+        #expect(await manager.hasNotifications(sessionId: "child") == false)
+    }
+
     @Test("kill cancels a running task and emits a killed notification")
     func killFlowsThrough() async {
         let outputDir = makeOutputDir()

--- a/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
+++ b/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+
+@Suite("Built-in subagent definitions")
+struct BuiltinSubagentDefinitionTests {
+    @Test("factory definitions sanitize tool sets")
+    func factoryToolSetsAreSafe() {
+        let general = SubagentDefinition.general()
+        #expect(general.name == "general")
+        #expect(general.tools == nil)
+        #expect(general.prompt.contains("general-purpose coding agent"))
+
+        let explore = SubagentDefinition.explore(tools: .all)
+        #expect(explore.name == "Explore")
+        #expect(explore.tools == .readOnly)
+        #expect(explore.prompt.contains("read-only code exploration"))
+        #expect(explore.prompt.contains("Do not edit"))
+
+        let plan = SubagentDefinition.plan(tools: .all)
+        #expect(plan.name == "Plan")
+        #expect(plan.tools == .readOnly)
+        #expect(plan.prompt.contains("read-only implementation planner"))
+    }
+
+    @Test("builtins respect selection and available tools")
+    func builtinsRespectSelection() {
+        let readOnly = SubagentDefinition.builtins(
+            for: .readOnly,
+            selection: [.general, .explore]
+        )
+        #expect(readOnly.map(\.name) == ["general", "Explore"])
+
+        let selected = SubagentDefinition.builtins(
+            for: .all,
+            selection: [.plan]
+        )
+        #expect(selected.map(\.name) == ["Plan"])
+    }
+
+    @Test("builtin selection parses CLI names")
+    func selectionParsing() {
+        #expect(BuiltinSubagentSelection.parseList("general,Explore") == [.general, .explore])
+        #expect(BuiltinSubagentSelection.parseList("none") == BuiltinSubagentSelection.none)
+        #expect(BuiltinSubagentSelection.parseList("all") == .all)
+        #expect(BuiltinSubagentSelection.parseList("bad") == nil)
+    }
+
+    @Test("CodingAgentConfig helper installs builtins")
+    func configHelper() {
+        let base = CodingAgentConfig(
+            model: .init(id: "m", name: "m", api: "a", provider: "p"),
+            cwd: "/tmp",
+            tools: .all
+        )
+
+        let configured = base.withBuiltinSubagents(.general.union(.plan))
+        #expect(configured.subagents.map { $0.name } == ["general", "Plan"])
+        #expect(base.subagents.isEmpty)
+    }
+}

--- a/Tests/KWWKAgentTests/SubagentToolTests.swift
+++ b/Tests/KWWKAgentTests/SubagentToolTests.swift
@@ -1,0 +1,816 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+@Suite("Subagent tool")
+struct SubagentToolTests {
+    @Test("coding agent only exposes agent tool when subagents are configured")
+    func agentToolIsConditional() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let cwd = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: cwd) }
+
+        let withoutSubagents = await makeCodingAgent(CodingAgentConfig(
+            model: faux.getModel(),
+            cwd: cwd.path,
+            tools: .readOnly
+        ))
+        #expect(!withoutSubagents.state.tools.contains { $0.name == "agent" })
+
+        let withSubagents = await makeCodingAgent(CodingAgentConfig(
+            model: faux.getModel(),
+            cwd: cwd.path,
+            tools: .readOnly,
+            subagents: [minimalSubagent()]
+        ))
+        #expect(withSubagents.state.tools.contains { $0.name == "agent" })
+    }
+
+    @Test("unknown subagent type returns a clear error")
+    func unknownSubagentType() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+
+        await #expect(throws: Error.self) {
+            _ = try await tool.execute(
+                "call-1",
+                .object([
+                    "description": .string("unknown child"),
+                    "prompt": .string("do work"),
+                    "subagent_type": .string("missing"),
+                ]),
+                nil,
+                nil
+            )
+        }
+    }
+
+    @Test("omitted subagent type falls back to general")
+    func omittedSubagentTypeFallsBackToGeneral() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("general answer"))])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [
+                SubagentDefinition(
+                    name: "general",
+                    description: "Use for general work.",
+                    prompt: "Return the requested answer."
+                ),
+                minimalSubagent(),
+            ],
+            parentModel: faux.getModel()
+        )
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("fallback child"),
+                "prompt": .string("answer from fallback"),
+            ]),
+            nil,
+            nil
+        )
+
+        #expect(resultText(result).contains("general answer"))
+        #expect(detailString(result, "subagent_type") == "general")
+    }
+
+    @Test("definition without tools uses wildcard coding tools")
+    func omittedToolsUsesWildcard() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let capture = SubagentContextCapture()
+        faux.setResponses([
+            .factory { context, _, _, _ in
+                await capture.record(
+                    messageCount: context.messages.count,
+                    toolNames: context.tools?.map(\.name) ?? []
+                )
+                return fauxAssistantMessage("captured wildcard")
+            },
+        ])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent(tools: nil)],
+            parentModel: faux.getModel()
+        )
+
+        _ = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("wildcard tools"),
+                "prompt": .string("inspect tools"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+
+        let snapshot = await capture.snapshot()
+        #expect(snapshot.toolNames.contains("write"))
+        #expect(snapshot.toolNames.contains("edit"))
+        #expect(snapshot.toolNames.contains("bash"))
+        #expect(!snapshot.toolNames.contains("agent"))
+    }
+
+    @Test("foreground subagent returns final assistant text")
+    func foregroundReturnsText() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("subagent answer"))])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("answer task"),
+                "prompt": .string("answer from child"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+
+        #expect(resultText(result).contains("subagent answer"))
+        guard case .object(let details) = result.details ?? .null else {
+            Issue.record("expected details object")
+            return
+        }
+        if case .string(let status) = details["status"] ?? .null {
+            #expect(status == "completed")
+        } else {
+            Issue.record("expected status detail")
+        }
+        if case .string(let model) = details["model"] ?? .null {
+            #expect(model == faux.getModel().id)
+        } else {
+            Issue.record("expected inherited model detail")
+        }
+    }
+
+    @Test("SDK SubagentRunner can run a subagent directly")
+    func sdkRunnerForeground() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("direct subagent answer"))])
+        let runner = SubagentRunner(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+
+        let result = try await runner.run(type: "mini", prompt: "answer directly")
+
+        #expect(result.text.contains("direct subagent answer"))
+        #expect(result.model.id == faux.getModel().id)
+        #expect(result.stopReason == .stop)
+    }
+
+    @Test("SDK SubagentRunner can start a background subagent")
+    func sdkRunnerBackground() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("direct background answer"))])
+        let manager = BackgroundTaskManager()
+        let runner = SubagentRunner(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel(),
+            backgroundManager: manager,
+            sessionId: "sdk-parent"
+        )
+
+        let started = try await runner.startBackground(
+            type: "mini",
+            prompt: "answer in background",
+            description: "sdk background"
+        )
+
+        #expect(started.subagentType == "mini")
+        let waitTool = createWaitTaskTool(manager: manager, sessionId: "sdk-parent")
+        let waitResult = try await waitTool.execute(
+            "wait",
+            .object(["task_id": .string(started.taskId), "timeout_ms": .int(1000)]),
+            nil,
+            nil
+        )
+        #expect(resultText(waitResult).contains("direct background answer"))
+        #expect(FileManager.default.fileExists(atPath: started.outputFile.path))
+    }
+
+    @Test("foreground subagent emits token progress updates")
+    func foregroundEmitsTokenProgress() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            tokenSize: FauxTokenSize(min: 1, max: 1)
+        ))
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("subagent token answer"))])
+        let updates = ToolUpdateCapture()
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("token task"),
+                "prompt": .string("answer with token accounting"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            { update in
+                updates.record(update)
+            }
+        )
+
+        let displays = updates.uiDisplays()
+        #expect(displays.contains { $0.contains("tokens") })
+        #expect(detailObject(result, "usage") != nil)
+        #expect(detailString(result, "child_session_id") != nil)
+    }
+
+    @Test("agent loop forwards subagent lifecycle events and aggregates summary")
+    func lifecycleEventsAndRunSummary() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            tokenSize: FauxTokenSize(min: 1, max: 1)
+        ))
+        defer { faux.unregister() }
+        faux.setResponses([
+            .message(fauxAssistantMessage(
+                blocks: [
+                    fauxToolCall(
+                        name: "agent",
+                        arguments: .object([
+                            "description": .string("delegate child"),
+                            "prompt": .string("answer from child"),
+                            "subagent_type": .string("mini"),
+                        ]),
+                        id: "agent-1"
+                    ),
+                ],
+                stopReason: .toolUse
+            )),
+            .message(fauxAssistantMessage("child lifecycle answer")),
+            .message(fauxAssistantMessage("parent done")),
+        ])
+
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+        let agent = Agent(initialState: AgentInitialState(
+            model: faux.getModel(),
+            tools: [tool]
+        ))
+        let capture = SubagentRuntimeCapture()
+        _ = agent.subscribe { event, _ in
+            switch event {
+            case .runtimeEvent(.subagent(let subagent)):
+                await capture.append(kind: subagent.kind)
+            case .agentEnd(_, let summary):
+                await capture.set(summary: summary)
+            default:
+                break
+            }
+        }
+
+        try await agent.prompt("delegate")
+
+        let kinds = await capture.kinds()
+        #expect(kinds.contains(.started))
+        #expect(kinds.contains(.toolUpdate))
+        #expect(kinds.contains(.completed))
+
+        guard let summary = await capture.summary() else {
+            Issue.record("expected agent summary")
+            return
+        }
+        #expect(summary.subagents.count == 1)
+        #expect(summary.subagents.first?.subagentType == "mini")
+        #expect(summary.subagents.first?.status == .completed)
+        #expect((summary.subagents.first?.usage?.totalTokens ?? 0) > 0)
+        #expect((summary.subagents.first?.turns ?? 0) > 0)
+        #expect((summary.subagents.first?.durationMs ?? 0) >= 0)
+    }
+
+    @Test("failed subagent results keep structured failure details")
+    func failedSubagentDetails() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([
+            .message(fauxAssistantMessage(
+                blocks: [
+                    fauxToolCall(
+                        name: "agent",
+                        arguments: .object([
+                            "description": .string("failing child"),
+                            "prompt": .string("fail from child"),
+                            "subagent_type": .string("mini"),
+                        ]),
+                        id: "agent-1"
+                    ),
+                ],
+                stopReason: .toolUse
+            )),
+            .message(fauxAssistantMessage(
+                "boom",
+                stopReason: .error,
+                errorMessage: "child blew up"
+            )),
+            .message(fauxAssistantMessage("parent observed failure")),
+        ])
+
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+        let agent = Agent(initialState: AgentInitialState(
+            model: faux.getModel(),
+            tools: [tool]
+        ))
+        let capture = SubagentRuntimeCapture()
+        _ = agent.subscribe { event, _ in
+            switch event {
+            case .runtimeEvent(.subagent(let subagent)):
+                await capture.append(kind: subagent.kind)
+            case .agentEnd(_, let summary):
+                await capture.set(summary: summary)
+            default:
+                break
+            }
+        }
+
+        try await agent.prompt("delegate")
+
+        let toolResult = agent.state.messages.compactMap { message -> ToolResultMessage? in
+            if case .toolResult(let result) = message, result.toolName == "agent" {
+                return result
+            }
+            return nil
+        }.first
+        guard let toolResult, case .object(let details) = toolResult.details ?? .null else {
+            Issue.record("expected structured tool result details")
+            return
+        }
+        #expect(toolResult.isError)
+        #expect(details["status"] == .string("failed"))
+        #expect(details["subagent_type"] == .string("mini"))
+        #expect(details["error_message"] == .string("agent: child blew up"))
+
+        let kinds = await capture.kinds()
+        #expect(kinds.contains(.failed))
+        let summary = await capture.summary()
+        #expect(summary?.subagents.first?.status == .failed)
+        #expect(summary?.subagents.first?.errorMessage == "agent: child blew up")
+    }
+
+    @Test("fresh subagent does not inherit parent transcript or recursive agent tool")
+    func freshContextAndNoRecursiveAgentTool() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let capture = SubagentContextCapture()
+        faux.setResponses([
+            .factory { context, _, _, _ in
+                await capture.record(
+                    messageCount: context.messages.count,
+                    toolNames: context.tools?.map(\.name) ?? []
+                )
+                return fauxAssistantMessage("captured")
+            },
+        ])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent(tools: .all)],
+            parentModel: faux.getModel()
+        )
+
+        _ = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("inspect child"),
+                "prompt": .string("child prompt only"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+
+        let snapshot = await capture.snapshot()
+        #expect(snapshot.messageCount == 1)
+        #expect(!snapshot.toolNames.contains("agent"))
+    }
+
+    @Test("definition model override and tool-call model override precedence")
+    func modelOverridePrecedence() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            models: [
+                FauxModelDefinition(id: "parent-model"),
+                FauxModelDefinition(id: "definition-model"),
+            ]
+        ))
+        defer { faux.unregister() }
+        let parent = faux.getModel(id: "parent-model")!
+        let definitionModel = faux.getModel(id: "definition-model")!
+        faux.setResponses([
+            .message(fauxAssistantMessage("definition model result")),
+            .message(fauxAssistantMessage("tool model result")),
+        ])
+        let definition = minimalSubagent(model: .override(definitionModel))
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [definition],
+            parentModel: parent
+        )
+
+        let definitionResult = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("definition model"),
+                "prompt": .string("use definition model"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+        #expect(detailString(definitionResult, "model") == "definition-model")
+
+        let toolOverrideResult = try await tool.execute(
+            "call-2",
+            .object([
+                "description": .string("tool model"),
+                "prompt": .string("use tool model"),
+                "subagent_type": .string("mini"),
+                "model": .string("tool-model"),
+            ]),
+            nil,
+            nil
+        )
+        #expect(detailString(toolOverrideResult, "model") == "tool-model")
+    }
+
+    @Test("public agent tool overload reads live parent agent state")
+    func publicOverloadReadsLiveParentState() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            models: [
+                FauxModelDefinition(id: "initial-parent"),
+                FauxModelDefinition(id: "live-parent"),
+            ]
+        ))
+        defer { faux.unregister() }
+        let parentAgent = Agent(initialState: AgentInitialState(
+            model: faux.getModel(id: "initial-parent")!
+        ))
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentAgent: parentAgent
+        )
+        parentAgent.state.model = faux.getModel(id: "live-parent")!
+        faux.setResponses([.message(fauxAssistantMessage("live model result"))])
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("live parent"),
+                "prompt": .string("use live parent model"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+
+        #expect(detailString(result, "model") == "live-parent")
+    }
+
+    @Test("background subagent writes output and can be read with wait_task")
+    func backgroundSubagent() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("background subagent answer"))])
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel(),
+            backgroundManager: manager,
+            sessionId: "s1"
+        )
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("background child"),
+                "prompt": .string("run in background"),
+                "subagent_type": .string("mini"),
+                "run_in_background": .bool(true),
+            ]),
+            nil,
+            nil
+        )
+        guard let taskId = detailString(result, "task_id") else {
+            Issue.record("expected task_id detail")
+            return
+        }
+
+        let done = await awaitUntil(3000) {
+            let snap = await manager.get(taskId)
+            return snap?.status != .running
+        }
+        #expect(done)
+        let snap = await manager.get(taskId)
+        #expect(snap?.status == .completed)
+        let contents = snap?.outputFile.flatMap { try? String(contentsOfFile: $0, encoding: .utf8) } ?? ""
+        #expect(contents.contains("background subagent answer"))
+
+        let waitTool = createWaitTaskTool(manager: manager, sessionId: "s1")
+        let waitResult = try await waitTool.execute(
+            "wait-1",
+            .object(["task_id": .string(taskId), "timeout_seconds": .int(1)]),
+            nil,
+            nil
+        )
+        #expect(resultText(waitResult).contains("background subagent answer"))
+    }
+
+    @Test("subagent internal background tasks use child session and are killed on completion")
+    func internalBackgroundTasksAreChildScopedAndClosed() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([
+            .message(fauxAssistantMessage(
+                blocks: [
+                    fauxToolCall(
+                        name: "bash",
+                        arguments: .object([
+                            "command": .string("exec sleep 30"),
+                            "description": .string("Sleep inside child"),
+                            "run_in_background": .bool(true),
+                        ]),
+                        id: "bash-child-1"
+                    ),
+                ],
+                stopReason: .toolUse
+            )),
+            .message(fauxAssistantMessage("child finished after starting background work")),
+        ])
+
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent(tools: [.bash])],
+            parentModel: faux.getModel(),
+            backgroundManager: manager,
+            sessionId: "parent-session"
+        )
+
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "description": .string("child bash task"),
+                "prompt": .string("start the background command and finish"),
+                "subagent_type": .string("mini"),
+            ]),
+            nil,
+            nil
+        )
+
+        guard let childSessionId = detailString(result, "child_session_id") else {
+            Issue.record("expected child_session_id detail")
+            return
+        }
+
+        let parentTasks = await manager.list(sessionId: "parent-session")
+        #expect(parentTasks.isEmpty)
+
+        let childTasks = await manager.list(sessionId: childSessionId)
+        #expect(childTasks.count == 1)
+        #expect(childTasks.first?.sessionId == childSessionId)
+        #expect(childTasks.first?.status == .killed)
+        #expect(await manager.hasNotifications(sessionId: childSessionId) == false)
+    }
+
+    @Test("foreground cancellation aborts the child subagent")
+    func foregroundCancellationAbortsChild() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            tokensPerSecond: 1,
+            tokenSize: FauxTokenSize(min: 1, max: 1)
+        ))
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage(String(repeating: "x", count: 200)))])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel()
+        )
+        let cancellation = CancellationHandle()
+
+        let task = Task {
+            try await tool.execute(
+                "call-1",
+                .object([
+                    "description": .string("cancel child"),
+                    "prompt": .string("produce a slow answer"),
+                    "subagent_type": .string("mini"),
+                ]),
+                cancellation,
+                nil
+            )
+        }
+
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        cancellation.cancel(reason: "test")
+
+        await #expect(throws: Error.self) {
+            _ = try await task.value
+        }
+    }
+
+    @Test("foreground cancellation closes the child provider session")
+    func foregroundCancellationClosesChildProviderSession() async throws {
+        let api = "subagent-cancel-\(UUID().uuidString)"
+        let sourceId = "subagent-cancel-source-\(UUID().uuidString)"
+        let provider = CancellationLifecycleProvider(api: api)
+        await APIRegistry.shared.register(provider, sourceId: sourceId)
+        defer { Task { await APIRegistry.shared.unregisterSource(sourceId) } }
+
+        let parentSessionId = "parent-\(UUID().uuidString)"
+        let model = Model(
+            id: "cancel-model",
+            api: api,
+            provider: "test-provider"
+        )
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: model,
+            sessionId: parentSessionId
+        )
+        let cancellation = CancellationHandle()
+
+        let task = Task {
+            try await tool.execute(
+                "call-1",
+                .object([
+                    "description": .string("cancel child"),
+                    "prompt": .string("wait until cancelled"),
+                    "subagent_type": .string("mini"),
+                ]),
+                cancellation,
+                nil
+            )
+        }
+
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        cancellation.cancel(reason: "test")
+
+        await #expect(throws: Error.self) {
+            _ = try await task.value
+        }
+
+        let prefix = "\(parentSessionId):subagent:mini:"
+        #expect(provider.closedSessions.contains { $0.hasPrefix(prefix) })
+    }
+}
+
+private func minimalSubagent(
+    tools: CodingTools? = nil,
+    model: SubagentModel = .inherit
+) -> SubagentDefinition {
+    SubagentDefinition(
+        name: "mini",
+        description: "Use for test subagent work.",
+        prompt: "Return the requested test answer. Do not edit files.",
+        tools: tools,
+        model: model
+    )
+}
+
+private func resultText(_ result: AgentToolResult) -> String {
+    result.content.compactMap { block in
+        if case .text(let text) = block { return text.text }
+        return nil
+    }.joined()
+}
+
+private func detailString(_ result: AgentToolResult, _ key: String) -> String? {
+    guard case .object(let details) = result.details ?? .null,
+          case .string(let value) = details[key] ?? .null else {
+        return nil
+    }
+    return value
+}
+
+private func detailObject(_ result: AgentToolResult, _ key: String) -> [String: JSONValue]? {
+    guard case .object(let details) = result.details ?? .null,
+          case .object(let value) = details[key] ?? .null else {
+        return nil
+    }
+    return value
+}
+
+private actor SubagentContextCapture {
+    private var messageCount: Int = -1
+    private var toolNames: [String] = []
+
+    func record(messageCount: Int, toolNames: [String]) {
+        self.messageCount = messageCount
+        self.toolNames = toolNames
+    }
+
+    func snapshot() -> (messageCount: Int, toolNames: [String]) {
+        (messageCount, toolNames)
+    }
+}
+
+private final class ToolUpdateCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var updates: [AgentToolResult] = []
+
+    func record(_ update: AgentToolResult) {
+        lock.withLock { updates.append(update) }
+    }
+
+    func uiDisplays() -> [String] {
+        lock.withLock { updates.flatMap { $0.uiDisplay ?? [] } }
+    }
+}
+
+private final class CancellationLifecycleProvider: APIProvider, APIProviderSessionLifecycle, @unchecked Sendable {
+    let api: String
+    private let lock = NSLock()
+    private var sessions: [String] = []
+
+    init(api: String) {
+        self.api = api
+    }
+
+    var closedSessions: [String] {
+        lock.withLock { sessions }
+    }
+
+    func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream {
+        let stream = AssistantMessageStream()
+        Task.detached { [api] in
+            while options?.cancellation?.isCancelled != true {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+            let aborted = AssistantMessage(
+                content: [],
+                api: api,
+                provider: model.provider,
+                model: model.id,
+                stopReason: .aborted,
+                errorMessage: "Request was aborted"
+            )
+            stream.push(.error(reason: .aborted, error: aborted))
+            stream.end(aborted)
+        }
+        return stream
+    }
+
+    func closeSession(sessionId: String) async {
+        lock.withLock { sessions.append(sessionId) }
+    }
+}
+
+private actor SubagentRuntimeCapture {
+    private var observedKinds: [SubagentLifecycleKind] = []
+    private var observedSummary: AgentRunSummary?
+
+    func append(kind: SubagentLifecycleKind) {
+        observedKinds.append(kind)
+    }
+
+    func set(summary: AgentRunSummary) {
+        observedSummary = summary
+    }
+
+    func kinds() -> [SubagentLifecycleKind] {
+        observedKinds
+    }
+
+    func summary() -> AgentRunSummary? {
+        observedSummary
+    }
+}

--- a/Tests/KWWKCliTests/BuiltinSubagentsTests.swift
+++ b/Tests/KWWKCliTests/BuiltinSubagentsTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import KWWKAgent
+@testable import KWWKCli
+
+@Suite("CLI builtin subagents")
+struct BuiltinSubagentsTests {
+    @Test("read-only CLI tools get general fallback plus read-only specialists")
+    func readOnlyBuiltins() {
+        let agents = defaultCLISubagents(for: .readOnly)
+        let names = agents.map(\.name)
+        #expect(names == ["general", "Explore", "Plan"])
+        #expect(agents.first { $0.name == "general" }?.tools == nil)
+        #expect(agents.first { $0.name == "Explore" }?.tools == .readOnly)
+        #expect(agents.first { $0.name == "Plan" }?.tools == .readOnly)
+    }
+
+    @Test("bash-enabled CLI tools keep the same default subagent set")
+    func bashBuiltins() {
+        let agents = defaultCLISubagents(for: .all)
+        let names = agents.map(\.name)
+        #expect(names == ["general", "Explore", "Plan"])
+        #expect(agents.first { $0.name == "general" }?.tools == nil)
+    }
+
+    @Test("CLI subagent selection can disable or narrow builtins")
+    func selectedBuiltins() {
+        #expect(defaultCLISubagents(for: .all, selection: .none).isEmpty)
+
+        let agents = defaultCLISubagents(for: .all, selection: [.general, .plan])
+        #expect(agents.map(\.name) == ["general", "Plan"])
+    }
+}

--- a/Tests/KWWKCliTests/EscapeKeyFlushTests.swift
+++ b/Tests/KWWKCliTests/EscapeKeyFlushTests.swift
@@ -24,7 +24,7 @@ struct EscapeKeyFlushTests {
         #expect(fired.get() == false)
 
         // Wait past the flush timer + scheduler jitter. 250ms is generous.
-        try? await Task.sleep(nanoseconds: 250_000_000)
+        _ = await waitUntil { fired.get() == true }
         #expect(fired.get() == true, "standalone ESC was never delivered")
     }
 
@@ -53,12 +53,25 @@ struct EscapeKeyFlushTests {
         runner.bind(.init("escape")) { _ in count.bump() }
 
         runner.ingest(Data([0x1B]))
-        try? await Task.sleep(nanoseconds: 150_000_000)
+        _ = await waitUntil { count.get() == 1 }
         runner.ingest(Data([0x1B]))
-        try? await Task.sleep(nanoseconds: 150_000_000)
+        _ = await waitUntil { count.get() == 2 }
 
         #expect(count.get() == 2)
     }
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    pollNanoseconds: UInt64 = 20_000_000,
+    _ predicate: @escaping @Sendable () -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+    while ContinuousClock.now < deadline {
+        if predicate() { return true }
+        try? await Task.sleep(nanoseconds: pollNanoseconds)
+    }
+    return predicate()
 }
 
 // MARK: - Thread-safe test bookkeeping

--- a/Tests/KWWKCliTests/TranscriptCommitTests.swift
+++ b/Tests/KWWKCliTests/TranscriptCommitTests.swift
@@ -26,6 +26,13 @@ struct TranscriptCommitTests {
         AgentToolResult(content: [.text(TextContent(text: text))])
     }
 
+    private func toolDisplay(_ text: String) -> AgentToolResult {
+        AgentToolResult(
+            content: [.text(TextContent(text: text))],
+            uiDisplay: [text]
+        )
+    }
+
     @MainActor
     @Test("user message commits immediately with leading blank + prompt marker")
     func userCommitsImmediately() {
@@ -198,6 +205,33 @@ struct TranscriptCommitTests {
         #expect(commits.contains(where: { $0.contains("file1") }))
         #expect(commits.last != "")
         #expect(r.liveLines.isEmpty)
+    }
+
+    @MainActor
+    @Test("tool execution updates render partial ui display while running")
+    func toolExecutionUpdateRendersPartialDisplay() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(toolCallId: "1", toolName: "agent", args: .object([:])))
+        r.apply(.toolExecutionUpdate(
+            toolCallId: "1",
+            toolName: "agent",
+            args: .object([:]),
+            partialResult: toolDisplay("agent explore running · 128 tokens")
+        ))
+
+        #expect(r.drainCommits().isEmpty)
+        #expect(r.liveLines.contains(where: { $0.contains("128 tokens") }))
+        #expect(!r.liveLines.contains(where: { $0.contains("running…") }))
+
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1",
+            toolName: "agent",
+            result: toolDisplay("agent explore completed · 256 tokens"),
+            isError: false
+        ))
+        let commits = r.drainCommits()
+        #expect(commits.contains(where: { $0.contains("256 tokens") }))
+        #expect(!commits.contains(where: { $0.contains("128 tokens") }))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- Add first-class subagent definitions and the `agent` tool, with fresh child sessions, child-scoped background tasks, cancellation handling, and runtime summary events.
- Mirror the CLI defaults after some-code: `general`, `Explore`, and `Plan`; omit `subagent_type` to fall back to `general`, and treat missing `tools` as wildcard/all tools.
- Add provider session lifecycle cleanup so `agent.closeSession()` can release session-owned resources such as OpenAI Responses WebSocket connections.
- Surface subagent token progress in the TUI and document the SDK/CLI subagent usage model.

## Validation

- `swift test --filter BuiltinSubagent`
- `swift test --filter SubagentToolTests`
- `swift test --filter closeProviderSessionNotifiesLifecycleProvider`
- `swift test --filter EscapeKeyFlushTests`
- `swift test`