### PR TITLE
[codex] Run Swift tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  PROCESS_TEST_FILTER: AgentBackgroundTests|BackgroundTaskManagerTests|BashBackgroundRunnerTests|BashToolBackgroundTests|BashToolTests|TaskStatusToolTests|TmuxSessionManagerTests|TmuxToolTests|WaitTaskToolTests
-
 jobs:
   build-macos:
     runs-on: macos-15
@@ -16,9 +13,7 @@ jobs:
       - name: swift build
         run: swift build --product kwwk
       - name: swift test
-        run: |
-          swift test --skip "$PROCESS_TEST_FILTER"
-          swift test --no-parallel --filter "$PROCESS_TEST_FILTER"
+        run: bash Scripts/test.sh
 
   build-linux:
     runs-on: ubuntu-latest
@@ -28,6 +23,4 @@ jobs:
       - name: swift build
         run: swift build --product kwwk
       - name: swift test
-        run: |
-          swift test --skip "$PROCESS_TEST_FILTER"
-          swift test --no-parallel --filter "$PROCESS_TEST_FILTER"
+        run: bash Scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ flow via `KWWKAI.OAuth` / `OAuthLogin` — the same code path the CLI's
 
 ```sh
 swift run kwwk-generate-models /path/to/pi-mono/packages/ai/src/models.generated.ts
-swift test
+Scripts/test.sh
 ```
 
 The generator writes `Sources/KWWKAI/Resources/models.json` by default.
@@ -356,8 +356,11 @@ Antigravity provider groups stay absent.
 - `Sources/kwwk` — the executable entry point
 - `Tests/` — XCTest suites for each module
 
+Use the test script instead of bare `swift test`; it runs isolated suites in
+parallel and keeps process/tmux suites serialized.
+
 ```sh
-swift test
+Scripts/test.sh
 ```
 
 ## A note on OAuth client IDs

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# These suites spawn background processes or tmux panes, so keep them isolated
+# while the rest of the package runs with SwiftPM's parallel test runner.
+SERIAL_TEST_FILTER=${SERIAL_TEST_FILTER:-'AgentBackgroundTests|BackgroundTaskManagerTests|BashBackgroundRunnerTests|BashToolBackgroundTests|BashToolTests|TaskStatusToolTests|TmuxSessionManagerTests|TmuxToolTests|WaitTaskToolTests'}
+
+if (($#)); then
+  echo "usage: Scripts/test.sh" >&2
+  exit 64
+fi
+
+swift test --parallel --skip "$SERIAL_TEST_FILTER"
+swift test --skip-build --no-parallel --filter "$SERIAL_TEST_FILTER"


### PR DESCRIPTION
## Summary

- Add `Scripts/test.sh` as the shared test entrypoint.
- Run isolated SwiftPM tests with `--parallel`.
- Keep background process and tmux suites serialized with `--no-parallel`.
- Update CI and README to use the script instead of bare `swift test`.

## Why

SwiftPM defaults `swift test` to `--no-parallel`, so the regular unit test suite was running serially even though most suites are safe to execute concurrently. The few process/tmux-heavy suites still need isolation, so the script splits the run into a parallel main pass and a serialized filtered pass.

## Validation

- `bash Scripts/test.sh` passed locally.
- Parallel pass: 571 tests in 99 suites passed after ~1.141s test runtime.
- Serialized pass: 63 tests in 9 suites passed after ~19.700s test runtime.