### PR TITLE
Fix OpenAI-compatible provider routing

### DIFF
--- a/Sources/KWWKAI/AuthHeaders.swift
+++ b/Sources/KWWKAI/AuthHeaders.swift
@@ -15,10 +15,18 @@ func applyResolvedAuth(
     case .none, .queryKey:
         break
     case .bearer:
-        merge(&headers, "authorization", "Bearer \(token)")
+        merge(&headers, "Authorization", bearerHeaderValue(token))
     case .apiKeyHeader(let name):
         merge(&headers, name, token)
     }
+}
+
+func bearerHeaderValue(_ token: String) -> String {
+    let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.range(of: "Bearer ", options: [.anchored, .caseInsensitive]) != nil {
+        return trimmed
+    }
+    return "Bearer \(trimmed)"
 }
 
 func resolvedQueryKey(_ auth: ResolvedProviderAuth?, expectedName: String) -> String? {

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -64,7 +64,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             return URL(string: "\(versioned)/chat/completions")
                 ?? fallback.appendingPathComponent("v1/chat/completions")
         }
-        self.authHeaderBuilder = authHeaderBuilder ?? { key in ["authorization": "Bearer \(key)"] }
+        self.authHeaderBuilder = authHeaderBuilder ?? { key in ["Authorization": bearerHeaderValue(key)] }
         self.bodyDecorator = bodyDecorator
         self.headersDecorator = headersDecorator
     }
@@ -115,9 +115,10 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
                 url: url, method: "POST", headers: headers, body: body
             )
             if response.statusCode >= 400 {
+                let bodyText = await Self.errorBodyPreview(from: stream)
                 let msg = Self.makeError(
                     api: api, model: model,
-                    text: "OpenAI returned status \(response.statusCode)"
+                    text: "OpenAI returned status \(response.statusCode)\(bodyText)"
                 )
                 out.push(.error(reason: .error, error: msg))
                 out.end(msg)
@@ -388,6 +389,28 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             errorMessage: text,
             timestamp: Timestamp.now()
         )
+    }
+
+    private static func errorBodyPreview(
+        from stream: AsyncThrowingStream<UInt8, Error>,
+        limit: Int = 4096
+    ) async -> String {
+        var data = Data()
+        do {
+            for try await byte in stream {
+                data.append(byte)
+                if data.count >= limit {
+                    break
+                }
+            }
+        } catch {
+            return ": failed to read error body: \(error)"
+        }
+        guard !data.isEmpty else { return "" }
+        let text = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return "" }
+        return ": \(text)"
     }
 }
 

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -75,7 +75,7 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             }
             return components?.url ?? httpURL
         }
-        self.authHeaderBuilder = authHeaderBuilder ?? { key in ["authorization": "Bearer \(key)"] }
+        self.authHeaderBuilder = authHeaderBuilder ?? { key in ["Authorization": bearerHeaderValue(key)] }
     }
 
     public func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream {

--- a/Sources/KWWKAI/ProviderVariants.swift
+++ b/Sources/KWWKAI/ProviderVariants.swift
@@ -152,7 +152,7 @@ public enum ProviderVariants {
         sessionToken: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
         integrationID: String = "vscode-chat",
-        api: String = "openai-completions",
+        api: String = "github-copilot-chat",
         baseURL: URL = URL(string: "https://api.githubcopilot.com")!
     ) -> OpenAICompletionsProvider {
         let baseString = baseURL.absoluteString.trimmedSlashes

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -216,7 +216,7 @@ struct AnthropicProviderTests {
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
         let headers = client.lastRequest?.headers ?? [:]
-        #expect(headers["authorization"] == "Bearer oauth-token")
+        #expect(headers["Authorization"] == "Bearer oauth-token")
         #expect(headers["x-api-key"] == nil)
         #expect(headers["anthropic-beta"] == "oauth-2025-04-20")
         #expect(headers["x-extra"] == "override")

--- a/Tests/KWWKAITests/OpenAICompletionsTests.swift
+++ b/Tests/KWWKAITests/OpenAICompletionsTests.swift
@@ -101,7 +101,7 @@ struct OpenAICompletionsTests {
             options: StreamOptions(apiKey: "sk-override")
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
-        #expect(client.lastRequest?.headers["authorization"] == "Bearer sk-override")
+        #expect(client.lastRequest?.headers["Authorization"] == "Bearer sk-override")
     }
 
     @Test("resolved auth overrides apiKey and default key")
@@ -117,7 +117,7 @@ struct OpenAICompletionsTests {
             )
         )
         try? await Task.sleep(nanoseconds: 20_000_000)
-        #expect(client.lastRequest?.headers["authorization"] == "Bearer sk-resolved")
+        #expect(client.lastRequest?.headers["Authorization"] == "Bearer sk-resolved")
     }
 
     @Test("encodes parallel_tool_calls=false + tool_choice at the root")

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -308,7 +308,7 @@ struct OpenAIResponsesTests {
         #expect(ws.connectCount == 1)
         #expect(http.lastRequest == nil)
         #expect(ws.lastURL?.absoluteString == "wss://api.openai.com/v1/responses")
-        #expect(ws.lastHeaders["authorization"] == "Bearer k")
+        #expect(ws.lastHeaders["Authorization"] == "Bearer k")
         #expect(ws.lastHeaders["OpenAI-Beta"] == "responses_websockets=2026-02-06")
 
         let payload = try Self.jsonObject(connection.sentTexts[0])


### PR DESCRIPTION
## Summary
- route GitHub Copilot chat completions through a dedicated `github-copilot-chat` API key so it no longer overrides generic `openai-completions` providers
- normalize Bearer auth header generation for OpenAI-compatible providers and avoid double-prefixing already formatted tokens
- surface OpenAI Chat Completions HTTP error bodies to make provider configuration failures debuggable

## Validation
- `cd kwwk && swift test` (provider-related tests passed before the suite hit existing unrelated failures in `EscapeKeyFlushTests.swift` and `BackgroundTaskManagerTests.swift:460`)
- OpenBridge UnsignedDebug build succeeded with this kwwk commit
- Manual OpenBridge check: custom OpenAI Chat Completions endpoint routed to its configured base URL instead of GitHub Copilot
