### PR TITLE
fix(tests): import FoundationNetworking on Linux

### DIFF
--- a/Tests/KWWKAITests/AWSSigV4Tests.swift
+++ b/Tests/KWWKAITests/AWSSigV4Tests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import KWWKAI
 

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import KWWKAI
 

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import KWWKAI
 

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import KWWKAI
 


### PR DESCRIPTION
## Summary
Linux CI failed after adding `swift test` because KWWKAITests stubs use `HTTPURLResponse`, which on Linux requires `FoundationNetworking` (same pattern as `Sources/KWWKAI/HTTPClient.swift`).

## Test plan
- [x] `swift test` on macOS (414 passed)

Made with [Cursor](https://cursor.com)