### PR TITLE
[codex] Simplify system prompt

### DIFF
--- a/Sources/KWWKAgent/SystemPrompt.swift
+++ b/Sources/KWWKAgent/SystemPrompt.swift
@@ -37,14 +37,10 @@ public struct SystemPromptOptions: Sendable {
 }
 
 /// Mirror of pi-coding-agent's `buildSystemPrompt`. The default tool list is
-/// [read, bash, edit, write]; tools only render in the prompt when they have
-/// a `toolSnippets` entry, matching the original behavior.
+/// [read, bash, edit, write] for guideline selection; tool schemas are provided
+/// to the model separately by the provider.
 public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
     let tools = options.selectedToolNames ?? ["read", "bash", "edit", "write"]
-    let visible = tools.filter { options.toolSnippets[$0] != nil }
-    let toolsList = visible.isEmpty
-        ? "(none)"
-        : visible.map { "- \($0): \(options.toolSnippets[$0] ?? "")" }.joined(separator: "\n")
 
     var guidelines: [String] = []
     var seenGuidelines: Set<String> = []
@@ -98,12 +94,7 @@ public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
 
     let guidelinesText = guidelines.map { "- \($0)" }.joined(separator: "\n")
     var prompt = """
-    You are an expert coding assistant operating inside kw, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
-
-    Available tools:
-    \(toolsList)
-
-    In addition to the tools above, you may have access to other custom tools depending on the project.
+    You are an expert coding assistant operating inside kwwk, a coding agent harness. Help users by reading files, running commands, editing code, and writing new files.
 
     Guidelines:
     \(guidelinesText)

--- a/Tests/KWWKAgentTests/SystemPromptTests.swift
+++ b/Tests/KWWKAgentTests/SystemPromptTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("System prompt")
 struct SystemPromptTests {
-    @Test("default prompt lists tools that have snippets and applies cwd + date")
+    @Test("default prompt applies identity, guidelines, cwd, and date")
     func defaultPrompt() {
         let prompt = buildSystemPrompt(SystemPromptOptions(
             cwd: "/tmp/project",
@@ -15,21 +15,23 @@ struct SystemPromptTests {
             ],
             date: "2024-06-15"
         ))
-        #expect(prompt.contains("Available tools:"))
-        #expect(prompt.contains("- read: Read file contents"))
-        #expect(prompt.contains("- bash: Execute shell commands"))
+        #expect(prompt.contains("operating inside kwwk"))
+        #expect(!prompt.contains("Available tools:"))
+        #expect(!prompt.contains("- read: Read file contents"))
+        #expect(!prompt.contains("- bash: Execute shell commands"))
         #expect(prompt.contains("Current date: 2024-06-15"))
         #expect(prompt.contains("Current working directory: /tmp/project"))
     }
 
-    @Test("omits tools without snippets and falls back to '(none)'")
+    @Test("does not render a synthetic tool list")
     func hiddenTools() {
         let prompt = buildSystemPrompt(SystemPromptOptions(
             cwd: "/tmp",
             selectedToolNames: ["read"],
             toolSnippets: [:]
         ))
-        #expect(prompt.contains("(none)"))
+        #expect(!prompt.contains("(none)"))
+        #expect(!prompt.contains("Available tools:"))
     }
 
     @Test("prefers grep/find/ls over bash when all are present")


### PR DESCRIPTION
## Summary
- Rename the default system prompt identity from kw to kwwk.
- Remove the synthetic Available tools section because tool schemas are already passed separately.
- Update system prompt tests for the simplified prompt.

## Validation
- swift test --filter SystemPromptTests