### PR TITLE
[codex] Upgrade swift-crypto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  PROCESS_TEST_FILTER: AgentBackgroundTests|BackgroundTaskManagerTests|BashBackgroundRunnerTests|BashToolBackgroundTests|BashToolTests|TaskStatusToolTests|TmuxSessionManagerTests|TmuxToolTests|WaitTaskToolTests
+
 jobs:
   build-macos:
     runs-on: macos-15
@@ -13,7 +16,9 @@ jobs:
       - name: swift build
         run: swift build --product kwwk
       - name: swift test
-        run: swift test
+        run: |
+          swift test --skip "$PROCESS_TEST_FILTER"
+          swift test --no-parallel --filter "$PROCESS_TEST_FILTER"
 
   build-linux:
     runs-on: ubuntu-latest
@@ -23,4 +28,6 @@ jobs:
       - name: swift build
         run: swift build --product kwwk
       - name: swift test
-        run: swift test
+        run: |
+          swift test --skip "$PROCESS_TEST_FILTER"
+          swift test --no-parallel --filter "$PROCESS_TEST_FILTER"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d022f6922ac40a7dfe5d0f83b23a39084b4cf759088b37e8bf00b696a72da282",
+  "originHash" : "4835f3bb1bfca1e12b14d199a549a4efbe98e0c41edb3ff96a828c17eb23aae2",
   "pins" : [
     {
       "identity" : "swift-asn1",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         // swift-crypto's `Crypto` module is source-compatible with Apple's
         // `CryptoKit` and ships on both Apple and Linux — one import, one
         // set of types, regardless of platform.
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
         // SwiftNIO backs the OAuth callback server. Replaces the Apple
         // `Network.framework`-only implementation so the OAuth login flow
         // runs the same code on macOS and Linux.

--- a/Tests/KWWKAgentTests/AgentBackgroundTests.swift
+++ b/Tests/KWWKAgentTests/AgentBackgroundTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import KWWKAgent
 @testable import KWWKAI
 
-@Suite("Agent + BackgroundTaskManager")
+@Suite("Agent + BackgroundTaskManager", .serialized)
 struct AgentBackgroundTests {
 
     @Test("background notification wakes an idle agent and shows up as a user message")
@@ -44,7 +44,10 @@ struct AgentBackgroundTests {
                 return false
             }
         }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for background notification in idle agent")
+            return
+        }
     }
 
     @Test("notifications delivered mid-turn are injected as steering at turn boundaries")
@@ -102,7 +105,10 @@ struct AgentBackgroundTests {
                 return false
             }
         }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for mid-turn background notification")
+            return
+        }
     }
 
     @Test("abortAndKillBackgroundTasks drains the manager")

--- a/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
+++ b/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
@@ -97,7 +97,7 @@ private func makeOutputDir() -> URL {
 
 // MARK: - Suites
 
-@Suite("BackgroundTaskManager")
+@Suite("BackgroundTaskManager", .serialized)
 struct BackgroundTaskManagerTests {
 
     @Test("spawn + complete enqueues a notification")
@@ -119,9 +119,15 @@ struct BackgroundTaskManagerTests {
         _ = file
 
         let ok = await awaitUntil(2000) { await manager.hasNotifications(sessionId: "s1") }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for task notification")
+            return
+        }
         let notifs = await manager.drainNotifications(sessionId: "s1")
-        #expect(notifs.count == 1)
+        guard notifs.count == 1 else {
+            Issue.record("expected exactly one notification, got \(notifs.count)")
+            return
+        }
         let notif = notifs[0]
         #expect(notif.taskId == taskId)
         #expect(notif.status == .completed)
@@ -167,7 +173,10 @@ struct BackgroundTaskManagerTests {
         #expect(snap2?.status == .killed)
 
         let ok = await awaitUntil(1000) { await manager.hasNotifications(sessionId: "s1") }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for killed notification")
+            return
+        }
         let notifs = await manager.drainNotifications(sessionId: "s1")
         #expect(notifs.contains { $0.status == .killed && $0.taskId == taskId })
     }
@@ -201,19 +210,29 @@ struct BackgroundTaskManagerTests {
         _ = await manager.spawn(runner: FauxRunner(label: "a"), sessionId: "alpha")
         _ = await manager.spawn(runner: FauxRunner(label: "b"), sessionId: "beta")
 
-        _ = await awaitUntil(2000) {
+        let ready = await awaitUntil(2000) {
             let hasAlpha = await manager.hasNotifications(sessionId: "alpha")
             let hasBeta = await manager.hasNotifications(sessionId: "beta")
             return hasAlpha && hasBeta
         }
+        guard ready else {
+            Issue.record("timed out waiting for alpha and beta notifications")
+            return
+        }
 
         let alpha = await manager.drainNotifications(sessionId: "alpha")
-        #expect(alpha.count == 1)
+        guard alpha.count == 1 else {
+            Issue.record("expected one alpha notification, got \(alpha.count)")
+            return
+        }
         #expect(alpha[0].label == "a")
 
         // Alpha drain should not have touched beta.
         let beta = await manager.drainNotifications(sessionId: "beta")
-        #expect(beta.count == 1)
+        guard beta.count == 1 else {
+            Issue.record("expected one beta notification, got \(beta.count)")
+            return
+        }
         #expect(beta[0].label == "b")
     }
 
@@ -229,11 +248,18 @@ struct BackgroundTaskManagerTests {
         }
         _ = await manager.spawn(runner: FauxRunner(label: "sub"), sessionId: "s1")
 
-        _ = await awaitUntil(2000) {
+        let delivered = await awaitUntil(2000) {
             await received.count() >= 1
         }
+        guard delivered else {
+            Issue.record("timed out waiting for subscriber notification")
+            return
+        }
         let all = await received.all()
-        #expect(all.count == 1)
+        guard all.count == 1 else {
+            Issue.record("expected one subscriber notification, got \(all.count)")
+            return
+        }
         #expect(all[0].label == "sub")
 
         await handle.unsubscribe()
@@ -290,7 +316,11 @@ struct BackgroundTaskManagerTests {
         let ok = await awaitUntil(5000) {
             await manager.hasNotifications(sessionId: "s1")
         }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for stalled notification")
+            try? await manager.kill(taskId)
+            return
+        }
         let notifs = await manager.drainNotifications(sessionId: "s1")
         #expect(notifs.contains { $0.stalled && $0.taskId == taskId })
 
@@ -337,7 +367,10 @@ struct BackgroundTaskManagerTests {
             let s = await manager.get(taskId)
             return s?.status == .completed
         }
-        #expect(ok)
+        guard ok else {
+            Issue.record("timed out waiting for adopted task completion")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.outcome?.summary == "done")
         if case .object(let obj) = snap?.outcome?.details ?? .null,
@@ -457,8 +490,15 @@ struct BackgroundTaskManagerTests {
             writeToFile: "hi\n"
         )
         _ = await manager.spawn(runner: runner, sessionId: "s1")
-        _ = await awaitUntil(1000) { await manager.hasNotifications(sessionId: "s1") }
-        let n = await manager.drainNotifications(sessionId: "s1").first!
+        let ok = await awaitUntil(1000) { await manager.hasNotifications(sessionId: "s1") }
+        guard ok else {
+            Issue.record("timed out waiting for notification")
+            return
+        }
+        guard let n = await manager.drainNotifications(sessionId: "s1").first else {
+            Issue.record("expected notification")
+            return
+        }
         let text = n.messageText()
         #expect(text.contains("<task-notification>"))
         #expect(text.contains("<kind>bash</kind>"))

--- a/Tests/KWWKAgentTests/BashBackgroundTests.swift
+++ b/Tests/KWWKAgentTests/BashBackgroundTests.swift
@@ -28,7 +28,7 @@ func awaitUntil(
     return false
 }
 
-@Suite("BashBackgroundRunner")
+@Suite("BashBackgroundRunner", .serialized)
 struct BashBackgroundRunnerTests {
 
     @Test("runs a command, writes stdout to the output file and reports exit 0")
@@ -46,7 +46,10 @@ struct BashBackgroundRunnerTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for bash background runner")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.status == .completed)
         if let outcome = snap?.outcome {
@@ -68,7 +71,10 @@ struct BashBackgroundRunnerTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for failing bash background runner")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.status == .failed)
         #expect(snap?.outcome?.summary == "exit 3")
@@ -88,7 +94,10 @@ struct BashBackgroundRunnerTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for cancelled bash background runner")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.status == .killed)
     }
@@ -107,13 +116,16 @@ struct BashBackgroundRunnerTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for bash environment propagation")
+            return
+        }
         let contents = (try? String(contentsOf: file, encoding: .utf8)) ?? ""
         #expect(contents.contains("extraenv-works"))
     }
 }
 
-@Suite("Bash tool + background manager")
+@Suite("Bash tool + background manager", .serialized)
 struct BashToolBackgroundTests {
 
     @Test("run_in_background=true returns immediately with a task id")
@@ -155,7 +167,10 @@ struct BashToolBackgroundTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for explicit background command")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.status == .completed)
     }
@@ -281,7 +296,10 @@ struct BashToolBackgroundTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for auto-backgrounded command")
+            return
+        }
         let snap = await manager.get(taskId)
         #expect(snap?.status == .completed)
         if let file = snap?.outputFile {
@@ -291,7 +309,7 @@ struct BashToolBackgroundTests {
     }
 }
 
-@Suite("task_status tool")
+@Suite("task_status tool", .serialized)
 struct TaskStatusToolTests {
 
     @Test("list returns running tasks")
@@ -328,7 +346,10 @@ struct TaskStatusToolTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for task before status lookup")
+            return
+        }
 
         let tool = createTaskStatusTool(manager: manager, sessionId: "s1")
         let result = try await tool.execute(
@@ -403,9 +424,13 @@ struct TaskStatusToolTests {
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let runner = BashBackgroundRunner(command: "echo done")
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
-        _ = await awaitUntil(3000) {
+        let done = await awaitUntil(3000) {
             let s = await manager.get(taskId)
             return s?.status != .running
+        }
+        guard done else {
+            Issue.record("timed out waiting for terminal task before kill")
+            return
         }
         let tool = createTaskStatusTool(manager: manager, sessionId: "s1")
         let result = try await tool.execute(

--- a/Tests/KWWKAgentTests/TmuxToolTests.swift
+++ b/Tests/KWWKAgentTests/TmuxToolTests.swift
@@ -20,7 +20,7 @@ private func makeSessionManager() -> TmuxSessionManager {
     )
 }
 
-@Suite("TmuxSessionManager")
+@Suite("TmuxSessionManager", .serialized)
 struct TmuxSessionManagerTests {
 
     @Test("availability probe reflects whether tmux is installed")
@@ -120,7 +120,7 @@ struct TmuxSessionManagerTests {
     }
 }
 
-@Suite("Tmux tool")
+@Suite("Tmux tool", .serialized)
 struct TmuxToolTests {
 
     @Test("createTmuxTool returns nil when tmux is unavailable")

--- a/Tests/KWWKAgentTests/WaitTaskToolTests.swift
+++ b/Tests/KWWKAgentTests/WaitTaskToolTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import KWWKAI
 @testable import KWWKAgent
 
-@Suite("wait_task tool")
+@Suite("wait_task tool", .serialized)
 struct WaitTaskToolTests {
 
     @Test("returns immediately when the task is already terminal")
@@ -17,7 +17,10 @@ struct WaitTaskToolTests {
             let s = await manager.get(taskId)
             return s?.status != .running
         }
-        #expect(done)
+        guard done else {
+            Issue.record("timed out waiting for task before fast-path wait")
+            return
+        }
 
         let tool = createWaitTaskTool(manager: manager, sessionId: "s1")
         let start = Date()
@@ -175,4 +178,3 @@ struct WaitTaskToolTests {
 }
 
 // MARK: - Helpers
-


### PR DESCRIPTION
## Summary

- Raise the `swift-crypto` SwiftPM requirement from `3.0.0` to `4.0.0`.
- Refresh `Package.resolved` so the package resolves to `swift-crypto` `4.5.0`.
- Stabilize CI for process-backed/background tests by running that subset serially and making notification assertions fail without crashing on empty arrays.

## Validation

- `swift build -c release --product kwwk`
- `swift test --skip "$PROCESS_TEST_FILTER"` with `PROCESS_TEST_FILTER=AgentBackgroundTests|BackgroundTaskManagerTests|BashBackgroundRunnerTests|BashToolBackgroundTests|BashToolTests|TaskStatusToolTests|TmuxSessionManagerTests|TmuxToolTests|WaitTaskToolTests` (352 tests)
- `swift test --no-parallel --filter "$PROCESS_TEST_FILTER"` with the same filter (62 tests)
- `git diff --check`

## Notes

The original CI failure was in existing background/process test timing, not a `swift-crypto` compile or API regression. The workflow keeps normal tests on the default runner and only serializes the shell/tmux/background subset.