### PR TITLE
fix(tests): widen async wait budgets on CI runners

### DIFF
--- a/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
+++ b/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
@@ -262,7 +262,8 @@ struct BackgroundTaskManagerTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         // Squeeze the watchdog timing so the test runs in under a second.
-        await manager.setStallTiming(intervalSeconds: 1, thresholdSeconds: 0.05)
+        let stallInterval: UInt64 = ProcessInfo.processInfo.environment["CI"] != nil ? 2 : 1
+        await manager.setStallTiming(intervalSeconds: stallInterval, thresholdSeconds: 0.05)
 
         // Runner writes a prompt-shaped tail, then holds the pane forever so
         // no new output arrives — simulating a command stuck on interactive
@@ -286,7 +287,7 @@ struct BackgroundTaskManagerTests {
         }
         let (taskId, _) = await manager.spawn(runner: PromptRunner(), sessionId: "s1")
 
-        let ok = await awaitUntil(3000) {
+        let ok = await awaitUntil(5000) {
             await manager.hasNotifications(sessionId: "s1")
         }
         #expect(ok)

--- a/Tests/KWWKAgentTests/BashBackgroundTests.swift
+++ b/Tests/KWWKAgentTests/BashBackgroundTests.swift
@@ -10,10 +10,16 @@ func makeTempDir() -> URL {
     return dir
 }
 
+private var isCIRunner: Bool {
+    ProcessInfo.processInfo.environment["CI"] == "true"
+        || ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
+}
+
 func awaitUntil(
     _ budgetMs: Int,
     _ predicate: @Sendable () async -> Bool
 ) async -> Bool {
+    let budgetMs = isCIRunner ? max(budgetMs * 10, budgetMs + 5000) : budgetMs
     let start = Date()
     while Date().timeIntervalSince(start) * 1000 < Double(budgetMs) {
         if await predicate() { return true }


### PR DESCRIPTION
## Summary
- Scale `awaitUntil` timeouts 10× (min +5s) when `CI` or `GITHUB_ACTIONS` is set.
- Relax stall-watchdog test pacing on CI.

Fixes flaky failures after adding `swift test` to CI (#14).

## Test plan
- [x] `CI=true swift test` locally (414 passed)

Made with [Cursor](https://cursor.com)