### PR TITLE
Add provider auth resolver

### DIFF
--- a/Sources/KWWKAI/AnthropicProvider.swift
+++ b/Sources/KWWKAI/AnthropicProvider.swift
@@ -98,7 +98,9 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
             "anthropic-version": apiVersion,
         ]
         for (k, v) in extraHeaders { headers[k] = v }
-        if let key = options?.apiKey ?? defaultAPIKey {
+        if let auth = options?.resolvedAuth {
+            applyResolvedAuth(auth, to: &headers)
+        } else if let key = options?.apiKey ?? defaultAPIKey {
             for (k, v) in authHeaderBuilder(key) { headers[k] = v }
         }
         if let extra = options?.headers {

--- a/Sources/KWWKAI/AuthHeaders.swift
+++ b/Sources/KWWKAI/AuthHeaders.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+func applyResolvedAuth(
+    _ auth: ResolvedProviderAuth,
+    to headers: inout [String: String],
+    merge: (_ headers: inout [String: String], _ name: String, _ value: String) -> Void = { headers, name, value in
+        headers[name] = value
+    }
+) {
+    for (name, value) in auth.headers {
+        merge(&headers, name, value)
+    }
+    guard let token = auth.token, !token.isEmpty else { return }
+    switch auth.scheme {
+    case .none, .queryKey:
+        break
+    case .bearer:
+        merge(&headers, "authorization", "Bearer \(token)")
+    case .apiKeyHeader(let name):
+        merge(&headers, name, token)
+    }
+}
+
+func resolvedQueryKey(_ auth: ResolvedProviderAuth?, expectedName: String) -> String? {
+    guard case .queryKey(let name) = auth?.scheme, name == expectedName else { return nil }
+    return auth?.token
+}

--- a/Sources/KWWKAI/Context.swift
+++ b/Sources/KWWKAI/Context.swift
@@ -48,6 +48,35 @@ public struct ThinkingBudgets: Codable, Sendable, Hashable {
     }
 }
 
+public enum AuthScheme: Sendable, Hashable {
+    case none
+    case bearer
+    case apiKeyHeader(name: String)
+    case queryKey(name: String)
+}
+
+public struct ResolvedProviderAuth: Sendable, Hashable {
+    public var token: String?
+    public var scheme: AuthScheme
+    public var headers: [String: String]
+    public var baseURL: String?
+    public var metadata: [String: JSONValue]
+
+    public init(
+        token: String? = nil,
+        scheme: AuthScheme = .none,
+        headers: [String: String] = [:],
+        baseURL: String? = nil,
+        metadata: [String: JSONValue] = [:]
+    ) {
+        self.token = token
+        self.scheme = scheme
+        self.headers = headers
+        self.baseURL = baseURL
+        self.metadata = metadata
+    }
+}
+
 /// Whether the model is allowed/required to call tools. Providers that don't
 /// support a direct analog ignore this. Matches the common shape across
 /// Anthropic, OpenAI Responses, and OpenAI Completions.
@@ -74,6 +103,7 @@ public struct StreamOptions: Sendable {
     public var headers: [String: String]?
     public var maxRetryDelayMs: Int?
     public var metadata: [String: JSONValue]?
+    public var resolvedAuth: ResolvedProviderAuth?
     public var reasoning: ReasoningLevel?
     public var thinkingBudgets: ThinkingBudgets?
     public var cancellation: CancellationHandle?
@@ -104,6 +134,7 @@ public struct StreamOptions: Sendable {
         headers: [String: String]? = nil,
         maxRetryDelayMs: Int? = nil,
         metadata: [String: JSONValue]? = nil,
+        resolvedAuth: ResolvedProviderAuth? = nil,
         reasoning: ReasoningLevel? = nil,
         thinkingBudgets: ThinkingBudgets? = nil,
         cancellation: CancellationHandle? = nil,
@@ -121,6 +152,7 @@ public struct StreamOptions: Sendable {
         self.headers = headers
         self.maxRetryDelayMs = maxRetryDelayMs
         self.metadata = metadata
+        self.resolvedAuth = resolvedAuth
         self.reasoning = reasoning
         self.thinkingBudgets = thinkingBudgets
         self.cancellation = cancellation

--- a/Sources/KWWKAI/GoogleGeminiProvider.swift
+++ b/Sources/KWWKAI/GoogleGeminiProvider.swift
@@ -75,9 +75,12 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
         options: StreamOptions?
     ) async {
         // When auth is a header (Vertex Bearer), build URL without the `?key=`.
-        let queryKey: String? = authHeaderBuilder == nil
-            ? (options?.apiKey ?? defaultAPIKey)
-            : nil
+        let queryKey: String? = {
+            if let auth = options?.resolvedAuth {
+                return resolvedQueryKey(auth, expectedName: "key")
+            }
+            return authHeaderBuilder == nil ? (options?.apiKey ?? defaultAPIKey) : nil
+        }()
         let url = urlBuilder(model, options, defaultBaseURL, queryKey)
 
         let body: Data
@@ -95,7 +98,9 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
             "accept": "text/event-stream",
         ]
         for (k, v) in extraHeaders { headers[k] = v }
-        if let builder = authHeaderBuilder, let key = options?.apiKey ?? defaultAPIKey {
+        if let auth = options?.resolvedAuth {
+            applyResolvedAuth(auth, to: &headers)
+        } else if let builder = authHeaderBuilder, let key = options?.apiKey ?? defaultAPIKey {
             for (k, v) in builder(key) { headers[k] = v }
         }
         for (k, v) in options?.headers ?? [:] { headers[k] = v }

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -194,14 +194,24 @@ public actor OAuthManager {
         return try await provider.apiKey(from: credentials, using: client)
     }
 
-    /// Build an `Agent.apiKeyResolver`-shaped closure. The resolver receives
-    /// a Model.provider string; we map common provider ids to our OAuth ids.
-    public nonisolated func resolver() -> @Sendable (String) async -> String? {
+    /// Build an auth resolver closure. The resolver receives the active model;
+    /// we map common provider ids to our OAuth ids and return a bearer token.
+    public nonisolated func resolver() -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
         let manager = self
-        return { provider in
-            let oauthId = Self.oauthId(forProvider: provider)
-            return try? await manager.apiKey(for: oauthId)
+        return { model, _ in
+            let oauthId = Self.oauthId(forProvider: model.provider)
+            return try? await manager.resolvedAuth(for: oauthId)
         }
+    }
+
+    private func resolvedAuth(for providerId: String) async throws -> ResolvedProviderAuth {
+        let token = try await apiKey(for: providerId)
+        let credentials = await store.get(providerId)
+        return ResolvedProviderAuth(
+            token: token,
+            scheme: .bearer,
+            baseURL: Self.baseURL(forOAuthId: providerId, credentials: credentials)
+        )
     }
 
     private static func oauthId(forProvider provider: String) -> String {
@@ -213,5 +223,14 @@ public actor OAuthManager {
         case "google-antigravity": return "google-antigravity"
         default: return provider
         }
+    }
+
+    private static func baseURL(forOAuthId providerId: String, credentials: OAuthCredentials?) -> String? {
+        guard providerId == "github-copilot",
+              case .string(let endpoint) = credentials?.extras["endpoint"] ?? .null,
+              !endpoint.isEmpty else {
+            return nil
+        }
+        return endpoint
     }
 }

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -102,7 +102,9 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             "accept": "text/event-stream",
         ]
         for (k, v) in extraHeaders { headers[k] = v }
-        if let key = options?.apiKey ?? defaultAPIKey {
+        if let auth = options?.resolvedAuth {
+            applyResolvedAuth(auth, to: &headers)
+        } else if let key = options?.apiKey ?? defaultAPIKey {
             for (k, v) in authHeaderBuilder(key) { headers[k] = v }
         }
         headersDecorator?(&headers, model, context, options)

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -415,7 +415,11 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             headers["accept"] = accept
         }
         for (k, v) in extraHeaders { mergeHeader(&headers, name: k, value: v, append: false) }
-        if let key = options?.apiKey ?? defaultAPIKey {
+        if let auth = options?.resolvedAuth {
+            applyResolvedAuth(auth, to: &headers) { headers, name, value in
+                mergeHeader(&headers, name: name, value: value, append: false)
+            }
+        } else if let key = options?.apiKey ?? defaultAPIKey {
             for (k, v) in authHeaderBuilder(key) {
                 mergeHeader(&headers, name: k, value: v, append: false)
             }

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -64,7 +64,7 @@ public struct AgentOptions: Sendable {
     public var convertToLlm: ConvertToLlmHook?
     public var transformContext: TransformContextHook?
     public var betweenTurns: BetweenTurnsHook?
-    public var apiKeyResolver: (@Sendable (String) async -> String?)?
+    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 
     public init(
         initialState: AgentInitialState,
@@ -84,7 +84,7 @@ public struct AgentOptions: Sendable {
         convertToLlm: ConvertToLlmHook? = nil,
         transformContext: TransformContextHook? = nil,
         betweenTurns: BetweenTurnsHook? = nil,
-        apiKeyResolver: (@Sendable (String) async -> String?)? = nil
+        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil
     ) {
         self.initialState = initialState
         self.streamFn = streamFn
@@ -103,7 +103,7 @@ public struct AgentOptions: Sendable {
         self.convertToLlm = convertToLlm
         self.transformContext = transformContext
         self.betweenTurns = betweenTurns
-        self.apiKeyResolver = apiKeyResolver
+        self.authResolver = authResolver
     }
 }
 
@@ -131,7 +131,7 @@ public final class Agent: @unchecked Sendable {
     public var convertToLlm: ConvertToLlmHook?
     public var transformContext: TransformContextHook?
     public var betweenTurns: BetweenTurnsHook?
-    public var apiKeyResolver: (@Sendable (String) async -> String?)?
+    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 
     /// Base delay (ms) used for exponential backoff between stream retries.
     /// Exposed internally so tests can shrink the 1-second default.
@@ -184,7 +184,7 @@ public final class Agent: @unchecked Sendable {
         self.convertToLlm = options.convertToLlm
         self.transformContext = options.transformContext
         self.betweenTurns = options.betweenTurns
-        self.apiKeyResolver = options.apiKeyResolver
+        self.authResolver = options.authResolver
         self.steeringQueue = PendingMessageQueue(mode: options.steeringMode)
         self.followUpQueue = PendingMessageQueue(mode: options.followUpMode)
     }
@@ -392,7 +392,7 @@ extension Agent {
                 return steering.drain()
             },
             getFollowUpMessages: { followUp.drain() },
-            apiKeyResolver: apiKeyResolver,
+            authResolver: authResolver,
             beforeToolCall: beforeToolCall,
             afterToolCall: afterToolCall,
             userPromptSubmit: userPromptSubmit,

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -22,7 +22,7 @@ public struct AgentLoopConfig: Sendable {
     public var retryBaseDelayMs: UInt64
     public var getSteeringMessages: @Sendable () async -> [Message]
     public var getFollowUpMessages: @Sendable () async -> [Message]
-    public var apiKeyResolver: (@Sendable (String) async -> String?)?
+    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
     public var beforeToolCall: BeforeToolCallHook?
     public var afterToolCall: AfterToolCallHook?
     public var userPromptSubmit: UserPromptSubmitHook?
@@ -44,7 +44,7 @@ public struct AgentLoopConfig: Sendable {
         retryBaseDelayMs: UInt64 = 1_000,
         getSteeringMessages: @escaping @Sendable () async -> [Message] = { [] },
         getFollowUpMessages: @escaping @Sendable () async -> [Message] = { [] },
-        apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
         beforeToolCall: BeforeToolCallHook? = nil,
         afterToolCall: AfterToolCallHook? = nil,
         userPromptSubmit: UserPromptSubmitHook? = nil,
@@ -65,7 +65,7 @@ public struct AgentLoopConfig: Sendable {
         self.retryBaseDelayMs = retryBaseDelayMs
         self.getSteeringMessages = getSteeringMessages
         self.getFollowUpMessages = getFollowUpMessages
-        self.apiKeyResolver = apiKeyResolver
+        self.authResolver = authResolver
         self.beforeToolCall = beforeToolCall
         self.afterToolCall = afterToolCall
         self.userPromptSubmit = userPromptSubmit
@@ -444,12 +444,22 @@ public enum AgentLoop {
             tools: context.tools.map { $0.toKWAITool() }
         )
 
-        let resolvedKey = await config.apiKeyResolver?(config.model.provider)
+        let resolvedAuth = await config.authResolver?(config.model, config.sessionId)
+        var requestModel = config.model
+        if let baseURL = resolvedAuth?.baseURL, !baseURL.isEmpty {
+            requestModel.baseUrl = baseURL
+        }
+        let mergedMetadata: [String: JSONValue]? = {
+            guard let authMetadata = resolvedAuth?.metadata, !authMetadata.isEmpty else { return nil }
+            return authMetadata
+        }()
         let options = StreamOptions(
-            apiKey: resolvedKey,
+            apiKey: resolvedAuth?.token,
             cacheRetention: nil,
             sessionId: config.sessionId,
             maxRetryDelayMs: config.maxRetryDelayMs,
+            metadata: mergedMetadata,
+            resolvedAuth: resolvedAuth,
             reasoning: config.reasoning,
             thinkingBudgets: config.thinkingBudgets,
             cancellation: cancellation,
@@ -469,7 +479,7 @@ public enum AgentLoop {
             }
 
             do {
-                let response = try await streamFn(config.model, llmContext, options)
+                let response = try await streamFn(requestModel, llmContext, options)
 
                 // Live-stream events as they arrive so the UI shows tokens
                 // in real time. A retryable mid-stream error emits

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -41,8 +41,8 @@ public struct CodingAgentConfig: Sendable {
     public var model: Model
     public var cwd: String
     public var tools: CodingTools
-    /// If nil, a system prompt is synthesized from the selected tools +
-    /// `DefaultToolSnippets.all`. Pass a non-nil string to fully override.
+    /// If nil, a default system prompt is synthesized. Pass a non-nil string
+    /// to fully override.
     public var systemPrompt: String?
     /// When non-nil, wired into both the bash tool (for
     /// `run_in_background` + auto-background-on-timeout) and the
@@ -53,7 +53,7 @@ public struct CodingAgentConfig: Sendable {
     /// When empty, no `agent` tool is registered.
     public var subagents: [SubagentDefinition]
     public var sessionId: String
-    public var apiKeyResolver: (@Sendable (String) async -> String?)?
+    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
     /// Soft foreground timeout for bash commands. The command auto-moves to
     /// the background on this deadline when a `backgroundManager` is attached.
     public var bashDefaultTimeoutSeconds: Int
@@ -67,7 +67,7 @@ public struct CodingAgentConfig: Sendable {
         backgroundManager: BackgroundTaskManager? = nil,
         subagents: [SubagentDefinition] = [],
         sessionId: String = UUID().uuidString,
-        apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600
     ) {
@@ -78,7 +78,7 @@ public struct CodingAgentConfig: Sendable {
         self.backgroundManager = backgroundManager
         self.subagents = subagents
         self.sessionId = sessionId
-        self.apiKeyResolver = apiKeyResolver
+        self.authResolver = authResolver
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
     }
@@ -132,7 +132,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         fallbackThinkingLevel: .off,
         fallbackThinkingBudgets: nil,
         fallbackMaxRetryDelayMs: nil,
-        fallbackAPIKeyResolver: config.apiKeyResolver
+        fallbackAuthResolver: config.authResolver
     )
     if !config.subagents.isEmpty {
         tools.append(_createAgentTool(
@@ -146,11 +146,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         ))
     }
 
-    let systemPrompt = config.systemPrompt ?? buildSystemPrompt(SystemPromptOptions(
-        cwd: cwd,
-        selectedToolNames: tools.map { $0.name },
-        toolSnippets: DefaultToolSnippets.all
-    ))
+    let systemPrompt = config.systemPrompt ?? buildSystemPrompt(SystemPromptOptions(cwd: cwd))
 
     let agent = Agent(options: AgentOptions(
         initialState: AgentInitialState(
@@ -159,7 +155,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
             tools: tools
         ),
         sessionId: sessionId,
-        apiKeyResolver: config.apiKeyResolver
+        authResolver: config.authResolver
     ))
     subagentParent.attach(agent)
 

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -10,7 +10,7 @@ public func createAgentTool(
     parentMaxRetryDelayMs: Int? = nil,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
-    apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+    authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600
 ) -> AgentTool {
@@ -19,7 +19,7 @@ public func createAgentTool(
         thinkingLevel: parentThinkingLevel,
         thinkingBudgets: parentThinkingBudgets,
         maxRetryDelayMs: parentMaxRetryDelayMs,
-        apiKeyResolver: apiKeyResolver
+        authResolver: authResolver
     )
     return _createAgentTool(
         cwd: cwd,
@@ -38,7 +38,7 @@ public func createAgentTool(
     parentAgent: Agent,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
-    fallbackAPIKeyResolver: (@Sendable (String) async -> String?)? = nil,
+    fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600
 ) -> AgentTool {
@@ -47,7 +47,7 @@ public func createAgentTool(
         fallbackThinkingLevel: parentAgent.state.thinkingLevel,
         fallbackThinkingBudgets: parentAgent.thinkingBudgets,
         fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
-        fallbackAPIKeyResolver: parentAgent.apiKeyResolver ?? fallbackAPIKeyResolver
+        fallbackAuthResolver: parentAgent.authResolver ?? fallbackAuthResolver
     )
     parentBox.attach(parentAgent)
     return _createAgentTool(
@@ -66,7 +66,7 @@ internal struct SubagentParentSnapshot: Sendable {
     var thinkingLevel: ThinkingLevel
     var thinkingBudgets: ThinkingBudgets?
     var maxRetryDelayMs: Int?
-    var apiKeyResolver: (@Sendable (String) async -> String?)?
+    var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 }
 
 internal final class SubagentParentBox: @unchecked Sendable {
@@ -76,20 +76,20 @@ internal final class SubagentParentBox: @unchecked Sendable {
     private let fallbackThinkingLevel: ThinkingLevel
     private let fallbackThinkingBudgets: ThinkingBudgets?
     private let fallbackMaxRetryDelayMs: Int?
-    private let fallbackAPIKeyResolver: (@Sendable (String) async -> String?)?
+    private let fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 
     init(
         fallbackModel: Model,
         fallbackThinkingLevel: ThinkingLevel,
         fallbackThinkingBudgets: ThinkingBudgets?,
         fallbackMaxRetryDelayMs: Int?,
-        fallbackAPIKeyResolver: (@Sendable (String) async -> String?)?
+        fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
     ) {
         self.fallbackModel = fallbackModel
         self.fallbackThinkingLevel = fallbackThinkingLevel
         self.fallbackThinkingBudgets = fallbackThinkingBudgets
         self.fallbackMaxRetryDelayMs = fallbackMaxRetryDelayMs
-        self.fallbackAPIKeyResolver = fallbackAPIKeyResolver
+        self.fallbackAuthResolver = fallbackAuthResolver
     }
 
     func attach(_ agent: Agent) {
@@ -104,7 +104,7 @@ internal final class SubagentParentBox: @unchecked Sendable {
                     thinkingLevel: fallbackThinkingLevel,
                     thinkingBudgets: fallbackThinkingBudgets,
                     maxRetryDelayMs: fallbackMaxRetryDelayMs,
-                    apiKeyResolver: fallbackAPIKeyResolver
+                    authResolver: fallbackAuthResolver
                 )
             }
             return SubagentParentSnapshot(
@@ -112,7 +112,7 @@ internal final class SubagentParentBox: @unchecked Sendable {
                 thinkingLevel: agent.state.thinkingLevel,
                 thinkingBudgets: agent.thinkingBudgets,
                 maxRetryDelayMs: agent.maxRetryDelayMs,
-                apiKeyResolver: agent.apiKeyResolver ?? fallbackAPIKeyResolver
+                authResolver: agent.authResolver ?? fallbackAuthResolver
             )
         }
     }
@@ -443,8 +443,6 @@ private enum SubagentPromptBuilder {
         """
         return buildSystemPrompt(SystemPromptOptions(
             cwd: cwd,
-            selectedToolNames: tools.map { $0.name },
-            toolSnippets: DefaultToolSnippets.all,
             appendSystemPrompt: instructions
         ))
     }
@@ -540,7 +538,7 @@ public struct SubagentRunner: Sendable {
         parentMaxRetryDelayMs: Int? = nil,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
-        apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600
     ) {
@@ -549,7 +547,7 @@ public struct SubagentRunner: Sendable {
             thinkingLevel: parentThinkingLevel,
             thinkingBudgets: parentThinkingBudgets,
             maxRetryDelayMs: parentMaxRetryDelayMs,
-            apiKeyResolver: apiKeyResolver
+            authResolver: authResolver
         )
         self.cwd = cwd
         self.subagents = subagents
@@ -566,7 +564,7 @@ public struct SubagentRunner: Sendable {
         parentAgent: Agent,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
-        fallbackAPIKeyResolver: (@Sendable (String) async -> String?)? = nil,
+        fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600
     ) {
@@ -575,7 +573,7 @@ public struct SubagentRunner: Sendable {
             fallbackThinkingLevel: parentAgent.state.thinkingLevel,
             fallbackThinkingBudgets: parentAgent.thinkingBudgets,
             fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
-            fallbackAPIKeyResolver: parentAgent.apiKeyResolver ?? fallbackAPIKeyResolver
+            fallbackAuthResolver: parentAgent.authResolver ?? fallbackAuthResolver
         )
         parentBox.attach(parentAgent)
         self.cwd = cwd
@@ -808,7 +806,7 @@ private struct SubagentInvocationRunner: Sendable {
             sessionId: childSessionId,
             thinkingBudgets: parent.thinkingBudgets,
             maxRetryDelayMs: parent.maxRetryDelayMs,
-            apiKeyResolver: parent.apiKeyResolver
+            authResolver: parent.authResolver
         ))
         let progress = SubagentProgressEmitter(
             subagentName: definition.name,

--- a/Sources/KWWKAgent/SystemPrompt.swift
+++ b/Sources/KWWKAgent/SystemPrompt.swift
@@ -3,10 +3,6 @@ import Foundation
 public struct SystemPromptOptions: Sendable {
     public var cwd: String
     public var customPrompt: String?
-    public var selectedToolNames: [String]?
-    /// One-line snippet per tool name — only tools with a snippet appear in the
-    /// "Available tools" list. Matches pi-coding-agent's `toolSnippets`.
-    public var toolSnippets: [String: String]
     public var promptGuidelines: [String]
     public var appendSystemPrompt: String?
     public var contextFiles: [(path: String, content: String)]
@@ -16,8 +12,6 @@ public struct SystemPromptOptions: Sendable {
     public init(
         cwd: String,
         customPrompt: String? = nil,
-        selectedToolNames: [String]? = nil,
-        toolSnippets: [String: String] = [:],
         promptGuidelines: [String] = [],
         appendSystemPrompt: String? = nil,
         contextFiles: [(path: String, content: String)] = [],
@@ -26,8 +20,6 @@ public struct SystemPromptOptions: Sendable {
     ) {
         self.cwd = cwd
         self.customPrompt = customPrompt
-        self.selectedToolNames = selectedToolNames
-        self.toolSnippets = toolSnippets
         self.promptGuidelines = promptGuidelines
         self.appendSystemPrompt = appendSystemPrompt
         self.contextFiles = contextFiles
@@ -36,12 +28,7 @@ public struct SystemPromptOptions: Sendable {
     }
 }
 
-/// Mirror of pi-coding-agent's `buildSystemPrompt`. The default tool list is
-/// [read, bash, edit, write] for guideline selection; tool schemas are provided
-/// to the model separately by the provider.
 public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
-    let tools = options.selectedToolNames ?? ["read", "bash", "edit", "write"]
-
     var guidelines: [String] = []
     var seenGuidelines: Set<String> = []
     func add(_ g: String) {
@@ -51,17 +38,6 @@ public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
         guidelines.append(trimmed)
     }
 
-    let hasBash = tools.contains("bash")
-    let hasGrep = tools.contains("grep")
-    let hasFind = tools.contains("find")
-    let hasLs = tools.contains("ls")
-    let hasRead = tools.contains("read")
-
-    if hasBash && !hasGrep && !hasFind && !hasLs {
-        add("Use bash for file operations like ls, rg, find")
-    } else if hasBash && (hasGrep || hasFind || hasLs) {
-        add("Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)")
-    }
     for g in options.promptGuidelines { add(g) }
     add("Be concise in your responses")
     add("Show file paths clearly when working with files")
@@ -85,7 +61,7 @@ public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
                 prompt += "## \(file.path)\n\n\(file.content)\n\n"
             }
         }
-        if (options.selectedToolNames == nil || hasRead), !options.skills.isEmpty {
+        if !options.skills.isEmpty {
             prompt += formatSkills(options.skills)
         }
         prompt += "\nCurrent date: \(date)\nCurrent working directory: \(normalizedCwd)"
@@ -106,7 +82,7 @@ public func buildSystemPrompt(_ options: SystemPromptOptions) -> String {
             prompt += "## \(file.path)\n\n\(file.content)\n\n"
         }
     }
-    if hasRead, !options.skills.isEmpty {
+    if !options.skills.isEmpty {
         prompt += formatSkills(options.skills)
     }
     prompt += "\nCurrent date: \(date)\nCurrent working directory: \(normalizedCwd)"
@@ -118,18 +94,4 @@ private func formatSkills(_ skills: [String]) -> String {
     var out = "\n\n# Skills\n\n"
     for skill in skills { out += "- \(skill)\n" }
     return out
-}
-
-// MARK: - Default tool snippets
-
-public enum DefaultToolSnippets {
-    public static let all: [String: String] = [
-        "read": "Read file contents",
-        "write": "Create or overwrite files",
-        "edit": "Make precise text replacements inside a file",
-        "bash": "Execute shell commands",
-        "grep": "Search file contents for a regex pattern",
-        "find": "Find files matching a glob pattern",
-        "ls": "List directory contents",
-    ]
 }

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -7,9 +7,9 @@ struct ResolvedAuth: Sendable {
     let model: Model
     let modelLabel: String
     /// For OAuth-backed providers (Codex, Anthropic OAuth, ...), an
-    /// `apiKeyResolver` that calls back into `OAuthManager.apiKey(for:)` so
+    /// `authResolver` that calls back into `OAuthManager.apiKey(for:)` so
     /// tokens refresh on demand. Nil for static api-key providers.
-    let apiKeyResolver: (@Sendable (String) async -> String?)?
+    let authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 }
 
 enum AuthResolveError: Error, LocalizedError {
@@ -116,7 +116,7 @@ private func registerCodex(
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     // Grab a fresh token if expired. If the refresh fails we still register
-    // the provider — the apiKeyResolver below will retry on the next request
+    // the provider — the authResolver below will retry on the next request
     // and surface the error to the user there.
     _ = try? await manager.apiKey(for: "openai-codex")
 
@@ -149,14 +149,10 @@ private func registerCodex(
         maxTokens: 0
     )
 
-    let resolver: @Sendable (String) async -> String? = { _ in
-        try? await manager.apiKey(for: "openai-codex")
-    }
-
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId) · ChatGPT Codex",
-        apiKeyResolver: resolver
+        authResolver: oauthResolver(manager: manager, providerId: "openai-codex", scheme: .bearer)
     )
 }
 
@@ -200,15 +196,11 @@ private func registerAnthropicOAuth(
         maxTokens: catalog?.maxTokens ?? 8192
     )
 
-    let resolver: @Sendable (String) async -> String? = { _ in
-        try? await manager.apiKey(for: "anthropic")
-    }
-
     let suffix = context1m ? " · Anthropic OAuth (1M ctx)" : " · Anthropic OAuth"
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId)\(suffix)",
-        apiKeyResolver: resolver
+        authResolver: oauthResolver(manager: manager, providerId: "anthropic", scheme: .bearer)
     )
 }
 
@@ -302,14 +294,15 @@ private func registerGitHubCopilot(
         )
     }()
 
-    let resolver: @Sendable (String) async -> String? = { _ in
-        try? await manager.apiKey(for: "github-copilot")
-    }
-
     return ResolvedAuth(
         model: model,
         modelLabel: "\(defaultId) · GitHub Copilot",
-        apiKeyResolver: resolver
+        authResolver: oauthResolver(
+            manager: manager,
+            providerId: "github-copilot",
+            scheme: .bearer,
+            baseURL: baseURLString
+        )
     )
 }
 
@@ -338,7 +331,7 @@ private func registerAnthropicAPIKey(
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId) · Anthropic (API key)",
-        apiKeyResolver: nil
+        authResolver: nil
     )
 }
 
@@ -367,7 +360,7 @@ private func registerOpenAIAPIKey(
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId) · OpenAI (API key)",
-        apiKeyResolver: nil
+        authResolver: nil
     )
 }
 
@@ -399,7 +392,7 @@ private func registerGoogleAPIKey(
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId) · Google AI Studio",
-        apiKeyResolver: nil
+        authResolver: nil
     )
 }
 
@@ -432,7 +425,7 @@ private func registerOpenAICompatible(
     return ResolvedAuth(
         model: model,
         modelLabel: "\(modelId) · \(baseURL)",
-        apiKeyResolver: nil
+        authResolver: nil
     )
 }
 
@@ -441,4 +434,16 @@ private func registerOpenAICompatible(
 private func stringExtra(_ creds: OAuthCredentials, _ key: String) -> String? {
     if case .string(let s) = creds.extras[key] ?? .null { return s }
     return nil
+}
+
+private func oauthResolver(
+    manager: OAuthManager,
+    providerId: String,
+    scheme: AuthScheme,
+    baseURL: String? = nil
+) -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
+    { _, _ in
+        guard let token = try? await manager.apiKey(for: providerId) else { return nil }
+        return ResolvedProviderAuth(token: token, scheme: scheme, baseURL: baseURL)
+    }
 }

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -13,7 +13,7 @@ func runCodingTUIInternal(
     cwd: String,
     tools: CodingTools,
     builtinSubagents: BuiltinSubagentSelection = .all,
-    apiKeyResolver: (@Sendable (String) async -> String?)? = nil,
+    authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
     autoCompactThreshold: Double? = 0.75,
     thinkingLevel: ThinkingLevel = .medium
 ) async throws {
@@ -27,7 +27,7 @@ func runCodingTUIInternal(
         backgroundManager: bgManager,
         subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
         sessionId: sessionId,
-        apiKeyResolver: apiKeyResolver
+        authResolver: authResolver
     ))
     // Turn on extended thinking by default — otherwise reasoning-capable
     // providers never produce `[thinking]` blocks. The level is a user

--- a/Sources/KWWKCli/CompactRunner.swift
+++ b/Sources/KWWKCli/CompactRunner.swift
@@ -60,7 +60,8 @@ func performCompact(
         let summary = try await summarizeTranscript(
             messages: snapshot,
             model: agent.state.model,
-            apiKeyResolver: agent.apiKeyResolver
+            sessionId: sessionId,
+            authResolver: agent.authResolver
         )
         var body = """
         <previous-session-summary>
@@ -153,12 +154,13 @@ enum CompactError: Error, LocalizedError {
 
 /// Fire a one-shot LLM call (no tools, isolated system prompt) to produce
 /// a compressed recap of the conversation. The call uses the same model +
-/// api-key resolver as the agent, so Codex / Anthropic / etc. all work
+/// auth resolver as the agent, so Codex / Anthropic / etc. all work
 /// transparently.
 func summarizeTranscript(
     messages: [Message],
     model: Model,
-    apiKeyResolver: (@Sendable (String) async -> String?)?
+    sessionId: String?,
+    authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 ) async throws -> String {
     let transcript = renderForSummary(messages)
 
@@ -191,13 +193,23 @@ func summarizeTranscript(
         tools: []
     )
 
-    var apiKey: String?
-    if let resolver = apiKeyResolver {
-        apiKey = await resolver(model.provider)
+    let resolvedAuth = await authResolver?(model, sessionId)
+    var requestModel = model
+    if let baseURL = resolvedAuth?.baseURL, !baseURL.isEmpty {
+        requestModel.baseUrl = baseURL
     }
-    let options = StreamOptions(apiKey: apiKey)
+    let metadata: [String: JSONValue]? = {
+        guard let authMetadata = resolvedAuth?.metadata, !authMetadata.isEmpty else { return nil }
+        return authMetadata
+    }()
+    let options = StreamOptions(
+        apiKey: resolvedAuth?.token,
+        sessionId: sessionId,
+        metadata: metadata,
+        resolvedAuth: resolvedAuth
+    )
 
-    let response = try await stream(model: model, context: context, options: options)
+    let response = try await stream(model: requestModel, context: context, options: options)
     let result = await response.result()
 
     if result.stopReason == .error {

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -44,7 +44,7 @@ func runHeadlessInternal(
         backgroundManager: bgManager,
         subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
         sessionId: sessionId,
-        apiKeyResolver: resolved.apiKeyResolver
+        authResolver: resolved.authResolver
     ))
     agent.state.thinkingLevel = thinkingLevel
 

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -40,7 +40,7 @@ public enum KWWK {
             cwd: workDir,
             tools: tools,
             builtinSubagents: builtinSubagents,
-            apiKeyResolver: resolved.apiKeyResolver,
+            authResolver: resolved.authResolver,
             autoCompactThreshold: autoCompactThreshold,
             thinkingLevel: thinkingLevel
         )

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -197,6 +197,31 @@ struct AnthropicProviderTests {
         #expect(req?.headers["accept"] == "text/event-stream")
     }
 
+    @Test("resolved auth can select bearer scheme and merge custom headers")
+    func resolvedAuthBearerHeaders() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = AnthropicProvider(client: client, defaultAPIKey: "default-key")
+        _ = provider.stream(
+            model: Self.sampleModel,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                apiKey: "ignored-key",
+                headers: ["x-extra": "override"],
+                resolvedAuth: ResolvedProviderAuth(
+                    token: "oauth-token",
+                    scheme: .bearer,
+                    headers: ["anthropic-beta": "oauth-2025-04-20", "x-extra": "auth"]
+                )
+            )
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let headers = client.lastRequest?.headers ?? [:]
+        #expect(headers["authorization"] == "Bearer oauth-token")
+        #expect(headers["x-api-key"] == nil)
+        #expect(headers["anthropic-beta"] == "oauth-2025-04-20")
+        #expect(headers["x-extra"] == "override")
+    }
+
     @Test("encodes user text and tool blocks in Anthropic body shape")
     func encodesBody() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAITests/GoogleGeminiTests.swift
+++ b/Tests/KWWKAITests/GoogleGeminiTests.swift
@@ -144,6 +144,40 @@ struct GoogleGeminiTests {
         #expect(client.lastRequest?.headers["authorization"] == nil)
     }
 
+    @Test("resolved auth query key controls URL auth")
+    func resolvedAuthQueryKey() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = GoogleGeminiProvider(client: client, defaultAPIKey: "default-key")
+        _ = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                apiKey: "ignored-key",
+                resolvedAuth: ResolvedProviderAuth(token: "resolved-key", scheme: .queryKey(name: "key"))
+            )
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(client.lastRequest?.url.absoluteString.contains("key=resolved-key") == true)
+        #expect(client.lastRequest?.url.absoluteString.contains("ignored-key") == false)
+        #expect(client.lastRequest?.headers["authorization"] == nil)
+    }
+
+    @Test("resolved auth ignores mismatched query key names")
+    func resolvedAuthMismatchedQueryKeyName() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = GoogleGeminiProvider(client: client, defaultAPIKey: "default-key")
+        _ = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                resolvedAuth: ResolvedProviderAuth(token: "resolved-key", scheme: .queryKey(name: "api_key"))
+            )
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(client.lastRequest?.url.absoluteString.contains("resolved-key") == false)
+        #expect(client.lastRequest?.headers["authorization"] == nil)
+    }
+
     @Test("encodes tools as functionDeclarations + systemInstruction")
     func bodyEncoding() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -250,7 +250,7 @@ struct OAuthManagerTests {
         }
     }
 
-    @Test("resolver() returns an agent-compatible api-key closure") func resolverShape() async throws {
+    @Test("resolver() returns an agent-compatible auth closure") func resolverShape() async throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -262,7 +262,37 @@ struct OAuthManagerTests {
         )
         let manager = OAuthManager(store: store, providers: [AnthropicOAuthProvider()])
         let resolver = manager.resolver()
-        #expect(await resolver("anthropic") == "static")
-        #expect(await resolver("unknown-xyz") == nil)
+        let model = Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
+        let auth = await resolver(model, nil)
+        #expect(auth?.token == "static")
+        #expect(auth?.scheme == .bearer)
+        let unknown = Model(id: "unknown", api: "unknown", provider: "unknown-xyz")
+        #expect(await resolver(unknown, nil) == nil)
+    }
+
+    @Test("resolver() includes GitHub Copilot endpoint as baseURL") func resolverPreservesCopilotEndpoint() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let endpoint = "https://api.business.githubcopilot.com"
+        let store = OAuthStore(url: tmp)
+        try await store.set(
+            OAuthCredentials(
+                access: "session-token",
+                refresh: "ghp_pat",
+                expires: Int64.max / 2,
+                extras: ["endpoint": .string(endpoint)]
+            ),
+            for: "github-copilot"
+        )
+        let manager = OAuthManager(store: store, providers: [GitHubCopilotOAuthProvider()])
+        let resolver = manager.resolver()
+        let model = Model(id: "gpt-4.1", api: "openai-completions", provider: "github-copilot")
+
+        let auth = await resolver(model, nil)
+        #expect(auth?.token == "session-token")
+        #expect(auth?.scheme == .bearer)
+        #expect(auth?.baseURL == endpoint)
     }
 }

--- a/Tests/KWWKAITests/OpenAICompletionsTests.swift
+++ b/Tests/KWWKAITests/OpenAICompletionsTests.swift
@@ -104,6 +104,22 @@ struct OpenAICompletionsTests {
         #expect(client.lastRequest?.headers["authorization"] == "Bearer sk-override")
     }
 
+    @Test("resolved auth overrides apiKey and default key")
+    func resolvedAuthHeader() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAICompletionsProvider(client: client, defaultAPIKey: "sk-default")
+        _ = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                apiKey: "sk-ignored",
+                resolvedAuth: ResolvedProviderAuth(token: "sk-resolved", scheme: .bearer)
+            )
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(client.lastRequest?.headers["authorization"] == "Bearer sk-resolved")
+    }
+
     @Test("encodes parallel_tool_calls=false + tool_choice at the root")
     func parallelOffEncoding() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -137,6 +137,29 @@ struct OpenAIResponsesTests {
         } else { Issue.record("expected text last") }
     }
 
+    @Test("resolved auth can select custom API key header")
+    func resolvedAuthCustomAPIKeyHeader() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "sk-default")
+        _ = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(
+                apiKey: "sk-ignored",
+                resolvedAuth: ResolvedProviderAuth(
+                    token: "azure-key",
+                    scheme: .apiKeyHeader(name: "api-key"),
+                    headers: ["x-ms-client-request-id": "req-1"]
+                )
+            )
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let headers = client.lastRequest?.headers ?? [:]
+        #expect(headers["authorization"] == nil)
+        #expect(headers["api-key"] == "azure-key")
+        #expect(headers["x-ms-client-request-id"] == "req-1")
+    }
+
     @Test("encodes input array with instructions + tools")
     func bodyEncoding() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAgentTests/AgentTests.swift
+++ b/Tests/KWWKAgentTests/AgentTests.swift
@@ -382,6 +382,58 @@ struct AgentIntegrationTests {
         #expect(events.first?.message == "connected")
         #expect(events.first?.metadata["attempt"] == .int(1))
     }
+
+    @Test("resolves provider auth per session before streaming")
+    func resolvesProviderAuthBeforeStreaming() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let capture = StreamAuthCapture()
+        let streamFn: StreamFn = { model, _, options in
+            await capture.record(model: model, options: options)
+            let message = AssistantMessage(
+                content: [.text(TextContent(text: "ok"))],
+                api: model.api,
+                provider: model.provider,
+                model: model.id
+            )
+            let stream = AssistantMessageStream()
+            stream.push(.start(partial: message))
+            stream.push(.textStart(contentIndex: 0, partial: message))
+            stream.push(.textDelta(contentIndex: 0, delta: "ok", partial: message))
+            stream.push(.textEnd(contentIndex: 0, content: "ok", partial: message))
+            stream.push(.done(reason: .stop, message: message))
+            stream.end(message)
+            return stream
+        }
+        let agent = Agent(options: AgentOptions(
+            initialState: AgentInitialState(model: registration.getModel()),
+            streamFn: streamFn,
+            sessionId: "session-auth",
+            authResolver: { model, sessionId in
+                await capture.recordResolver(model: model, sessionId: sessionId)
+                return ResolvedProviderAuth(
+                    token: "resolved-token",
+                    scheme: .bearer,
+                    baseURL: "https://proxy.example",
+                    metadata: ["deployment": .string("prod")]
+                )
+            }
+        ))
+
+        try await agent.prompt("hi")
+
+        let resolved = await capture.resolved
+        let streamed = await capture.streamed
+        #expect(resolved?.model.id == registration.getModel().id)
+        #expect(resolved?.sessionId == "session-auth")
+        #expect(streamed?.model.baseUrl == "https://proxy.example")
+        #expect(streamed?.options?.apiKey == "resolved-token")
+        #expect(streamed?.options?.sessionId == "session-auth")
+        #expect(streamed?.options?.resolvedAuth?.scheme == .bearer)
+        #expect(streamed?.options?.resolvedAuth?.token == "resolved-token")
+        #expect(streamed?.options?.metadata?["deployment"] == .string("prod"))
+    }
 }
 
 @Suite("Agent.continue")
@@ -525,6 +577,19 @@ actor VerboseEventLog {
     var log: [VerboseEvent] = []
     func append(_ event: VerboseEvent) { log.append(event) }
     func values() -> [VerboseEvent] { log }
+}
+
+actor StreamAuthCapture {
+    var resolved: (model: Model, sessionId: String?)?
+    var streamed: (model: Model, options: StreamOptions?)?
+
+    func recordResolver(model: Model, sessionId: String?) {
+        resolved = (model, sessionId)
+    }
+
+    func record(model: Model, options: StreamOptions?) {
+        streamed = (model, options)
+    }
 }
 
 actor AsyncBarrier {

--- a/Tests/KWWKAgentTests/SystemPromptTests.swift
+++ b/Tests/KWWKAgentTests/SystemPromptTests.swift
@@ -8,11 +8,6 @@ struct SystemPromptTests {
     func defaultPrompt() {
         let prompt = buildSystemPrompt(SystemPromptOptions(
             cwd: "/tmp/project",
-            selectedToolNames: ["read", "bash"],
-            toolSnippets: [
-                "read": "Read file contents",
-                "bash": "Execute shell commands",
-            ],
             date: "2024-06-15"
         ))
         #expect(prompt.contains("operating inside kwwk"))
@@ -25,23 +20,9 @@ struct SystemPromptTests {
 
     @Test("does not render a synthetic tool list")
     func hiddenTools() {
-        let prompt = buildSystemPrompt(SystemPromptOptions(
-            cwd: "/tmp",
-            selectedToolNames: ["read"],
-            toolSnippets: [:]
-        ))
+        let prompt = buildSystemPrompt(SystemPromptOptions(cwd: "/tmp"))
         #expect(!prompt.contains("(none)"))
         #expect(!prompt.contains("Available tools:"))
-    }
-
-    @Test("prefers grep/find/ls over bash when all are present")
-    func preferenceGuideline() {
-        let prompt = buildSystemPrompt(SystemPromptOptions(
-            cwd: "/tmp",
-            selectedToolNames: ["bash", "grep", "find", "ls", "read", "write", "edit"],
-            toolSnippets: DefaultToolSnippets.all
-        ))
-        #expect(prompt.contains("Prefer grep/find/ls tools over bash for file exploration"))
     }
 
     @Test("customPrompt replaces the default body and keeps metadata")
@@ -62,8 +43,6 @@ struct SystemPromptTests {
     func contextFiles() {
         let prompt = buildSystemPrompt(SystemPromptOptions(
             cwd: "/a",
-            selectedToolNames: ["read"],
-            toolSnippets: ["read": "Read file contents"],
             contextFiles: [
                 (path: "CLAUDE.md", content: "be helpful"),
                 (path: "AGENTS.md", content: "use tools"),

--- a/Tests/KWWKCliTests/CompactCommandTests.swift
+++ b/Tests/KWWKCliTests/CompactCommandTests.swift
@@ -133,6 +133,57 @@ struct CompactCommandTests {
     }
 
     @MainActor
+    @Test("compact passes the active session to auth resolution and streaming")
+    func compactUsesSessionBoundAuth() async {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+
+        let capture = CompactAuthCapture()
+        faux.setResponses([
+            .factory { _, options, _, _ in
+                capture.recordStream(
+                    sessionId: options?.sessionId,
+                    token: options?.resolvedAuth?.token
+                )
+                return fauxAssistantMessage("session-bound recap")
+            }
+        ])
+
+        let messages: [Message] = [
+            .user(UserMessage(content: [.text(TextContent(text: "one"))])),
+            .assistant(fauxAssistantMessage("two")),
+            .user(UserMessage(content: [.text(TextContent(text: "three"))])),
+            .assistant(fauxAssistantMessage("four")),
+        ]
+        let agent = Agent(options: AgentOptions(
+            initialState: AgentInitialState(
+                model: faux.getModel(),
+                messages: messages
+            ),
+            authResolver: { model, sessionId in
+                capture.recordResolver(provider: model.provider, sessionId: sessionId)
+                return ResolvedProviderAuth(token: "session-token", scheme: .bearer)
+            }
+        ))
+
+        let outcome = await performCompact(
+            agent: agent,
+            backgroundManager: BackgroundTaskManager(outputDir: makeTempDir()),
+            sessionId: "compact-session"
+        )
+
+        if case .compacted = outcome {
+            // Expected.
+        } else {
+            Issue.record("expected compaction to succeed")
+        }
+        #expect(capture.resolverProvider == faux.provider)
+        #expect(capture.resolverSessionId == "compact-session")
+        #expect(capture.streamSessionId == "compact-session")
+        #expect(capture.streamToken == "session-token")
+    }
+
+    @MainActor
     @Test("renderCompactBoundary fills the width with a compacted rule")
     func renderCompactBoundaryShape() {
         let lines = renderCompactBoundary(
@@ -210,4 +261,26 @@ final class CommitBox {
     }
 
     var joined: String { lines.joined(separator: "\n") }
+}
+
+private final class CompactAuthCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var resolverProvider: String?
+    private(set) var resolverSessionId: String?
+    private(set) var streamSessionId: String?
+    private(set) var streamToken: String?
+
+    func recordResolver(provider: String, sessionId: String?) {
+        lock.withLock {
+            resolverProvider = provider
+            resolverSessionId = sessionId
+        }
+    }
+
+    func recordStream(sessionId: String?, token: String?) {
+        lock.withLock {
+            streamSessionId = sessionId
+            streamToken = token
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace provider-name apiKeyResolver with a model/session authResolver returning ResolvedProviderAuth
- support bearer, custom API-key headers, query-key auth, per-request baseURL overrides, and auth metadata
- simplify system prompt options by removing tool-list and tool-snippet parameters

## Testing
- swift test