### PR TITLE
[codex] Fix Codex Spark tool arguments

### DIFF
--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -493,8 +493,12 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                             if case .string(let v) = item["id"] ?? .null { return v }
                             return ""
                         }()
+                        let arguments: String = {
+                            if case .string(let v) = item["arguments"] ?? .null { return v }
+                            return ""
+                        }()
                         let index = state.noteFunctionCallItem(
-                            outputIndex: outputIndex, callId: callId, name: name
+                            outputIndex: outputIndex, callId: callId, name: name, arguments: arguments
                         )
                         if !emittedStart {
                             out.push(.start(partial: state.snapshot()))
@@ -556,6 +560,29 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
 
             case "response.output_item.done":
                 if case .int(let outputIndex) = obj["output_index"] ?? .null {
+                    if case .object(let item) = obj["item"] ?? .null,
+                       case .string(let itemType) = item["type"] ?? .null,
+                       itemType == "function_call" {
+                        let callId: String? = {
+                            if case .string(let v) = item["call_id"] ?? .null { return v }
+                            if case .string(let v) = item["id"] ?? .null { return v }
+                            return nil
+                        }()
+                        let name: String? = {
+                            if case .string(let v) = item["name"] ?? .null { return v }
+                            return nil
+                        }()
+                        let arguments: String? = {
+                            if case .string(let v) = item["arguments"] ?? .null { return v }
+                            return nil
+                        }()
+                        state.updateFunctionCallItem(
+                            outputIndex: outputIndex,
+                            callId: callId,
+                            name: name,
+                            arguments: arguments
+                        )
+                    }
                     if let index = state.reasoningIndex(for: outputIndex) {
                         let content = state.thinkingValue(at: index)
                         out.push(.thinkingEnd(contentIndex: index, content: content, partial: state.snapshot()))
@@ -1148,14 +1175,27 @@ final class OpenAIResponsesState: @unchecked Sendable {
         }
     }
 
-    func noteFunctionCallItem(outputIndex: Int, callId: String, name: String) -> Int {
+    func noteFunctionCallItem(outputIndex: Int, callId: String, name: String, arguments: String = "") -> Int {
         lock.withLock {
             if let existing = toolCallByOutput[outputIndex] { return existing }
             let idx = order.count
             toolCallByOutput[outputIndex] = idx
             order.append(idx)
-            blocks[idx] = .toolUse(id: callId, name: name, json: "")
+            blocks[idx] = .toolUse(id: callId, name: name, json: arguments)
             return idx
+        }
+    }
+
+    func updateFunctionCallItem(outputIndex: Int, callId: String?, name: String?, arguments: String?) {
+        lock.withLock {
+            guard let index = toolCallByOutput[outputIndex],
+                  case .toolUse(let currentId, let currentName, let currentJSON) = blocks[index]
+            else { return }
+            blocks[index] = .toolUse(
+                id: callId ?? currentId,
+                name: name ?? currentName,
+                json: arguments ?? currentJSON
+            )
         }
     }
 

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -50,6 +50,17 @@ struct OpenAIResponsesTests {
 
     """
 
+    static let toolUseDoneArgumentsSSE = """
+    data: {"type":"response.created","response":{"id":"resp_4","status":"in_progress"}}
+
+    data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"calc","arguments":""}}
+
+    data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"calc","arguments":"{\\"a\\":1,\\"b\\":2}"}}
+
+    data: {"type":"response.completed","response":{"id":"resp_4","status":"completed","usage":{"input_tokens":12,"output_tokens":8}}}
+
+    """
+
     static let reasoningSSE = """
     data: {"type":"response.created","response":{"id":"resp_3","status":"in_progress"}}
 
@@ -97,6 +108,29 @@ struct OpenAIResponsesTests {
     @Test("streams function_call with incremental arguments")
     func toolUse() async throws {
         let client = StubSSEClient(body: Self.toolUseSSE)
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "go"))]),
+            options: nil
+        )
+        var seenEnd = false
+        for await event in s {
+            if case .toolCallEnd(_, let call, _) = event {
+                #expect(call.id == "call_1")
+                #expect(call.name == "calc")
+                #expect(call.arguments == .object(["a": 1, "b": 2]))
+                seenEnd = true
+            }
+        }
+        let result = await s.result()
+        #expect(seenEnd)
+        #expect(result.stopReason == .toolUse)
+    }
+
+    @Test("reads function_call arguments from output_item.done")
+    func toolUseDoneArguments() async throws {
+        let client = StubSSEClient(body: Self.toolUseDoneArgumentsSSE)
         let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
         let s = provider.stream(
             model: Self.model,


### PR DESCRIPTION
## Summary
- Preserve function call arguments when Responses streams provide them on output_item.added or output_item.done
- Add a regression test for the Spark-style done item argument payload

## Root cause
Codex Spark can return function_call arguments as the completed output item instead of streaming response.function_call_arguments.delta events. The parser only accumulated delta chunks, so the stored JSON stayed empty and tool calls executed with {}.

## Validation
- swift test --filter OpenAIResponsesTests