### PR TITLE
chore: run tests in CI and pin SwiftPM dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: swift build
         run: swift build --product kwwk
+      - name: swift test
+        run: swift test
 
   build-linux:
     runs-on: ubuntu-latest
@@ -20,3 +22,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: swift build
         run: swift build --product kwwk
+      - name: swift test
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 xcuserdata/
 DerivedData/
 .swiftpm/
-Package.resolved
 *.xcodeproj
 .vscode/
 .claude/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash" : "d022f6922ac40a7dfe5d0f83b23a39084b4cf759088b37e8bf00b696a72da282",
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Swift-native coding agent with two faces:
 ## Requirements
 
 - macOS 14+
-- Swift 6.0 toolchain (Xcode 16 or the matching `swift` toolchain)
+- Swift 6.1 toolchain (Xcode 16.3+ or the matching `swift` toolchain)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `swift test` to macOS and Linux CI jobs (414 tests, no live-network tests without env vars).
- Align README requirements with Swift 6.1 / CI container.
- Commit `Package.resolved` for reproducible dependency resolution.

## Test plan
- [x] `swift test` locally (414 passed)

Made with [Cursor](https://cursor.com)