### PR TITLE
[codex] Update model catalog

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -59,26 +59,6 @@
       "provider" : "amazon-bedrock",
       "reasoning" : false
     },
-    "amazon.nova-premier-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 12.5
-      },
-      "id" : "amazon.nova-premier-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Nova Premier",
-      "provider" : "amazon-bedrock",
-      "reasoning" : true
-    },
     "amazon.nova-pro-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -96,106 +76,6 @@
       ],
       "maxTokens" : 8192,
       "name" : "Nova Pro",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "anthropic.claude-3-5-haiku-20241022-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.080000000000000002,
-        "cacheWrite" : 1,
-        "input" : 0.80000000000000004,
-        "output" : 4
-      },
-      "id" : "anthropic.claude-3-5-haiku-20241022-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Haiku 3.5",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "anthropic.claude-3-5-sonnet-20240620-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Sonnet 3.5",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "anthropic.claude-3-5-sonnet-20241022-v2:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Sonnet 3.5 v2",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "anthropic.claude-3-7-sonnet-20250219-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic.claude-3-7-sonnet-20250219-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Sonnet 3.7",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "anthropic.claude-3-haiku-20240307-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 1.25
-      },
-      "id" : "anthropic.claude-3-haiku-20240307-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Claude Haiku 3",
       "provider" : "amazon-bedrock",
       "reasoning" : false
     },
@@ -305,25 +185,28 @@
         "xhigh" : "xhigh"
       }
     },
-    "anthropic.claude-opus-4-20250514-v1:0" : {
+    "anthropic.claude-opus-4-8" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1.5,
-        "cacheWrite" : 18.75,
-        "input" : 15,
-        "output" : 75
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
       },
-      "id" : "anthropic.claude-opus-4-20250514-v1:0",
+      "id" : "anthropic.claude-opus-4-8",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 32000,
-      "name" : "Claude Opus 4",
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -365,23 +248,23 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
-    "anthropic.claude-sonnet-4-20250514-v1:0" : {
+    "au.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 5
       },
-      "id" : "anthropic.claude-sonnet-4-20250514-v1:0",
+      "id" : "au.anthropic.claude-haiku-4-5-20251001-v1:0",
       "input" : [
         "text",
         "image"
       ],
       "maxTokens" : 64000,
-      "name" : "Claude Sonnet 4",
+      "name" : "Claude Haiku 4.5 (AU)",
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
@@ -407,6 +290,49 @@
       "thinkingLevelMap" : {
         "xhigh" : "max"
       }
+    },
+    "au.anthropic.claude-opus-4-8" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "au.anthropic.claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8 (AU)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "au.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.29999999999999999,
+        "cacheWrite" : 3.75,
+        "input" : 3,
+        "output" : 15
+      },
+      "id" : "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Claude Sonnet 4.5 (AU)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true
     },
     "au.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
@@ -571,6 +497,29 @@
         "xhigh" : "xhigh"
       }
     },
+    "eu.anthropic.claude-opus-4-8" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "eu.anthropic.claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8 (EU)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
@@ -608,26 +557,6 @@
       ],
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (EU)",
-      "provider" : "amazon-bedrock",
-      "reasoning" : true
-    },
-    "eu.anthropic.claude-sonnet-4-20250514-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "eu.anthropic.claude-sonnet-4-20250514-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Claude Sonnet 4 (EU)",
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
@@ -717,6 +646,29 @@
         "xhigh" : "xhigh"
       }
     },
+    "global.anthropic.claude-opus-4-8" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "global.anthropic.claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8 (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -754,26 +706,6 @@
       ],
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (Global)",
-      "provider" : "amazon-bedrock",
-      "reasoning" : true
-    },
-    "global.anthropic.claude-sonnet-4-20250514-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "global.anthropic.claude-sonnet-4-20250514-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Claude Sonnet 4 (Global)",
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
@@ -817,6 +749,92 @@
       "provider" : "amazon-bedrock",
       "reasoning" : false
     },
+    "jp.anthropic.claude-opus-4-7" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "jp.anthropic.claude-opus-4-7",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.7 (JP)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "jp.anthropic.claude-opus-4-8" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "jp.anthropic.claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8 (JP)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "jp.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.29999999999999999,
+        "cacheWrite" : 3.75,
+        "input" : 3,
+        "output" : 15
+      },
+      "id" : "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Claude Sonnet 4.5 (JP)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true
+    },
+    "jp.anthropic.claude-sonnet-4-6" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.29999999999999999,
+        "cacheWrite" : 3.75,
+        "input" : 3,
+        "output" : 15
+      },
+      "id" : "jp.anthropic.claude-sonnet-4-6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Claude Sonnet 4.6 (JP)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true
+    },
     "meta.llama3-1-8b-instruct-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -852,103 +870,6 @@
       ],
       "maxTokens" : 4096,
       "name" : "Llama 3.1 70B Instruct",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "meta.llama3-1-405b-instruct-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 2.3999999999999999,
-        "output" : 2.3999999999999999
-      },
-      "id" : "meta.llama3-1-405b-instruct-v1:0",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.1 405B Instruct",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "meta.llama3-2-1b-instruct-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 131000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
-      },
-      "id" : "meta.llama3-2-1b-instruct-v1:0",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.2 1B Instruct",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "meta.llama3-2-3b-instruct-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 131000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
-      },
-      "id" : "meta.llama3-2-3b-instruct-v1:0",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.2 3B Instruct",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "meta.llama3-2-11b-instruct-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.16,
-        "output" : 0.16
-      },
-      "id" : "meta.llama3-2-11b-instruct-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.2 11B Instruct",
-      "provider" : "amazon-bedrock",
-      "reasoning" : false
-    },
-    "meta.llama3-2-90b-instruct-v1:0" : {
-      "api" : "bedrock-converse-stream",
-      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
-      },
-      "id" : "meta.llama3-2-90b-instruct-v1:0",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.2 90B Instruct",
       "provider" : "amazon-bedrock",
       "reasoning" : false
     },
@@ -1246,7 +1167,7 @@
     "moonshot.kimi-k2-thinking" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 256000,
+      "contextWindow" : 262143,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -1257,7 +1178,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 256000,
+      "maxTokens" : 16000,
       "name" : "Kimi K2 Thinking",
       "provider" : "amazon-bedrock",
       "reasoning" : true
@@ -1265,7 +1186,7 @@
     "moonshotai.kimi-k2.5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 256000,
+      "contextWindow" : 262143,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -1277,7 +1198,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 256000,
+      "maxTokens" : 16000,
       "name" : "Kimi K2.5",
       "provider" : "amazon-bedrock",
       "reasoning" : true
@@ -1373,7 +1294,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "gpt-oss-20b",
       "provider" : "amazon-bedrock",
       "reasoning" : false
@@ -1392,7 +1313,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "gpt-oss-120b",
       "provider" : "amazon-bedrock",
       "reasoning" : false
@@ -1411,7 +1332,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "GPT OSS Safeguard 20B",
       "provider" : "amazon-bedrock",
       "reasoning" : false
@@ -1430,7 +1351,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "GPT OSS Safeguard 120B",
       "provider" : "amazon-bedrock",
       "reasoning" : false
@@ -1675,25 +1596,28 @@
         "xhigh" : "xhigh"
       }
     },
-    "us.anthropic.claude-opus-4-20250514-v1:0" : {
+    "us.anthropic.claude-opus-4-8" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1.5,
-        "cacheWrite" : 18.75,
-        "input" : 15,
-        "output" : 75
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
       },
-      "id" : "us.anthropic.claude-opus-4-20250514-v1:0",
+      "id" : "us.anthropic.claude-opus-4-8",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 32000,
-      "name" : "Claude Opus 4 (US)",
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8 (US)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -1735,25 +1659,64 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
-    "us.anthropic.claude-sonnet-4-20250514-v1:0" : {
+    "us.deepseek.r1-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "contextWindow" : 200000,
+      "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.3500000000000001,
+        "output" : 5.4000000000000004
       },
-      "id" : "us.anthropic.claude-sonnet-4-20250514-v1:0",
+      "id" : "us.deepseek.r1-v1:0",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "DeepSeek-R1 (US)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true
+    },
+    "us.meta.llama4-maverick-17b-instruct-v1:0" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.23999999999999999,
+        "output" : 0.96999999999999997
+      },
+      "id" : "us.meta.llama4-maverick-17b-instruct-v1:0",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 64000,
-      "name" : "Claude Sonnet 4 (US)",
+      "maxTokens" : 16384,
+      "name" : "Llama 4 Maverick 17B Instruct (US)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : false
+    },
+    "us.meta.llama4-scout-17b-instruct-v1:0" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 3500000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.17000000000000001,
+        "output" : 0.66000000000000003
+      },
+      "id" : "us.meta.llama4-scout-17b-instruct-v1:0",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "Llama 4 Scout 17B Instruct (US)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : false
     },
     "writer.palmyra-x4-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -2155,6 +2118,9 @@
     "claude-opus-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -2178,6 +2144,9 @@
     "claude-opus-4-7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -2192,6 +2161,32 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 4.7",
+      "provider" : "anthropic",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "claude-opus-4-8" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8",
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -2281,6 +2276,9 @@
     "claude-sonnet-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.29999999999999999,
@@ -2404,7 +2402,7 @@
       "baseUrl" : "",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
         "input" : 0.10000000000000001,
         "output" : 0.40000000000000002
@@ -2504,7 +2502,7 @@
       "baseUrl" : "",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
         "input" : 0.14999999999999999,
         "output" : 0.59999999999999998
@@ -2662,7 +2660,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0.125,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 10
@@ -3080,6 +3078,8 @@
       "provider" : "azure-openai-responses",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "low" : null,
+        "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -3208,7 +3208,7 @@
       "baseUrl" : "",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.28000000000000003,
+        "cacheRead" : 0.27500000000000002,
         "cacheWrite" : 0,
         "input" : 1.1000000000000001,
         "output" : 4.4000000000000004
@@ -3280,25 +3280,6 @@
       ],
       "maxTokens" : 8000,
       "name" : "Llama 3.1 8B",
-      "provider" : "cerebras",
-      "reasoning" : false
-    },
-    "qwen-3-235b-a22b-instruct-2507" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.cerebras.ai\/v1",
-      "contextWindow" : 131000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 1.2
-      },
-      "id" : "qwen-3-235b-a22b-instruct-2507",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32000,
-      "name" : "Qwen 3 235B Instruct",
       "provider" : "cerebras",
       "reasoning" : false
     },
@@ -3526,6 +3507,9 @@
     "claude-opus-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -3549,6 +3533,9 @@
     "claude-opus-4-7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -3612,6 +3599,9 @@
     "claude-sonnet-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.29999999999999999,
@@ -4088,13 +4078,57 @@
       "provider" : "cloudflare-workers-ai",
       "reasoning" : true
     },
+    "@cf\/ibm-granite\/granite-4.0-h-micro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true
+      },
+      "contextWindow" : 131000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.017000000000000001,
+        "output" : 0.112
+      },
+      "id" : "@cf\/ibm-granite\/granite-4.0-h-micro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131000,
+      "name" : "Granite 4.0 H Micro",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : false
+    },
+    "@cf\/meta\/llama-3.3-70b-instruct-fp8-fast" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true
+      },
+      "contextWindow" : 24000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.29299999999999998,
+        "output" : 2.2530000000000001
+      },
+      "id" : "@cf\/meta\/llama-3.3-70b-instruct-fp8-fast",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 24000,
+      "name" : "Llama 3.3 70B Instruct fp8 Fast",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : false
+    },
     "@cf\/meta\/llama-4-scout-17b-16e-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
       "compat" : {
         "sendSessionAffinityHeaders" : true
       },
-      "contextWindow" : 128000,
+      "contextWindow" : 131000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -4108,6 +4142,28 @@
       ],
       "maxTokens" : 16384,
       "name" : "Llama 4 Scout 17B 16E Instruct",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : false
+    },
+    "@cf\/mistralai\/mistral-small-3.1-24b-instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.35099999999999998,
+        "output" : 0.55500000000000005
+      },
+      "id" : "@cf\/mistralai\/mistral-small-3.1-24b-instruct",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Mistral Small 3.1 24B Instruct",
       "provider" : "cloudflare-workers-ai",
       "reasoning" : false
     },
@@ -4140,7 +4196,7 @@
       "compat" : {
         "sendSessionAffinityHeaders" : true
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
@@ -4223,6 +4279,28 @@
       "provider" : "cloudflare-workers-ai",
       "reasoning" : true
     },
+    "@cf\/qwen\/qwen3-30b-a3b-fp8" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true
+      },
+      "contextWindow" : 32768,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.050900000000000001,
+        "output" : 0.33500000000000002
+      },
+      "id" : "@cf\/qwen\/qwen3-30b-a3b-fp8",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Qwen3 30B A3b fp8",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true
+    },
     "@cf\/zai-org\/glm-4.7-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
@@ -4233,7 +4311,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.060499999999999998,
         "output" : 0.40000000000000002
       },
       "id" : "@cf\/zai-org\/glm-4.7-flash",
@@ -4309,50 +4387,43 @@
     }
   },
   "fireworks" : {
-    "accounts\/fireworks\/models\/deepseek-v3p1" : {
+    "accounts\/fireworks\/models\/deepseek-v4-flash" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 163840,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.56000000000000005,
-        "output" : 1.6799999999999999
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
       },
-      "id" : "accounts\/fireworks\/models\/deepseek-v3p1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.14000000000000001,
+        "output" : 0.28000000000000003
+      },
+      "id" : "accounts\/fireworks\/models\/deepseek-v4-flash",
       "input" : [
         "text"
       ],
-      "maxTokens" : 163840,
-      "name" : "DeepSeek V3.1",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/models\/deepseek-v3p2" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 160000,
-      "cost" : {
-        "cacheRead" : 0.28000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.56000000000000005,
-        "output" : 1.6799999999999999
-      },
-      "id" : "accounts\/fireworks\/models\/deepseek-v3p2",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 160000,
-      "name" : "DeepSeek V3.2",
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Flash",
       "provider" : "fireworks",
       "reasoning" : true
     },
     "accounts\/fireworks\/models\/deepseek-v4-pro" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.14499999999999999,
         "cacheWrite" : 0,
         "input" : 1.74,
         "output" : 3.48
@@ -4366,85 +4437,15 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
-    "accounts\/fireworks\/models\/glm-4p5" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.55000000000000004,
-        "output" : 2.1899999999999999
-      },
-      "id" : "accounts\/fireworks\/models\/glm-4p5",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "GLM 4.5",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/models\/glm-4p5-air" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.22,
-        "output" : 0.88
-      },
-      "id" : "accounts\/fireworks\/models\/glm-4p5-air",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "GLM 4.5 Air",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/models\/glm-4p7" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 198000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
-      },
-      "id" : "accounts\/fireworks\/models\/glm-4p7",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 198000,
-      "name" : "GLM 4.7",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/models\/glm-5" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 202752,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3.2000000000000002
-      },
-      "id" : "accounts\/fireworks\/models\/glm-5",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "GLM 5",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
     "accounts\/fireworks\/models\/glm-5p1" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 202800,
       "cost" : {
         "cacheRead" : 0.26000000000000001,
@@ -4464,12 +4465,18 @@
     "accounts\/fireworks\/models\/gpt-oss-20b" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.035000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.20000000000000001
+        "input" : 0.070000000000000007,
+        "output" : 0.29999999999999999
       },
       "id" : "accounts\/fireworks\/models\/gpt-oss-20b",
       "input" : [
@@ -4483,9 +4490,15 @@
     "accounts\/fireworks\/models\/gpt-oss-120b" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.014999999999999999,
         "cacheWrite" : 0,
         "input" : 0.14999999999999999,
         "output" : 0.59999999999999998
@@ -4499,47 +4512,15 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
-    "accounts\/fireworks\/models\/kimi-k2-instruct" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3
-      },
-      "id" : "accounts\/fireworks\/models\/kimi-k2-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Kimi K2 Instruct",
-      "provider" : "fireworks",
-      "reasoning" : false
-    },
-    "accounts\/fireworks\/models\/kimi-k2-thinking" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.5
-      },
-      "id" : "accounts\/fireworks\/models\/kimi-k2-thinking",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 256000,
-      "name" : "Kimi K2 Thinking",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
     "accounts\/fireworks\/models\/kimi-k2p5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0.10000000000000001,
@@ -4560,6 +4541,12 @@
     "accounts\/fireworks\/models\/kimi-k2p6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 262000,
       "cost" : {
         "cacheRead" : 0.16,
@@ -4577,28 +4564,15 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
-    "accounts\/fireworks\/models\/minimax-m2p1" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 1.2
-      },
-      "id" : "accounts\/fireworks\/models\/minimax-m2p1",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 200000,
-      "name" : "MiniMax-M2.1",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
     "accounts\/fireworks\/models\/minimax-m2p5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 196608,
       "cost" : {
         "cacheRead" : 0.029999999999999999,
@@ -4618,9 +4592,15 @@
     "accounts\/fireworks\/models\/minimax-m2p7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 196608,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
         "input" : 0.29999999999999999,
         "output" : 1.2
@@ -4637,6 +4617,12 @@
     "accounts\/fireworks\/models\/qwen3p6-plus" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.10000000000000001,
@@ -4654,23 +4640,54 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
-    "accounts\/fireworks\/routers\/kimi-k2p5-turbo" : {
+    "accounts\/fireworks\/routers\/glm-5p1-fast" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
       },
-      "id" : "accounts\/fireworks\/routers\/kimi-k2p5-turbo",
+      "contextWindow" : 202800,
+      "cost" : {
+        "cacheRead" : 0.52000000000000002,
+        "cacheWrite" : 0,
+        "input" : 2.7999999999999998,
+        "output" : 8.8000000000000007
+      },
+      "id" : "accounts\/fireworks\/routers\/glm-5p1-fast",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM 5.1 Fast",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/routers\/kimi-k2p6-turbo" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 262000,
+      "cost" : {
+        "cacheRead" : 0.29999999999999999,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 8
+      },
+      "id" : "accounts\/fireworks\/routers\/kimi-k2p6-turbo",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 256000,
-      "name" : "Kimi K2.5 Turbo",
+      "maxTokens" : 262000,
+      "name" : "Kimi K2.6 Turbo",
       "provider" : "fireworks",
       "reasoning" : true
     }
@@ -4734,6 +4751,9 @@
     "claude-opus-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
@@ -4763,6 +4783,9 @@
     "claude-opus-4.7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 144000,
       "cost" : {
         "cacheRead" : 0,
@@ -4788,35 +4811,6 @@
       "thinkingLevelMap" : {
         "xhigh" : "xhigh"
       }
-    },
-    "claude-sonnet-4" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "compat" : {
-        "supportsEagerToolInputStreaming" : false
-      },
-      "contextWindow" : 216000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "claude-sonnet-4",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16000,
-      "name" : "Claude Sonnet 4",
-      "provider" : "github-copilot",
-      "reasoning" : true
     },
     "claude-sonnet-4.5" : {
       "api" : "anthropic-messages",
@@ -4850,6 +4844,9 @@
     "claude-sonnet-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
@@ -4935,37 +4932,6 @@
       "provider" : "github-copilot",
       "reasoning" : true
     },
-    "gemini-3-pro-preview" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gemini-3-pro-preview",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Gemini 3 Pro Preview",
-      "provider" : "github-copilot",
-      "reasoning" : true
-    },
     "gemini-3.1-pro-preview" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
@@ -4994,6 +4960,37 @@
       ],
       "maxTokens" : 64000,
       "name" : "Gemini 3.1 Pro Preview",
+      "provider" : "github-copilot",
+      "reasoning" : true
+    },
+    "gemini-3.5-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "Copilot-Integration-Id" : "vscode-chat",
+        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
+        "Editor-Version" : "vscode\/1.107.0",
+        "User-Agent" : "GitHubCopilotChat\/0.35.0"
+      },
+      "id" : "gemini-3.5-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Gemini 3.5 Flash",
       "provider" : "github-copilot",
       "reasoning" : true
     },
@@ -5059,35 +5056,6 @@
       "provider" : "github-copilot",
       "reasoning" : false
     },
-    "gpt-5" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gpt-5",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5",
-      "provider" : "github-copilot",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
     "gpt-5-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
@@ -5114,122 +5082,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 264000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gpt-5.1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "GPT-5.1",
-      "provider" : "github-copilot",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gpt-5.1-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1-Codex",
-      "provider" : "github-copilot",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex-max" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gpt-5.1-codex-max",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1-Codex-max",
-      "provider" : "github-copilot",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex-mini" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "Copilot-Integration-Id" : "vscode-chat",
-        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
-        "Editor-Version" : "vscode\/1.107.0",
-        "User-Agent" : "GitHubCopilotChat\/0.35.0"
-      },
-      "id" : "gpt-5.1-codex-mini",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1-Codex-mini",
-      "provider" : "github-copilot",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null
       }
     },
@@ -5259,6 +5112,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5289,6 +5143,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5319,6 +5174,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5349,6 +5205,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5379,6 +5236,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5409,6 +5267,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5445,66 +5304,6 @@
     }
   },
   "google" : {
-    "gemini-1.5-flash" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.018749999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
-      },
-      "id" : "gemini-1.5-flash",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemini 1.5 Flash",
-      "provider" : "google",
-      "reasoning" : false
-    },
-    "gemini-1.5-flash-8b" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0,
-        "input" : 0.037499999999999999,
-        "output" : 0.14999999999999999
-      },
-      "id" : "gemini-1.5-flash-8b",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemini 1.5 Flash-8B",
-      "provider" : "google",
-      "reasoning" : false
-    },
-    "gemini-1.5-pro" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.3125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 5
-      },
-      "id" : "gemini-1.5-pro",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemini 1.5 Pro",
-      "provider" : "google",
-      "reasoning" : false
-    },
     "gemini-2.0-flash" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -5541,7 +5340,7 @@
         "image"
       ],
       "maxTokens" : 8192,
-      "name" : "Gemini 2.0 Flash Lite",
+      "name" : "Gemini 2.0 Flash-Lite",
       "provider" : "google",
       "reasoning" : false
     },
@@ -5570,7 +5369,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.01,
         "cacheWrite" : 0,
         "input" : 0.10000000000000001,
         "output" : 0.40000000000000002
@@ -5581,107 +5380,7 @@
         "image"
       ],
       "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Lite",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-flash-lite-preview-06-17" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
-      },
-      "id" : "gemini-2.5-flash-lite-preview-06-17",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Lite Preview 06-17",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-flash-lite-preview-09-2025" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
-      },
-      "id" : "gemini-2.5-flash-lite-preview-09-2025",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Lite Preview 09-25",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-flash-preview-04-17" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
-      },
-      "id" : "gemini-2.5-flash-preview-04-17",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Preview 04-17",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-flash-preview-05-20" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
-      },
-      "id" : "gemini-2.5-flash-preview-05-20",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Preview 05-20",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-flash-preview-09-2025" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 2.5
-      },
-      "id" : "gemini-2.5-flash-preview-09-2025",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Flash Preview 09-25",
+      "name" : "Gemini 2.5 Flash-Lite",
       "provider" : "google",
       "reasoning" : true
     },
@@ -5702,46 +5401,6 @@
       ],
       "maxTokens" : 65536,
       "name" : "Gemini 2.5 Pro",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-pro-preview-05-06" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.31,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gemini-2.5-pro-preview-05-06",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Pro Preview 05-06",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-2.5-pro-preview-06-05" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.31,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gemini-2.5-pro-preview-06-05",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 2.5 Pro Preview 06-05",
       "provider" : "google",
       "reasoning" : true
     },
@@ -5771,7 +5430,7 @@
     "gemini-3-pro-preview" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1000000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
@@ -5783,7 +5442,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 64000,
+      "maxTokens" : 65536,
       "name" : "Gemini 3 Pro Preview",
       "provider" : "google",
       "reasoning" : true,
@@ -5795,13 +5454,36 @@
         "off" : null
       }
     },
+    "gemini-3.1-flash-lite" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.025000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 1.5
+      },
+      "id" : "gemini-3.1-flash-lite",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.1 Flash Lite",
+      "provider" : "google",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
     "gemini-3.1-flash-lite-preview" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 1,
+        "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
       },
@@ -5872,6 +5554,29 @@
         "off" : null
       }
     },
+    "gemini-3.5-flash" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.14999999999999999,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 9
+      },
+      "id" : "gemini-3.5-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.5 Flash",
+      "provider" : "google",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
     "gemini-flash-latest" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -5912,69 +5617,10 @@
       "provider" : "google",
       "reasoning" : true
     },
-    "gemini-live-2.5-flash" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2
-      },
-      "id" : "gemini-live-2.5-flash",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8000,
-      "name" : "Gemini Live 2.5 Flash",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemini-live-2.5-flash-preview-native-audio" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2
-      },
-      "id" : "gemini-live-2.5-flash-preview-native-audio",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini Live 2.5 Flash Preview Native Audio",
-      "provider" : "google",
-      "reasoning" : true
-    },
-    "gemma-3-27b-it" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "gemma-3-27b-it",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemma 3 27B",
-      "provider" : "google",
-      "reasoning" : false
-    },
     "gemma-4-26b-a4b-it" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -5986,8 +5632,8 @@
         "text",
         "image"
       ],
-      "maxTokens" : 8192,
-      "name" : "Gemma 4 26B",
+      "maxTokens" : 32768,
+      "name" : "Gemma 4 26B A4B IT",
       "provider" : "google",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -6001,7 +5647,7 @@
     "gemma-4-31b-it" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -6013,8 +5659,8 @@
         "text",
         "image"
       ],
-      "maxTokens" : 8192,
-      "name" : "Gemma 4 31B",
+      "maxTokens" : 32768,
+      "name" : "Gemma 4 31B IT",
       "provider" : "google",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -6548,7 +6194,7 @@
       "baseUrl" : "https:\/\/api.groq.com\/openai\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 3
@@ -6567,7 +6213,7 @@
       "baseUrl" : "https:\/\/api.groq.com\/openai\/v1",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.037499999999999999,
         "cacheWrite" : 0,
         "input" : 0.074999999999999997,
         "output" : 0.29999999999999999
@@ -6586,7 +6232,7 @@
       "baseUrl" : "https:\/\/api.groq.com\/openai\/v1",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
         "input" : 0.14999999999999999,
         "output" : 0.59999999999999998
@@ -6717,10 +6363,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14499999999999999,
+        "cacheRead" : 0.0036250000000000002,
         "cacheWrite" : 0,
-        "input" : 1.74,
-        "output" : 3.48
+        "input" : 0.435,
+        "output" : 0.87
       },
       "id" : "deepseek-ai\/DeepSeek-V4-Pro",
       "input" : [
@@ -7154,29 +6800,6 @@
     }
   },
   "kimi-coding" : {
-    "k2p6" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.kimi.com\/coding",
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
-      },
-      "id" : "k2p6",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Kimi K2.6",
-      "provider" : "kimi-coding",
-      "reasoning" : true
-    },
     "kimi-for-coding" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.kimi.com\/coding",
@@ -8307,7 +7930,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
         "input" : 0.10000000000000001,
         "output" : 0.40000000000000002
@@ -8407,7 +8030,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
         "input" : 0.14999999999999999,
         "output" : 0.59999999999999998
@@ -8565,7 +8188,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0.125,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 10
@@ -8580,7 +8203,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null
+        "off" : "none"
       }
     },
     "gpt-5.1-chat-latest" : {
@@ -8695,7 +8318,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8815,7 +8438,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8863,7 +8486,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8887,7 +8510,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8911,7 +8534,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8959,7 +8582,7 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -8983,6 +8606,8 @@
       "provider" : "openai",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "low" : null,
+        "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -9111,7 +8736,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.28000000000000003,
+        "cacheRead" : 0.27500000000000002,
         "cacheWrite" : 0,
         "input" : 1.1000000000000001,
         "output" : 4.4000000000000004
@@ -9148,72 +8773,6 @@
     }
   },
   "openai-codex" : {
-    "gpt-5.1" : {
-      "api" : "openai-codex-responses",
-      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
-      "contextWindow" : 272000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1",
-      "provider" : "openai-codex",
-      "reasoning" : true
-    },
-    "gpt-5.1-codex-max" : {
-      "api" : "openai-codex-responses",
-      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
-      "contextWindow" : 272000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-codex-max",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex Max",
-      "provider" : "openai-codex",
-      "reasoning" : true
-    },
-    "gpt-5.1-codex-mini" : {
-      "api" : "openai-codex-responses",
-      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
-      "contextWindow" : 272000,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 2
-      },
-      "id" : "gpt-5.1-codex-mini",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex Mini",
-      "provider" : "openai-codex",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "medium",
-        "medium" : "medium",
-        "minimal" : "medium"
-      }
-    },
     "gpt-5.2" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
@@ -9231,30 +8790,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT-5.2",
-      "provider" : "openai-codex",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "minimal" : "low",
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.2-codex" : {
-      "api" : "openai-codex-responses",
-      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
-      "contextWindow" : 272000,
-      "cost" : {
-        "cacheRead" : 0.17499999999999999,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.2-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.2 Codex",
       "provider" : "openai-codex",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -9291,10 +8826,10 @@
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.17499999999999999,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.75,
+        "output" : 14
       },
       "id" : "gpt-5.3-codex-spark",
       "input" : [
@@ -9349,7 +8884,7 @@
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "GPT-5.4 Mini",
+      "name" : "GPT-5.4 mini",
       "provider" : "openai-codex",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -9384,8 +8919,8 @@
   },
   "opencode" : {
     "big-pickle" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0,
@@ -9397,7 +8932,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 32000,
       "name" : "Big Pickle",
       "provider" : "opencode",
       "reasoning" : true
@@ -9465,6 +9000,9 @@
     "claude-opus-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -9488,6 +9026,9 @@
     "claude-opus-4-7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -9502,6 +9043,32 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 4.7",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "claude-opus-4-8" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "claude-opus-4-8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8",
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -9551,6 +9118,9 @@
     "claude-sonnet-4-6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.29999999999999999,
@@ -9567,6 +9137,36 @@
       "name" : "Claude Sonnet 4.6",
       "provider" : "opencode",
       "reasoning" : true
+    },
+    "deepseek-v4-flash-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "deepseek-v4-flash-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 128000,
+      "name" : "DeepSeek V4 Flash Free",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : "max"
+      }
     },
     "gemini-3-flash" : {
       "api" : "google-generative-ai",
@@ -9615,6 +9215,29 @@
         "low" : "LOW",
         "medium" : null,
         "minimal" : null,
+        "off" : null
+      }
+    },
+    "gemini-3.5-flash" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.14999999999999999,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 9
+      },
+      "id" : "gemini-3.5-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.5 Flash",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
         "off" : null
       }
     },
@@ -9707,10 +9330,10 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.0050000000000000001,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.050000000000000003,
+        "output" : 0.40000000000000002
       },
       "id" : "gpt-5-nano",
       "input" : [
@@ -10029,26 +9652,29 @@
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "low" : null,
+        "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
       }
     },
-    "hy3-preview-free" : {
+    "grok-build-0.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1,
+        "output" : 2
       },
-      "id" : "hy3-preview-free",
+      "id" : "grok-build-0.1",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
-      "maxTokens" : 64000,
-      "name" : "Hy3 preview Free",
+      "maxTokens" : 256000,
+      "name" : "Grok Build 0.1",
       "provider" : "opencode",
       "reasoning" : true
     },
@@ -10092,6 +9718,26 @@
       "provider" : "opencode",
       "reasoning" : true
     },
+    "mimo-v2.5-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "mimo-v2.5-free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "MiMo V2.5 Free",
+      "provider" : "opencode",
+      "reasoning" : true
+    },
     "minimax-m2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -10108,25 +9754,6 @@
       ],
       "maxTokens" : 131072,
       "name" : "MiniMax M2.5",
-      "provider" : "opencode",
-      "reasoning" : true
-    },
-    "minimax-m2.5-free" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen",
-      "contextWindow" : 204800,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "minimax-m2.5-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiniMax M2.5 Free",
       "provider" : "opencode",
       "reasoning" : true
     },
@@ -10331,12 +9958,15 @@
     "kimi-k2.6" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "thinkingFormat" : "string-thinking"
+      },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.053999999999999999,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.32000000000000001,
-        "output" : 1.3400000000000001
+        "input" : 0.94999999999999996,
+        "output" : 4
       },
       "id" : "kimi-k2.6",
       "input" : [
@@ -10344,58 +9974,22 @@
         "image"
       ],
       "maxTokens" : 65536,
-      "name" : "Kimi K2.6 (3x limits)",
+      "name" : "Kimi K2.6",
       "provider" : "opencode-go",
-      "reasoning" : true
-    },
-    "mimo-v2-omni" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.080000000000000002,
-        "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 2
-      },
-      "id" : "mimo-v2-omni",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "MiMo V2 Omni",
-      "provider" : "opencode-go",
-      "reasoning" : true
-    },
-    "mimo-v2-pro" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.20000000000000001,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3
-      },
-      "id" : "mimo-v2-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 128000,
-      "name" : "MiMo V2 Pro",
-      "provider" : "opencode-go",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : "none"
+      }
     },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 2
+        "input" : 0.14000000000000001,
+        "output" : 0.28000000000000003
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -10412,10 +10006,10 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.014500000000000001,
         "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3
+        "input" : 1.74,
+        "output" : 3.48
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
@@ -10427,8 +10021,8 @@
       "reasoning" : true
     },
     "minimax-m2.5" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
       "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0.029999999999999999,
@@ -10446,8 +10040,8 @@
       "reasoning" : true
     },
     "minimax-m2.7" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
       "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0.059999999999999998,
@@ -10465,8 +10059,11 @@
       "reasoning" : true
     },
     "qwen3.5-plus" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "thinkingFormat" : "qwen"
+      },
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.02,
@@ -10485,8 +10082,11 @@
       "reasoning" : true
     },
     "qwen3.6-plus" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "thinkingFormat" : "qwen"
+      },
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.050000000000000003,
@@ -10501,6 +10101,25 @@
       ],
       "maxTokens" : 65536,
       "name" : "Qwen3.6 Plus",
+      "provider" : "opencode-go",
+      "reasoning" : true
+    },
+    "qwen3.7-max" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 7.5
+      },
+      "id" : "qwen3.7-max",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Qwen3.7 Max",
       "provider" : "opencode-go",
       "reasoning" : true
     }
@@ -10571,10 +10190,10 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.049999999999999996,
+        "cacheRead" : 0.14999999999999999,
         "cacheWrite" : 0.083333333333333343,
-        "input" : 0.5,
-        "output" : 3
+        "input" : 1.5,
+        "output" : 9
       },
       "id" : "~google\/gemini-flash-latest",
       "input" : [
@@ -10609,11 +10228,11 @@
     "~moonshotai\/kimi-latest" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262142,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14000000000000001,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 0.73999999999999999,
+        "input" : 0.72999999999999998,
         "output" : 3.4900000000000002
       },
       "id" : "~moonshotai\/kimi-latest",
@@ -10682,44 +10301,6 @@
       ],
       "maxTokens" : 4096,
       "name" : "AI21: Jamba Large 1.7",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "alibaba\/tongyi-deepresearch-30b-a3b" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.089999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.44999999999999996
-      },
-      "id" : "alibaba\/tongyi-deepresearch-30b-a3b",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Tongyi DeepResearch 30B A3B",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "allenai\/olmo-3.1-32b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 65536,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 0.59999999999999998
-      },
-      "id" : "allenai\/olmo-3.1-32b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "AllenAI: Olmo 3.1 32B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -10861,46 +10442,6 @@
       "name" : "Anthropic: Claude 3.5 Haiku",
       "provider" : "openrouter",
       "reasoning" : false
-    },
-    "anthropic\/claude-3.7-sonnet" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic\/claude-3.7-sonnet",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Anthropic: Claude 3.7 Sonnet",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "anthropic\/claude-3.7-sonnet:thinking" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic\/claude-3.7-sonnet:thinking",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Anthropic: Claude 3.7 Sonnet (thinking)",
-      "provider" : "openrouter",
-      "reasoning" : true
     },
     "anthropic\/claude-haiku-4.5" : {
       "api" : "openai-completions",
@@ -11051,6 +10592,75 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic\/claude-opus-4.7-fast" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 3,
+        "cacheWrite" : 37.5,
+        "input" : 30,
+        "output" : 150
+      },
+      "id" : "anthropic\/claude-opus-4.7-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Anthropic: Claude Opus 4.7 (Fast)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-4.8" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "anthropic\/claude-opus-4.8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Anthropic: Claude Opus 4.8",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-4.8-fast" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 1,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-opus-4.8-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Anthropic: Claude Opus 4.8 (Fast)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic\/claude-sonnet-4" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -11110,25 +10720,6 @@
       "name" : "Anthropic: Claude Sonnet 4.6",
       "provider" : "openrouter",
       "reasoning" : true
-    },
-    "arcee-ai\/trinity-large-preview" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.44999999999999996
-      },
-      "id" : "arcee-ai\/trinity-large-preview",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Arcee AI: Trinity Large Preview",
-      "provider" : "openrouter",
-      "reasoning" : false
     },
     "arcee-ai\/trinity-large-thinking" : {
       "api" : "openai-completions",
@@ -11210,7 +10801,7 @@
     "baidu\/ernie-4.5-21b-a3b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 120000,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -11229,7 +10820,7 @@
     "baidu\/ernie-4.5-vl-28b-a3b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 30000,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -11367,18 +10958,18 @@
     "deepseek\/deepseek-chat" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 163840,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.32000000000000001,
-        "output" : 0.8899999999999999
+        "input" : 0.2288,
+        "output" : 0.91439999999999999
       },
       "id" : "deepseek\/deepseek-chat",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 16000,
       "name" : "DeepSeek: DeepSeek V3",
       "provider" : "openrouter",
       "reasoning" : false
@@ -11405,18 +10996,18 @@
     "deepseek\/deepseek-chat-v3.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 32768,
+      "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.75
+        "input" : 0.20999999999999999,
+        "output" : 0.78999999999999992
       },
       "id" : "deepseek\/deepseek-chat-v3.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 7168,
+      "maxTokens" : 32768,
       "name" : "DeepSeek: DeepSeek V3.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -11424,7 +11015,7 @@
     "deepseek\/deepseek-r1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 64000,
+      "contextWindow" : 163840,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -11466,8 +11057,8 @@
       "cost" : {
         "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.20999999999999999,
-        "output" : 0.78999999999999992
+        "input" : 0.27000000000000002,
+        "output" : 0.94999999999999996
       },
       "id" : "deepseek\/deepseek-v3.1-terminus",
       "input" : [
@@ -11520,21 +11111,20 @@
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
+        "requiresReasoningContentOnAssistantMessages" : true
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0028,
+        "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.099999999999999992,
+        "output" : 0.19999999999999998
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
         "text"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 16384,
       "name" : "DeepSeek: DeepSeek V4 Flash",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -11543,15 +11133,43 @@
         "low" : null,
         "medium" : null,
         "minimal" : null,
-        "xhigh" : "max"
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek\/deepseek-v4-flash:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "deepseek\/deepseek-v4-flash:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek: DeepSeek V4 Flash (free)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : "xhigh"
       }
     },
     "deepseek\/deepseek-v4-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
+        "requiresReasoningContentOnAssistantMessages" : true
       },
       "contextWindow" : 1048576,
       "cost" : {
@@ -11573,7 +11191,7 @@
         "low" : null,
         "medium" : null,
         "minimal" : null,
-        "xhigh" : "max"
+        "xhigh" : "xhigh"
       }
     },
     "essentialai\/rnj-1-instruct" : {
@@ -11598,7 +11216,7 @@
     "google\/gemini-2.0-flash-001" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 1048576,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.024999999999999998,
         "cacheWrite" : 0.083333333333333343,
@@ -11775,6 +11393,26 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "google\/gemini-3.1-flash-lite" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.024999999999999998,
+        "cacheWrite" : 0.083333333333333343,
+        "input" : 0.25,
+        "output" : 1.5
+      },
+      "id" : "google\/gemini-3.1-flash-lite",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.1 Flash Lite",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "google\/gemini-3.1-flash-lite-preview" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -11818,7 +11456,7 @@
     "google\/gemini-3.1-pro-preview-customtools" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 1048576,
+      "contextWindow" : 1048756,
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0.375,
@@ -11832,6 +11470,26 @@
       ],
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Pro Preview Custom Tools",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "google\/gemini-3.5-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.14999999999999999,
+        "cacheWrite" : 0.083333333333333343,
+        "input" : 1.5,
+        "output" : 9
+      },
+      "id" : "google\/gemini-3.5-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.5 Flash",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -11922,8 +11580,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.13,
-        "output" : 0.38
+        "input" : 0.12,
+        "output" : 0.37
       },
       "id" : "google\/gemma-4-31b-it",
       "input" : [
@@ -11991,24 +11649,27 @@
       "maxTokens" : 50000,
       "name" : "Inception: Mercury 2",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
-    "inclusionai\/ling-2.6-1t:free" : {
+    "inclusionai\/ling-2.6-1t" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.014999999999999999,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.074999999999999997,
+        "output" : 0.625
       },
-      "id" : "inclusionai\/ling-2.6-1t:free",
+      "id" : "inclusionai\/ling-2.6-1t",
       "input" : [
         "text"
       ],
       "maxTokens" : 32768,
-      "name" : "inclusionAI: Ling-2.6-1T (free)",
+      "name" : "inclusionAI: Ling-2.6-1T",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -12017,10 +11678,10 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.016,
+        "cacheRead" : 0.002,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.23999999999999999
+        "input" : 0.01,
+        "output" : 0.029999999999999999
       },
       "id" : "inclusionai\/ling-2.6-flash",
       "input" : [
@@ -12030,6 +11691,25 @@
       "name" : "inclusionAI: Ling-2.6-flash",
       "provider" : "openrouter",
       "reasoning" : false
+    },
+    "inclusionai\/ring-2.6-1t" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.625
+      },
+      "id" : "inclusionai\/ring-2.6-1t",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 65536,
+      "name" : "inclusionAI: Ring-2.6-1T",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "kwaipilot\/kat-coder-pro-v2" : {
       "api" : "openai-completions",
@@ -12050,29 +11730,10 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "meta-llama\/llama-3-8b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.029999999999999999,
-        "output" : 0.040000000000000001
-      },
-      "id" : "meta-llama\/llama-3-8b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Meta: Llama 3 8B Instruct",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "meta-llama\/llama-3.1-8b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 16384,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -12129,7 +11790,7 @@
     "meta-llama\/llama-3.3-70b-instruct:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 65536,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -12148,7 +11809,7 @@
     "meta-llama\/llama-4-scout" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 327680,
+      "contextWindow" : 10000000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -12187,7 +11848,7 @@
     "minimax\/minimax-m2" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 196608,
+      "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0.029999999999999999,
         "cacheWrite" : 0,
@@ -12206,7 +11867,7 @@
     "minimax\/minimax-m2.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 196608,
+      "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0.029999999999999999,
         "cacheWrite" : 0,
@@ -12225,9 +11886,9 @@
     "minimax\/minimax-m2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 196608,
+      "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.14999999999999999,
         "output" : 1.1499999999999999
@@ -12236,7 +11897,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 196608,
       "name" : "MiniMax: MiniMax M2.5",
       "provider" : "openrouter",
       "reasoning" : true
@@ -12244,7 +11905,7 @@
     "minimax\/minimax-m2.5:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 196608,
+      "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -12263,18 +11924,18 @@
     "minimax\/minimax-m2.7" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 196608,
+      "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.058999999999999997,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.27899999999999997,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.7",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 131072,
       "name" : "MiniMax: MiniMax M2.7",
       "provider" : "openrouter",
       "reasoning" : true
@@ -12512,6 +12173,26 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "mistralai\/mistral-medium-3-5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 7.5
+      },
+      "id" : "mistralai\/mistral-medium-3-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Mistral: Mistral Medium 3.5",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "mistralai\/mistral-medium-3.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -12610,25 +12291,6 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "mistralai\/mixtral-8x7b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 32768,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.54000000000000004,
-        "output" : 0.54000000000000004
-      },
-      "id" : "mistralai\/mixtral-8x7b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Mistral: Mixtral 8x7B Instruct",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "mistralai\/mixtral-8x22b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -12713,8 +12375,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.39999999999999997,
-        "output" : 2
+        "input" : 0.59999999999999998,
+        "output" : 2.5
       },
       "id" : "moonshotai\/kimi-k2-0905",
       "input" : [
@@ -12730,7 +12392,7 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.59999999999999998,
         "output" : 2.5
@@ -12767,11 +12429,11 @@
     "moonshotai\/kimi-k2.6" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262142,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14000000000000001,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 0.73999999999999999,
+        "input" : 0.72999999999999998,
         "output" : 3.4900000000000002
       },
       "id" : "moonshotai\/kimi-k2.6",
@@ -12781,6 +12443,26 @@
       ],
       "maxTokens" : 262142,
       "name" : "MoonshotAI: Kimi K2.6",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "moonshotai\/kimi-k2.6:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "moonshotai\/kimi-k2.6:free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "MoonshotAI: Kimi K2.6 (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -12800,25 +12482,6 @@
       ],
       "maxTokens" : 163840,
       "name" : "Nex AGI: DeepSeek V3.1 Nex N1",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "nvidia\/llama-3.1-nemotron-70b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 1.2,
-        "output" : 1.2
-      },
-      "id" : "nvidia\/llama-3.1-nemotron-70b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "NVIDIA: Llama 3.1 Nemotron 70B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -12902,7 +12565,7 @@
     "nvidia\/nemotron-3-super-120b-a12b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262144,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -12921,7 +12584,7 @@
     "nvidia\/nemotron-3-super-120b-a12b:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262144,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -13472,7 +13135,7 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.125,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 10
@@ -13482,7 +13145,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 32000,
       "name" : "OpenAI: GPT-5.1 Chat",
       "provider" : "openrouter",
       "reasoning" : false
@@ -13492,7 +13155,7 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.125,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 10
@@ -13532,7 +13195,7 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.024999999999999998,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -13542,7 +13205,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 100000,
       "name" : "OpenAI: GPT-5.1-Codex-Mini",
       "provider" : "openrouter",
       "reasoning" : true
@@ -13585,7 +13248,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 32000,
+      "maxTokens" : 16384,
       "name" : "OpenAI: GPT-5.2 Chat",
       "provider" : "openrouter",
       "reasoning" : false,
@@ -13820,6 +13483,9 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "low" : null,
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -13858,6 +13524,26 @@
       ],
       "maxTokens" : 16384,
       "name" : "OpenAI: GPT Audio Mini",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
+    "openai\/gpt-chat-latest" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-chat-latest",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT Chat Latest",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -14196,7 +13882,7 @@
     "poolside\/laguna-m.1:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14207,7 +13893,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 32768,
       "name" : "Poolside: Laguna M.1 (free)",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14215,7 +13901,7 @@
     "poolside\/laguna-xs.2:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14226,7 +13912,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 32768,
       "name" : "Poolside: Laguna XS.2 (free)",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14253,7 +13939,7 @@
     "qwen\/qwen-2.5-7b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 32768,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14272,7 +13958,7 @@
     "qwen\/qwen-2.5-72b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 32768,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14285,25 +13971,6 @@
       ],
       "maxTokens" : 16384,
       "name" : "Qwen2.5 72B Instruct",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "qwen\/qwen-max" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 32768,
-      "cost" : {
-        "cacheRead" : 0.20800000000000002,
-        "cacheWrite" : 0,
-        "input" : 1.04,
-        "output" : 4.1600000000000001
-      },
-      "id" : "qwen\/qwen-max",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Qwen: Qwen-Max ",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -14332,7 +13999,7 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.32500000000000001,
+        "cacheWrite" : 0,
         "input" : 0.26000000000000001,
         "output" : 0.78000000000000003
       },
@@ -14364,49 +14031,10 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "qwen\/qwen-turbo" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.006500000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.032500000000000001,
-        "output" : 0.13
-      },
-      "id" : "qwen\/qwen-turbo",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Qwen: Qwen-Turbo",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "qwen\/qwen-vl-max" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.52000000000000002,
-        "output" : 2.0800000000000001
-      },
-      "id" : "qwen\/qwen-vl-max",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Qwen: Qwen VL Max",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "qwen\/qwen3-8b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0.049999999999999996,
         "cacheWrite" : 0,
@@ -14425,11 +14053,11 @@
     "qwen\/qwen3-14b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 40960,
+      "contextWindow" : 131702,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.099999999999999992,
         "output" : 0.23999999999999999
       },
       "id" : "qwen\/qwen3-14b",
@@ -14444,18 +14072,18 @@
     "qwen\/qwen3-30b-a3b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.28000000000000003
+        "input" : 0.089999999999999997,
+        "output" : 0.44999999999999996
       },
       "id" : "qwen\/qwen3-30b-a3b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 20000,
       "name" : "Qwen: Qwen3 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14501,18 +14129,18 @@
     "qwen\/qwen3-32b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.080000000000000002,
-        "output" : 0.23999999999999999
+        "output" : 0.28000000000000003
       },
       "id" : "qwen\/qwen3-32b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 40960,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 32B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14558,7 +14186,7 @@
     "qwen\/qwen3-235b-a22b-thinking-2507" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14577,7 +14205,7 @@
     "qwen\/qwen3-coder" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262144,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14638,7 +14266,7 @@
       "cost" : {
         "cacheRead" : 0.070000000000000007,
         "cacheWrite" : 0,
-        "input" : 0.12,
+        "input" : 0.11,
         "output" : 0.79999999999999993
       },
       "id" : "qwen\/qwen3-coder-next",
@@ -14672,7 +14300,7 @@
     "qwen\/qwen3-coder:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 262000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14767,7 +14395,7 @@
     "qwen\/qwen3-next-80b-a3b-thinking" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14786,7 +14414,7 @@
     "qwen\/qwen3-vl-8b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14806,7 +14434,7 @@
     "qwen\/qwen3-vl-8b-thinking" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14826,7 +14454,7 @@
     "qwen\/qwen3-vl-30b-a3b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14866,7 +14494,7 @@
     "qwen\/qwen3-vl-32b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14930,7 +14558,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.099999999999999992,
+        "input" : 0.040000000000000001,
         "output" : 0.14999999999999999
       },
       "id" : "qwen\/qwen3.5-9b",
@@ -14938,7 +14566,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 81920,
       "name" : "Qwen: Qwen3.5-9B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14970,15 +14598,15 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.16250000000000001,
-        "output" : 1.3
+        "input" : 0.13899999999999998,
+        "output" : 1
       },
       "id" : "qwen\/qwen3.5-35b-a3b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 4096,
       "name" : "Qwen: Qwen3.5-35B-A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14998,7 +14626,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3.5-122B-A10B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15008,7 +14636,7 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.19500000000000001,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.39000000000000001,
         "output" : 2.3399999999999999
@@ -15029,7 +14657,7 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.081250000000000003,
+        "cacheWrite" : 0,
         "input" : 0.065000000000000002,
         "output" : 0.26000000000000001
       },
@@ -15049,7 +14677,7 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.32500000000000001,
+        "cacheWrite" : 0,
         "input" : 0.26000000000000001,
         "output" : 1.5600000000000001
       },
@@ -15069,9 +14697,9 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.39999999999999997,
-        "output" : 2.3999999999999999
+        "cacheWrite" : 0.375,
+        "input" : 0.29999999999999999,
+        "output" : 1.7999999999999998
       },
       "id" : "qwen\/qwen3.5-plus-20260420",
       "input" : [
@@ -15090,7 +14718,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.32000000000000001,
+        "input" : 0.28999999999999998,
         "output" : 3.1999999999999997
       },
       "id" : "qwen\/qwen3.6-27b",
@@ -15098,8 +14726,28 @@
         "text",
         "image"
       ],
-      "maxTokens" : 81920,
+      "maxTokens" : 262140,
       "name" : "Qwen: Qwen3.6 27B",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "qwen\/qwen3.6-35b-a3b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.14000000000000001,
+        "output" : 1
+      },
+      "id" : "qwen\/qwen3.6-35b-a3b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262140,
+      "name" : "Qwen: Qwen3.6 35B A3B",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -15109,9 +14757,9 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.3125,
-        "input" : 0.25,
-        "output" : 1.5
+        "cacheWrite" : 0.234375,
+        "input" : 0.1875,
+        "output" : 1.125
       },
       "id" : "qwen\/qwen3.6-flash",
       "input" : [
@@ -15159,6 +14807,25 @@
       ],
       "maxTokens" : 65536,
       "name" : "Qwen: Qwen3.6 Plus",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "qwen\/qwen3.7-max" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 1.5625,
+        "input" : 1.25,
+        "output" : 3.75
+      },
+      "id" : "qwen\/qwen3.7-max",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Qwen: Qwen3.7 Max",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -15244,36 +14911,36 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.099999999999999992,
+        "input" : 0.089999999999999997,
         "output" : 0.29999999999999999
       },
       "id" : "stepfun\/step-3.5-flash",
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 16384,
       "name" : "StepFun: Step 3.5 Flash",
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "tencent\/hy3-preview:free" : {
+    "tencent\/hy3-preview" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.020999999999999998,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.063,
+        "output" : 0.20999999999999999
       },
-      "id" : "tencent\/hy3-preview:free",
+      "id" : "tencent\/hy3-preview",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
-      "name" : "Tencent: Hy3 preview (free)",
+      "maxTokens" : 4096,
+      "name" : "Tencent: Hy3 preview",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -15315,25 +14982,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "tngtech\/deepseek-r1t2-chimera" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 163840,
-      "cost" : {
-        "cacheRead" : 0.14999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 1.1000000000000001
-      },
-      "id" : "tngtech\/deepseek-r1t2-chimera",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 163840,
-      "name" : "TNG: DeepSeek R1T2 Chimera",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
     "upstage\/solar-pro-3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -15350,142 +14998,6 @@
       ],
       "maxTokens" : 4096,
       "name" : "Upstage: Solar Pro 3",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "x-ai\/grok-3" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "x-ai\/grok-3",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "xAI: Grok 3",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "x-ai\/grok-3-beta" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "x-ai\/grok-3-beta",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "xAI: Grok 3 Beta",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "x-ai\/grok-3-mini" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.5
-      },
-      "id" : "x-ai\/grok-3-mini",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "xAI: Grok 3 Mini",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "x-ai\/grok-3-mini-beta" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.5
-      },
-      "id" : "x-ai\/grok-3-mini-beta",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "xAI: Grok 3 Mini Beta",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "x-ai\/grok-4" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "x-ai\/grok-4",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "xAI: Grok 4",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "x-ai\/grok-4-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.049999999999999996,
-        "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 0.5
-      },
-      "id" : "x-ai\/grok-4-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "xAI: Grok 4 Fast",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "x-ai\/grok-4.1-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.049999999999999996,
-        "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 0.5
-      },
-      "id" : "x-ai\/grok-4.1-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "xAI: Grok 4.1 Fast",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -15529,22 +15041,23 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "x-ai\/grok-code-fast-1" : {
+    "x-ai\/grok-build-0.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.02,
+        "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 1.5
+        "input" : 1,
+        "output" : 2
       },
-      "id" : "x-ai\/grok-code-fast-1",
+      "id" : "x-ai\/grok-build-0.1",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
-      "maxTokens" : 10000,
-      "name" : "xAI: Grok Code Fast 1",
+      "maxTokens" : 4096,
+      "name" : "xAI: Grok Build 0.1",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -15553,10 +15066,10 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.044999999999999998,
+        "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.28999999999999998
+        "input" : 0.099999999999999992,
+        "output" : 0.29999999999999999
       },
       "id" : "xiaomi\/mimo-v2-flash",
       "input" : [
@@ -15611,10 +15124,10 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.39999999999999997,
-        "output" : 2
+        "input" : 0.14000000000000001,
+        "output" : 0.28000000000000003
       },
       "id" : "xiaomi\/mimo-v2.5",
       "input" : [
@@ -15631,10 +15144,10 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.19999999999999998,
+        "cacheRead" : 0.0035999999999999999,
         "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3
+        "input" : 0.435,
+        "output" : 0.87
       },
       "id" : "xiaomi\/mimo-v2.5-pro",
       "input" : [
@@ -15688,16 +15201,16 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.024999999999999998,
+        "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.13,
+        "input" : 0.125,
         "output" : 0.84999999999999998
       },
       "id" : "z-ai\/glm-4.5-air",
       "input" : [
         "text"
       ],
-      "maxTokens" : 98304,
+      "maxTokens" : 131070,
       "name" : "Z.ai: GLM 4.5 Air",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15744,18 +15257,18 @@
     "z-ai\/glm-4.6" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "contextWindow" : 204800,
+      "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.080000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.39000000000000001,
-        "output" : 1.8999999999999999
+        "input" : 0.42999999999999999,
+        "output" : 1.74
       },
       "id" : "z-ai\/glm-4.6",
       "input" : [
         "text"
       ],
-      "maxTokens" : 204800,
+      "maxTokens" : 131072,
       "name" : "Z.ai: GLM 4.6",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15785,16 +15298,16 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.080000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.38,
-        "output" : 1.74
+        "input" : 0.39999999999999997,
+        "output" : 1.75
       },
       "id" : "z-ai\/glm-4.7",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 131072,
       "name" : "Z.ai: GLM 4.7",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15832,7 +15345,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 4096,
       "name" : "Z.ai: GLM 5",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15861,16 +15374,16 @@
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.52499999999999991,
+        "cacheRead" : 0.182,
         "cacheWrite" : 0,
-        "input" : 1.0499999999999998,
-        "output" : 3.5
+        "input" : 0.97999999999999998,
+        "output" : 3.0800000000000001
       },
       "id" : "z-ai\/glm-5.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 65535,
+      "maxTokens" : 4096,
       "name" : "Z.ai: GLM 5.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15894,6 +15407,589 @@
       "name" : "Z.ai: GLM 5V Turbo",
       "provider" : "openrouter",
       "reasoning" : true
+    }
+  },
+  "together" : {
+    "deepseek-ai\/DeepSeek-V3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 1.25
+      },
+      "id" : "deepseek-ai\/DeepSeek-V3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "DeepSeek V3",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "deepseek-ai\/DeepSeek-V3-1" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.59999999999999998,
+        "output" : 1.7
+      },
+      "id" : "deepseek-ai\/DeepSeek-V3-1",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "DeepSeek V3.1",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "deepseek-ai\/DeepSeek-V4-Pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 512000,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 2.1000000000000001,
+        "output" : 4.4000000000000004
+      },
+      "id" : "deepseek-ai\/DeepSeek-V4-Pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
+    },
+    "essentialai\/Rnj-1-Instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 32768,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.14999999999999999,
+        "output" : 0.14999999999999999
+      },
+      "id" : "essentialai\/Rnj-1-Instruct",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Rnj-1 Instruct",
+      "provider" : "together",
+      "reasoning" : false
+    },
+    "google\/gemma-4-31B-it" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.20000000000000001,
+        "output" : 0.5
+      },
+      "id" : "google\/gemma-4-31B-it",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Gemma 4 31B Instruct",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "meta-llama\/Llama-3.3-70B-Instruct-Turbo" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.88,
+        "output" : 0.88
+      },
+      "id" : "meta-llama\/Llama-3.3-70B-Instruct-Turbo",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Llama 3.3 70B",
+      "provider" : "together",
+      "reasoning" : false
+    },
+    "MiniMaxAI\/MiniMax-M2.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 204800,
+      "cost" : {
+        "cacheRead" : 0.059999999999999998,
+        "cacheWrite" : 0,
+        "input" : 0.29999999999999999,
+        "output" : 1.2
+      },
+      "id" : "MiniMaxAI\/MiniMax-M2.5",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiniMax-M2.5",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null
+      }
+    },
+    "MiniMaxAI\/MiniMax-M2.7" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 202752,
+      "cost" : {
+        "cacheRead" : 0.059999999999999998,
+        "cacheWrite" : 0,
+        "input" : 0.29999999999999999,
+        "output" : 1.2
+      },
+      "id" : "MiniMaxAI\/MiniMax-M2.7",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiniMax-M2.7",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null
+      }
+    },
+    "moonshotai\/Kimi-K2.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 2.7999999999999998
+      },
+      "id" : "moonshotai\/Kimi-K2.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Kimi K2.5",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "moonshotai\/Kimi-K2.6" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1.2,
+        "output" : 4.5
+      },
+      "id" : "moonshotai\/Kimi-K2.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131000,
+      "name" : "Kimi K2.6",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "openai\/gpt-oss-120b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "openai"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.14999999999999999,
+        "output" : 0.59999999999999998
+      },
+      "id" : "openai\/gpt-oss-120b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GPT OSS 120B",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "minimal" : null,
+        "off" : null
+      }
+    },
+    "Qwen\/Qwen3-235B-A22B-Instruct-2507-tput" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.20000000000000001,
+        "output" : 0.59999999999999998
+      },
+      "id" : "Qwen\/Qwen3-235B-A22B-Instruct-2507-tput",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Qwen3 235B A22B Instruct 2507 FP8",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "Qwen\/Qwen3-Coder-480B-A35B-Instruct-FP8" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 2
+      },
+      "id" : "Qwen\/Qwen3-Coder-480B-A35B-Instruct-FP8",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Qwen3 Coder 480B A35B Instruct",
+      "provider" : "together",
+      "reasoning" : false
+    },
+    "Qwen\/Qwen3-Coder-Next-FP8" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 1.2
+      },
+      "id" : "Qwen\/Qwen3-Coder-Next-FP8",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Qwen3 Coder Next FP8",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "Qwen\/Qwen3.5-397B-A17B" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.59999999999999998,
+        "output" : 3.6000000000000001
+      },
+      "id" : "Qwen\/Qwen3.5-397B-A17B",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 130000,
+      "name" : "Qwen3.5 397B A17B",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "Qwen\/Qwen3.6-Plus" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 3
+      },
+      "id" : "Qwen\/Qwen3.6-Plus",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Qwen3.6 Plus",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "Qwen\/Qwen3.7-Max" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 2.5,
+        "output" : 7.5
+      },
+      "id" : "Qwen\/Qwen3.7-Max",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Qwen3.7 Max",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "zai-org\/GLM-5.1" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 202752,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.3999999999999999,
+        "output" : 4.4000000000000004
+      },
+      "id" : "zai-org\/GLM-5.1",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.1",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
     }
   },
   "vercel-ai-gateway" : {
@@ -16246,6 +16342,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "alibaba\/qwen3.7-max" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 991000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 1.5625,
+        "input" : 1.25,
+        "output" : 3.75
+      },
+      "id" : "alibaba\/qwen3.7-max",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Qwen 3.7 Max",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "anthropic\/claude-3-haiku" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -16285,26 +16401,6 @@
       "name" : "Claude 3.5 Haiku",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
-    },
-    "anthropic\/claude-3.7-sonnet" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "anthropic\/claude-3.7-sonnet",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude 3.7 Sonnet",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
     },
     "anthropic\/claude-haiku-4.5" : {
       "api" : "anthropic-messages",
@@ -16389,6 +16485,9 @@
     "anthropic\/claude-opus-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -16412,6 +16511,9 @@
     "anthropic\/claude-opus-4.7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -16426,6 +16528,32 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 4.7",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-4.8" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "anthropic\/claude-opus-4.8",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 4.8",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -16475,6 +16603,9 @@
     "anthropic\/claude-sonnet-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.29999999999999999,
@@ -16860,6 +16991,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "google\/gemini-3.1-flash-lite" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 1.5
+      },
+      "id" : "google\/gemini-3.1-flash-lite",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65000,
+      "name" : "Gemini 3.1 Flash Lite",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "google\/gemini-3.1-flash-lite-preview" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -16897,6 +17048,26 @@
       ],
       "maxTokens" : 64000,
       "name" : "Gemini 3.1 Pro Preview",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "google\/gemini-3.5-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.14999999999999999,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 9
+      },
+      "id" : "google\/gemini-3.5-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Gemini 3.5 Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -17264,7 +17435,7 @@
         "image"
       ],
       "maxTokens" : 131000,
-      "name" : "Minimax M2.7",
+      "name" : "MiniMax M2.7",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -17422,6 +17593,25 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
+    "mistral\/mistral-medium-3.5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 7.5
+      },
+      "id" : "mistral\/mistral-medium-3.5",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 256000,
+      "name" : "Mistral Medium Latest",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "mistral\/mistral-small" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -17498,25 +17688,6 @@
       ],
       "maxTokens" : 131072,
       "name" : "Kimi K2 Instruct",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "moonshotai\/kimi-k2-0905" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.5
-      },
-      "id" : "moonshotai\/kimi-k2-0905",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Kimi K2 0905",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
@@ -18268,6 +18439,9 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "low" : null,
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -18286,7 +18460,7 @@
         "text"
       ],
       "maxTokens" : 8192,
-      "name" : "GPT OSS 120B",
+      "name" : "GPT OSS 20B",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -18468,146 +18642,10 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
-    "xai\/grok-3" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "xai\/grok-3",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Grok 3 Beta",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-3-fast" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 1.25,
-        "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 25
-      },
-      "id" : "xai\/grok-3-fast",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Grok 3 Fast Beta",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-3-mini" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.5
-      },
-      "id" : "xai\/grok-3-mini",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Grok 3 Mini Beta",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-3-mini-fast" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 4
-      },
-      "id" : "xai\/grok-3-mini-fast",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Grok 3 Mini Fast Beta",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-4" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "xai\/grok-4",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 256000,
-      "name" : "Grok 4",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4-fast-non-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.049999999999999996,
-        "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 0.5
-      },
-      "id" : "xai\/grok-4-fast-non-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 256000,
-      "name" : "Grok 4 Fast Non-Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-4-fast-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.049999999999999996,
-        "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 0.5
-      },
-      "id" : "xai\/grok-4-fast-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 256000,
-      "name" : "Grok 4 Fast Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
     "xai\/grok-4.1-fast-non-reasoning" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.049999999999999996,
         "cacheWrite" : 0,
@@ -18619,7 +18657,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 30000,
+      "maxTokens" : 1000000,
       "name" : "Grok 4.1 Fast Non-Reasoning",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
@@ -18627,7 +18665,7 @@
     "xai\/grok-4.1-fast-reasoning" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.049999999999999996,
         "cacheWrite" : 0,
@@ -18639,7 +18677,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 30000,
+      "maxTokens" : 1000000,
       "name" : "Grok 4.1 Fast Reasoning",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -18671,8 +18709,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-multi-agent",
       "input" : [
@@ -18691,8 +18729,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-multi-agent-beta",
       "input" : [
@@ -18711,8 +18749,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-non-reasoning",
       "input" : [
@@ -18731,8 +18769,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-non-reasoning-beta",
       "input" : [
@@ -18751,8 +18789,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-reasoning",
       "input" : [
@@ -18771,8 +18809,8 @@
       "cost" : {
         "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "xai\/grok-4.20-reasoning-beta",
       "input" : [
@@ -18784,22 +18822,23 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
-    "xai\/grok-code-fast-1" : {
+    "xai\/grok-build-0.1" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.02,
+        "cacheRead" : 0.19999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.19999999999999998,
-        "output" : 1.5
+        "input" : 1,
+        "output" : 2
       },
-      "id" : "xai\/grok-code-fast-1",
+      "id" : "xai\/grok-build-0.1",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 256000,
-      "name" : "Grok Code Fast 1",
+      "name" : "Grok Build 0.1",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -18846,10 +18885,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.39999999999999997,
-        "output" : 2
+        "input" : 0.14000000000000001,
+        "output" : 0.28000000000000003
       },
       "id" : "xiaomi\/mimo-v2.5",
       "input" : [
@@ -18866,10 +18905,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.19999999999999998,
+        "cacheRead" : 0.0035999999999999999,
         "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 3
+        "input" : 0.435,
+        "output" : 0.87
       },
       "id" : "xiaomi\/mimo-v2.5-pro",
       "input" : [
@@ -19134,123 +19173,6 @@
     }
   },
   "xai" : {
-    "grok-2" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 2",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-2-1212" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2-1212",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 2 (1212)",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-2-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2-latest",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 2 Latest",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-2-vision" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2-vision",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Grok 2 Vision",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-2-vision-1212" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2-vision-1212",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Grok 2 Vision (1212)",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-2-vision-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 10
-      },
-      "id" : "grok-2-vision-latest",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Grok 2 Vision Latest",
-      "provider" : "xai",
-      "reasoning" : false
-    },
     "grok-3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
@@ -19289,219 +19211,6 @@
       "provider" : "xai",
       "reasoning" : false
     },
-    "grok-3-fast-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 1.25,
-        "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 25
-      },
-      "id" : "grok-3-fast-latest",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Fast Latest",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-3-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "grok-3-latest",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Latest",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-3-mini" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.5
-      },
-      "id" : "grok-3-mini",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Mini",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-3-mini-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.14999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 4
-      },
-      "id" : "grok-3-mini-fast",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Mini Fast",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-3-mini-fast-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.14999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 4
-      },
-      "id" : "grok-3-mini-fast-latest",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Mini Fast Latest",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-3-mini-latest" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.5
-      },
-      "id" : "grok-3-mini-latest",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Grok 3 Mini Latest",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-4" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.75,
-        "cacheWrite" : 0,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "grok-4",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Grok 4",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-4-1-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.5
-      },
-      "id" : "grok-4-1-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "Grok 4.1 Fast",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-4-1-fast-non-reasoning" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.5
-      },
-      "id" : "grok-4-1-fast-non-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "Grok 4.1 Fast (Non-Reasoning)",
-      "provider" : "xai",
-      "reasoning" : false
-    },
-    "grok-4-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.5
-      },
-      "id" : "grok-4-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "Grok 4 Fast",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-4-fast-non-reasoning" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.5
-      },
-      "id" : "grok-4-fast-non-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 30000,
-      "name" : "Grok 4 Fast (Non-Reasoning)",
-      "provider" : "xai",
-      "reasoning" : false
-    },
     "grok-4.3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
@@ -19529,8 +19238,8 @@
       "cost" : {
         "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "grok-4.20-0309-non-reasoning",
       "input" : [
@@ -19549,8 +19258,8 @@
       "cost" : {
         "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
+        "input" : 1.25,
+        "output" : 2.5
       },
       "id" : "grok-4.20-0309-reasoning",
       "input" : [
@@ -19562,29 +19271,30 @@
       "provider" : "xai",
       "reasoning" : true
     },
-    "grok-beta" : {
+    "grok-build-0.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 131072,
+      "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 5,
+        "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 15
+        "input" : 1,
+        "output" : 2
       },
-      "id" : "grok-beta",
+      "id" : "grok-build-0.1",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
-      "maxTokens" : 4096,
-      "name" : "Grok Beta",
+      "maxTokens" : 256000,
+      "name" : "Grok Build 0.1",
       "provider" : "xai",
-      "reasoning" : false
+      "reasoning" : true
     },
     "grok-code-fast-1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 256000,
+      "contextWindow" : 32768,
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
@@ -19595,37 +19305,21 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 10000,
+      "maxTokens" : 8192,
       "name" : "Grok Code Fast 1",
-      "provider" : "xai",
-      "reasoning" : true
-    },
-    "grok-vision-beta" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.x.ai\/v1",
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 5,
-        "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 15
-      },
-      "id" : "grok-vision-beta",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Grok Vision Beta",
       "provider" : "xai",
       "reasoning" : false
     }
   },
   "xiaomi" : {
     "mimo-v2-flash" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/anthropic",
-      "contextWindow" : 256000,
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
@@ -19636,15 +19330,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 64000,
+      "maxTokens" : 65536,
       "name" : "MiMo-V2-Flash",
       "provider" : "xiaomi",
       "reasoning" : true
     },
     "mimo-v2-omni" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/anthropic",
-      "contextWindow" : 256000,
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.080000000000000002,
         "cacheWrite" : 0,
@@ -19656,15 +19354,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 131072,
       "name" : "MiMo-V2-Omni",
       "provider" : "xiaomi",
       "reasoning" : true
     },
     "mimo-v2-pro" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/anthropic",
-      "contextWindow" : 1000000,
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.20000000000000001,
         "cacheWrite" : 0,
@@ -19675,14 +19377,18 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 131072,
       "name" : "MiMo-V2-Pro",
       "provider" : "xiaomi",
       "reasoning" : true
     },
     "mimo-v2.5" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/anthropic",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
       "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.080000000000000002,
@@ -19692,7 +19398,8 @@
       },
       "id" : "mimo-v2.5",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 131072,
       "name" : "MiMo-V2.5",
@@ -19700,8 +19407,12 @@
       "reasoning" : true
     },
     "mimo-v2.5-pro" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/anthropic",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
       "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.20000000000000001,
@@ -19711,12 +19422,299 @@
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
-        "text",
-        "image"
+        "text"
       ],
       "maxTokens" : 131072,
       "name" : "MiMo-V2.5-Pro",
       "provider" : "xiaomi",
+      "reasoning" : true
+    }
+  },
+  "xiaomi-token-plan-ams" : {
+    "mimo-v2-omni" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2-omni",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Omni",
+      "provider" : "xiaomi-token-plan-ams",
+      "reasoning" : true
+    },
+    "mimo-v2-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Pro",
+      "provider" : "xiaomi-token-plan-ams",
+      "reasoning" : true
+    },
+    "mimo-v2.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5",
+      "provider" : "xiaomi-token-plan-ams",
+      "reasoning" : true
+    },
+    "mimo-v2.5-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2.5-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5-Pro",
+      "provider" : "xiaomi-token-plan-ams",
+      "reasoning" : true
+    }
+  },
+  "xiaomi-token-plan-cn" : {
+    "mimo-v2-omni" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2-omni",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Omni",
+      "provider" : "xiaomi-token-plan-cn",
+      "reasoning" : true
+    },
+    "mimo-v2-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Pro",
+      "provider" : "xiaomi-token-plan-cn",
+      "reasoning" : true
+    },
+    "mimo-v2.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5",
+      "provider" : "xiaomi-token-plan-cn",
+      "reasoning" : true
+    },
+    "mimo-v2.5-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2.5-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5-Pro",
+      "provider" : "xiaomi-token-plan-cn",
+      "reasoning" : true
+    }
+  },
+  "xiaomi-token-plan-sgp" : {
+    "mimo-v2-omni" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2-omni",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Omni",
+      "provider" : "xiaomi-token-plan-sgp",
+      "reasoning" : true
+    },
+    "mimo-v2-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2-Pro",
+      "provider" : "xiaomi-token-plan-sgp",
+      "reasoning" : true
+    },
+    "mimo-v2.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.080000000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.40000000000000002,
+        "output" : 2
+      },
+      "id" : "mimo-v2.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5",
+      "provider" : "xiaomi-token-plan-sgp",
+      "reasoning" : true
+    },
+    "mimo-v2.5-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 3
+      },
+      "id" : "mimo-v2.5-pro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo-V2.5-Pro",
+      "provider" : "xiaomi-token-plan-sgp",
       "reasoning" : true
     }
   },
@@ -19837,7 +19835,7 @@
         "image"
       ],
       "maxTokens" : 131072,
-      "name" : "glm-5v-turbo",
+      "name" : "GLM-5V-Turbo",
       "provider" : "zai",
       "reasoning" : true
     }


### PR DESCRIPTION
## Summary

Updates the bundled model catalog generated from pi-mono's `packages/ai/src/models.generated.ts` at source commit `7be8a10d2358fe60f1cf4507140aa9cfa81682ee`.

The generated catalog now contains 32 providers and 931 models. The unsupported `google-gemini-cli` and `google-antigravity` provider groups remain absent.

## Validation

- `swift test`
