### PR TITLE
[codex] fix session compaction persistence

### DIFF
--- a/Sources/KWWKAgent/SessionRecorder.swift
+++ b/Sources/KWWKAgent/SessionRecorder.swift
@@ -11,7 +11,8 @@ import KWWKAI
 /// (`messageEnd`, `turnEnd`, `agentEnd`) by diffing the agent's current
 /// transcript against the count already written, then appending only the new
 /// tail. That keeps writes append-only even when the loop produces several
-/// messages between events.
+/// messages between events. Compaction is persisted as its own append-only
+/// marker and resets the live-message baseline to the compacted context.
 public final class SessionRecorder: @unchecked Sendable {
     private let store: SessionStore
     private let sessionId: String
@@ -22,6 +23,8 @@ public final class SessionRecorder: @unchecked Sendable {
     private let lock = NSLock()
     /// Number of transcript messages already flushed to disk.
     private var persistedCount: Int
+    /// Usage snapshot from the latest compactStart, consumed by compactEnd.
+    private var pendingCompactionUsage: AgentContextUsage?
     /// Tail of the serialized append chain. Each flush enqueues its write after
     /// the previous one so concurrent events can't reorder the on-disk JSONL.
     private var appendChain: Task<Void, Never>?
@@ -60,6 +63,15 @@ public final class SessionRecorder: @unchecked Sendable {
             switch event {
             case .messageEnd, .turnEnd, .agentEnd:
                 await self.flush(messages: agent.state.messages)
+            case .compactStart(_, let usage):
+                await self.noteCompactionStart(usage)
+            case .compactEnd(let outcome):
+                if case .compacted(let messagesCompacted, _) = outcome {
+                    await self.recordCompaction(
+                        messages: agent.state.messages,
+                        messagesCompacted: messagesCompacted
+                    )
+                }
             default:
                 break
             }
@@ -96,5 +108,51 @@ public final class SessionRecorder: @unchecked Sendable {
             return next
         }
         await work?.value
+    }
+
+    /// Record that the live context has been replaced by a compacted
+    /// projection. This appends a compaction marker after any queued message
+    /// writes and resets the baseline so the next post-compaction message is
+    /// persisted immediately.
+    public func recordCompaction(
+        messages replacementMessages: [Message],
+        messagesCompacted: Int,
+        tokensBefore: Int? = nil,
+        contextWindow: Int? = nil
+    ) async {
+        let work: Task<Void, Never> = lock.withLock {
+            let usage = pendingCompactionUsage
+            pendingCompactionUsage = nil
+            persistedCount = replacementMessages.count
+
+            let previous = appendChain
+            let store = self.store
+            let sessionId = self.sessionId
+            let cwd = self.cwd
+            let model = self.model
+            let provider = self.provider
+            let next = Task<Void, Never> {
+                await previous?.value
+                try? await store.appendCompaction(
+                    id: sessionId,
+                    cwd: cwd,
+                    replacementMessages: replacementMessages,
+                    messagesCompacted: messagesCompacted,
+                    tokensBefore: tokensBefore ?? usage?.tokens,
+                    contextWindow: contextWindow ?? usage?.window,
+                    model: model,
+                    provider: provider
+                )
+            }
+            appendChain = next
+            return next
+        }
+        await work.value
+    }
+
+    private func noteCompactionStart(_ usage: AgentContextUsage) async {
+        lock.withLock {
+            pendingCompactionUsage = usage
+        }
     }
 }

--- a/Sources/KWWKAgent/SessionResume.swift
+++ b/Sources/KWWKAgent/SessionResume.swift
@@ -23,7 +23,7 @@ public enum SessionResume: Sendable, Hashable {
 }
 
 /// Result of resolving a `SessionResume` against a `SessionStore`: the
-/// session id to use plus any transcript to seed the agent with. When nothing
+/// session id to use plus any context to seed the agent with. When nothing
 /// matched (`.none`, or `.latestForCwd` with no prior session), `messages` is
 /// empty and `persistedCount` is zero so the recorder starts appending from
 /// scratch.
@@ -32,7 +32,8 @@ public struct ResolvedResume: Sendable {
     public var messages: [Message]
     public var model: String?
     public var thinkingLevel: String?
-    /// Number of transcript messages already on disk for this session.
+    /// Number of projected context messages already represented on disk for
+    /// this session.
     public var persistedCount: Int
     /// True when an existing session was loaded (vs. a fresh id minted).
     public var resumed: Bool
@@ -82,7 +83,7 @@ extension SessionStore {
                 messages: loaded.messages,
                 model: loaded.model,
                 thinkingLevel: loaded.thinkingLevel,
-                persistedCount: loaded.messages.count,
+                persistedCount: loaded.persistedContextCount,
                 resumed: true
             )
 
@@ -97,7 +98,7 @@ extension SessionStore {
                     messages: loaded.messages,
                     model: loaded.model,
                     thinkingLevel: loaded.thinkingLevel,
-                    persistedCount: loaded.messages.count,
+                    persistedCount: loaded.persistedContextCount,
                     resumed: true
                 )
             } catch SessionStoreError.notFound {

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -8,18 +8,21 @@ import KWWKAI
 /// Mirrors pi's `packages/agent/src/harness/session` storage in spirit but
 /// keeps a flat append-only log instead of pi's branching entry tree: each
 /// session file is a versioned header line followed by one JSON entry per
-/// line. Entries are either transcript messages (`user` / `assistant` /
-/// `toolResult`) or sparse metadata updates (model / thinking-level changes).
+/// line. Entries are transcript messages (`user` / `assistant` /
+/// `toolResult`), sparse metadata updates (model / thinking-level changes),
+/// or compaction markers that describe the projected resumable context.
 ///
 /// The store never rewrites the file — every `append(...)` is an `O(1)` write
 /// to the end of the file, so persisting on every message is cheap. Loading
-/// replays the log to reconstruct the transcript plus the latest metadata.
+/// replays the log to reconstruct the projected context plus the latest
+/// metadata.
 ///
 /// File layout (one JSON object per line):
 /// ```
 /// {"type":"session","version":1,"id":"…","cwd":"…","createdAt":…,"model":"…","provider":"…"}
 /// {"type":"message","timestamp":…,"message":{ …Message… }}
 /// {"type":"meta","timestamp":…,"model":"…","provider":"…","thinkingLevel":"…"}
+/// {"type":"compaction","timestamp":…,"replacementMessages":[{ …Message… }],"messagesCompacted":42}
 /// ```
 public actor SessionStore {
 
@@ -85,16 +88,44 @@ public actor SessionStore {
         }
     }
 
-    /// One appended log line after the header. Either a transcript message or
-    /// a metadata update.
+    /// Append-only marker written when the live agent context is compacted.
+    /// `replacementMessages` is the model-facing context that should replace
+    /// prior projected messages when the session is resumed.
+    public struct Compaction: Codable, Sendable, Hashable {
+        public var replacementMessages: [Message]
+        public var messagesCompacted: Int
+        public var firstKeptMessageIndex: Int?
+        public var tokensBefore: Int?
+        public var contextWindow: Int?
+
+        public init(
+            replacementMessages: [Message],
+            messagesCompacted: Int,
+            firstKeptMessageIndex: Int? = nil,
+            tokensBefore: Int? = nil,
+            contextWindow: Int? = nil
+        ) {
+            self.replacementMessages = replacementMessages
+            self.messagesCompacted = messagesCompacted
+            self.firstKeptMessageIndex = firstKeptMessageIndex
+            self.tokensBefore = tokensBefore
+            self.contextWindow = contextWindow
+        }
+    }
+
+    /// One appended log line after the header. Either a transcript message,
+    /// a metadata update, or a context compaction marker.
     public enum Entry: Codable, Sendable, Hashable {
         case message(timestamp: Int64, message: Message)
         case meta(timestamp: Int64, model: String?, provider: String?, thinkingLevel: String?)
+        case compaction(timestamp: Int64, compaction: Compaction)
 
         private enum CodingKeys: String, CodingKey {
             case type, timestamp, message, model, provider, thinkingLevel
+            case replacementMessages, messagesCompacted, firstKeptMessageIndex
+            case tokensBefore, contextWindow
         }
-        private enum Kind: String, Codable { case message, meta }
+        private enum Kind: String, Codable { case message, meta, compaction }
 
         public init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -108,6 +139,19 @@ public actor SessionStore {
                     model: try c.decodeIfPresent(String.self, forKey: .model),
                     provider: try c.decodeIfPresent(String.self, forKey: .provider),
                     thinkingLevel: try c.decodeIfPresent(String.self, forKey: .thinkingLevel)
+                )
+            case .compaction:
+                self = .compaction(
+                    timestamp: timestamp,
+                    compaction: Compaction(
+                        replacementMessages: try c.decode(
+                            [Message].self, forKey: .replacementMessages),
+                        messagesCompacted: try c.decode(Int.self, forKey: .messagesCompacted),
+                        firstKeptMessageIndex: try c.decodeIfPresent(
+                            Int.self, forKey: .firstKeptMessageIndex),
+                        tokensBefore: try c.decodeIfPresent(Int.self, forKey: .tokensBefore),
+                        contextWindow: try c.decodeIfPresent(Int.self, forKey: .contextWindow)
+                    )
                 )
             }
         }
@@ -125,14 +169,28 @@ public actor SessionStore {
                 try c.encodeIfPresent(model, forKey: .model)
                 try c.encodeIfPresent(provider, forKey: .provider)
                 try c.encodeIfPresent(thinkingLevel, forKey: .thinkingLevel)
+            case .compaction(let timestamp, let compaction):
+                try c.encode(Kind.compaction, forKey: .type)
+                try c.encode(timestamp, forKey: .timestamp)
+                try c.encode(compaction.replacementMessages, forKey: .replacementMessages)
+                try c.encode(compaction.messagesCompacted, forKey: .messagesCompacted)
+                try c.encodeIfPresent(
+                    compaction.firstKeptMessageIndex, forKey: .firstKeptMessageIndex)
+                try c.encodeIfPresent(compaction.tokensBefore, forKey: .tokensBefore)
+                try c.encodeIfPresent(compaction.contextWindow, forKey: .contextWindow)
             }
         }
     }
 
-    /// Metadata + replayed transcript returned by `load`.
+    /// Metadata + projected resumable context returned by `load`.
     public struct LoadedSession: Sendable, Hashable {
         public var header: Header
+        /// Model-facing context after replaying any compaction markers.
         public var messages: [Message]
+        /// Raw transcript message entries, excluding compaction replacements.
+        public var transcriptMessages: [Message]
+        /// Number of messages in `messages` already represented on disk.
+        public var persistedContextCount: Int
         /// Latest model id seen (from the header or a later `meta` entry).
         public var model: String?
         /// Latest provider id seen.
@@ -143,12 +201,16 @@ public actor SessionStore {
         public init(
             header: Header,
             messages: [Message],
+            transcriptMessages: [Message]? = nil,
+            persistedContextCount: Int? = nil,
             model: String?,
             provider: String?,
             thinkingLevel: String?
         ) {
             self.header = header
             self.messages = messages
+            self.transcriptMessages = transcriptMessages ?? messages
+            self.persistedContextCount = persistedContextCount ?? messages.count
             self.model = model
             self.provider = provider
             self.thinkingLevel = thinkingLevel
@@ -297,6 +359,38 @@ public actor SessionStore {
         ))
     }
 
+    /// Record a context compaction without rewriting prior message entries.
+    /// Loading the session will project `replacementMessages` first, followed
+    /// by message entries appended after this marker.
+    public func appendCompaction(
+        id: String,
+        cwd: String,
+        replacementMessages: [Message],
+        messagesCompacted: Int,
+        firstKeptMessageIndex: Int? = nil,
+        tokensBefore: Int? = nil,
+        contextWindow: Int? = nil,
+        model: String? = nil,
+        provider: String? = nil
+    ) throws {
+        let url = try path(for: id)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try create(id: id, cwd: cwd, model: model, provider: provider)
+        }
+        try appendEntry(
+            id: id,
+            .compaction(
+                timestamp: Timestamp.now(),
+                compaction: Compaction(
+                    replacementMessages: replacementMessages,
+                    messagesCompacted: messagesCompacted,
+                    firstKeptMessageIndex: firstKeptMessageIndex,
+                    tokensBefore: tokensBefore,
+                    contextWindow: contextWindow
+                )
+            ))
+    }
+
     private func appendEntry(id: String, _ entry: Entry) throws {
         let url = try path(for: id)
         guard FileManager.default.fileExists(atPath: url.path) else {
@@ -312,8 +406,9 @@ public actor SessionStore {
 
     // MARK: - Load
 
-    /// Replay a session file into its header, full transcript, and latest
-    /// metadata. Throws on a missing/invalid header or unsupported version.
+    /// Replay a session file into its header, projected resumable context, raw
+    /// transcript message entries, and latest metadata. Throws on a
+    /// missing/invalid header or unsupported version.
     public func load(id: String) throws -> LoadedSession {
         try load(at: try path(for: id))
     }
@@ -329,6 +424,7 @@ public actor SessionStore {
         let header = try parseHeader(String(first), path: url.path)
 
         var messages: [Message] = []
+        var transcriptMessages: [Message] = []
         var model = header.model
         var provider = header.provider
         var thinkingLevel: String?
@@ -342,17 +438,22 @@ public actor SessionStore {
             }
             switch entry {
             case .message(_, let message):
+                transcriptMessages.append(message)
                 messages.append(message)
             case .meta(_, let m, let p, let t):
                 if let m { model = m }
                 if let p { provider = p }
                 if let t { thinkingLevel = t }
+            case .compaction(_, let compaction):
+                messages = compaction.replacementMessages
             }
         }
 
         return LoadedSession(
             header: header,
             messages: messages,
+            transcriptMessages: transcriptMessages,
+            persistedContextCount: messages.count,
             model: model,
             provider: provider,
             thinkingLevel: thinkingLevel
@@ -426,6 +527,8 @@ public actor SessionStore {
             case .meta(_, let m, let p, _):
                 if let m { model = m }
                 if let p { provider = p }
+            case .compaction:
+                continue
             }
         }
 

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -351,6 +351,7 @@ private func handleCompactCommand(_ ctx: SlashContext, _ args: String) async {
     case .compacted(let n, let hasLedger):
         // Show a compact record + durable boundary so the user can
         // scroll up later and see where the compact happened.
+        await ctx.recordCompaction(n)
         ctx.notify(Style.dimmed("  /compact: summarizing \(n) messages…"))
         ctx.commitScrollback { width in
             renderCompactBoundary(

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -364,6 +364,12 @@ func runCodingTUIInternal(
             renderer.setThinkingDisplay(agent.state.thinkingDisplay)
             recomputeTranscript()
             runner.tui.requestRender()
+        },
+        recordCompaction: { messagesCompacted in
+            await sessionRecorder.recordCompaction(
+                messages: agent.state.messages,
+                messagesCompacted: messagesCompacted
+            )
         }
     )
 

--- a/Sources/KWWKCli/SlashCommand.swift
+++ b/Sources/KWWKCli/SlashCommand.swift
@@ -64,6 +64,9 @@ final class SlashContext {
     /// (e.g. `/thinking show|hide`) without emitting an AgentEvent the
     /// listener would otherwise observe.
     let refreshTranscript: @MainActor () -> Void
+    /// Persist a successful manual compaction. Automatic compaction uses
+    /// AgentEvent subscriptions; slash commands need an explicit hook.
+    let recordCompaction: @MainActor (_ messagesCompacted: Int) async -> Void
 
     init(
         agent: Agent,
@@ -72,7 +75,8 @@ final class SlashContext {
         sessionId: String,
         notifyBlock: @MainActor @escaping ([String]) -> Void,
         commitScrollback: @MainActor @escaping ((Int) -> [String]) -> Void,
-        refreshTranscript: @MainActor @escaping () -> Void
+        refreshTranscript: @MainActor @escaping () -> Void,
+        recordCompaction: @MainActor @escaping (_ messagesCompacted: Int) async -> Void = { _ in }
     ) {
         self.agent = agent
         self.modal = modal
@@ -81,6 +85,7 @@ final class SlashContext {
         self.notifyBlock = notifyBlock
         self.commitScrollback = commitScrollback
         self.refreshTranscript = refreshTranscript
+        self.recordCompaction = recordCompaction
     }
 
     /// Single-line convenience: one-off status messages (`/model switched

--- a/Tests/KWWKAgentTests/SessionStoreTests.swift
+++ b/Tests/KWWKAgentTests/SessionStoreTests.swift
@@ -44,6 +44,28 @@ struct SessionStoreTests {
         }
     }
 
+    private func text(from message: Message?) -> String {
+        switch message {
+        case .user(let user):
+            return user.content.compactMap { block in
+                guard case .text(let text) = block else { return nil }
+                return text.text
+            }.joined(separator: "\n")
+        case .assistant(let assistant):
+            return assistant.content.compactMap { block in
+                guard case .text(let text) = block else { return nil }
+                return text.text
+            }.joined(separator: "\n")
+        case .toolResult(let result):
+            return result.content.compactMap { block in
+                guard case .text(let text) = block else { return nil }
+                return text.text
+            }.joined(separator: "\n")
+        case nil:
+            return ""
+        }
+    }
+
     @Test("round-trip: append then load preserves order and content")
     func roundTrip() async throws {
         let (store, dir) = tempStore()
@@ -215,6 +237,85 @@ struct SessionStoreTests {
         #expect(loaded.messages.count == 1)
     }
 
+    @Test("load projects the latest compaction entry as resumable context")
+    func loadProjectsCompaction() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-compact"
+        let cwd = "/w"
+        let before = [
+            userMsg("one"),
+            assistantMsg("two"),
+            toolResultMsg("three"),
+        ]
+        for message in before {
+            try await store.append(id: id, cwd: cwd, message: message)
+        }
+
+        let summary = userMsg(
+            "<previous-session-summary>one through three</previous-session-summary>")
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [summary],
+            messagesCompacted: before.count,
+            tokensBefore: 123,
+            contextWindow: 456
+        )
+
+        let after = userMsg("after compact")
+        try await store.append(id: id, cwd: cwd, message: after)
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [summary, after])
+        #expect(loaded.transcriptMessages == before + [after])
+        #expect(loaded.persistedContextCount == 2)
+
+        let raw = try String(contentsOf: dir.appendingPathComponent("\(id).jsonl"), encoding: .utf8)
+        #expect(raw.contains(#""type":"compaction""#))
+        #expect(raw.contains(#""tokensBefore":123"#))
+    }
+
+    @Test("repeated compactions project from the newest marker")
+    func repeatedCompactionsUseNewestProjection() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-repeat-compact"
+        let cwd = "/w"
+        let a = userMsg("a")
+        let b = assistantMsg("b")
+        try await store.append(id: id, cwd: cwd, messages: [a, b])
+
+        let firstSummary = userMsg("summary a-b")
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [firstSummary],
+            messagesCompacted: 2
+        )
+
+        let c = userMsg("c")
+        try await store.append(id: id, cwd: cwd, message: c)
+
+        let secondSummary = userMsg("summary compacted-plus-c")
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [secondSummary],
+            messagesCompacted: 2
+        )
+
+        let d = assistantMsg("d")
+        try await store.append(id: id, cwd: cwd, message: d)
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [secondSummary, d])
+        #expect(loaded.transcriptMessages == [a, b, c, d])
+        #expect(loaded.persistedContextCount == 2)
+    }
+
     @Test("resolveResume(.latestForCwd) seeds the stored transcript")
     func resolveResumeLatest() async throws {
         let (store, dir) = tempStore()
@@ -263,5 +364,113 @@ struct SessionStoreTests {
 
         let loaded = try await store.load(id: id)
         #expect(loaded.messages.count == 2)
+    }
+
+    @Test("SessionRecorder resets its append baseline after compaction")
+    func recorderAppendsImmediatelyAfterCompaction() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-rec-compact"
+        let recorder = SessionRecorder(
+            store: store, sessionId: id, cwd: "/w",
+            model: "m1", provider: "p1"
+        )
+        await recorder.ensureCreated()
+
+        let before = [
+            userMsg("a"),
+            assistantMsg("b"),
+            userMsg("c"),
+            assistantMsg("d"),
+        ]
+        await recorder.flush(messages: before)
+
+        let summary = userMsg("<previous-session-summary>a-d</previous-session-summary>")
+        await recorder.recordCompaction(
+            messages: [summary],
+            messagesCompacted: before.count,
+            tokensBefore: 99,
+            contextWindow: 1000
+        )
+
+        let after = userMsg("post-compact")
+        await recorder.flush(messages: [summary, after])
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [summary, after])
+        #expect(loaded.transcriptMessages == before + [after])
+        #expect(loaded.persistedContextCount == 2)
+
+        let raw = try String(contentsOf: dir.appendingPathComponent("\(id).jsonl"), encoding: .utf8)
+        #expect(raw.contains(#""contextWindow":1000"#))
+        #expect(raw.contains(#""tokensBefore":99"#))
+    }
+
+    @Test("SessionRecorder persists compactEnd events from an agent")
+    func recorderPersistsAgentCompactEnd() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let faux = await registerFauxProvider(
+            RegisterFauxProviderOptions(models: [
+                FauxModelDefinition(id: "compact-recorder-window", contextWindow: 5)
+            ]))
+        defer { faux.unregister() }
+
+        let model = faux.getModel()
+        let highUsage = AssistantMessage(
+            content: [.text(TextContent(text: "large answer"))],
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(input: 80, output: 1)
+        )
+        faux.setResponses([
+            .message(highUsage),
+            .message(fauxAssistantMessage("event summary")),
+        ])
+
+        let agent = Agent(
+            options: AgentOptions(
+                initialState: AgentInitialState(
+                    model: model,
+                    messages: [userMsg("seed"), assistantMsg("reply")]
+                ),
+                autoCompact: AgentAutoCompactOptions(
+                    threshold: 0.1,
+                    config: AgentContextCompactionConfig(minMessages: 1)
+                )
+            ))
+
+        let id = "sess-agent-compact"
+        let recorder = SessionRecorder(
+            store: store,
+            sessionId: id,
+            cwd: "/w",
+            model: model.id,
+            provider: model.provider
+        )
+        await recorder.ensureCreated()
+        let unsubscribe = recorder.attach(to: agent)
+        defer { unsubscribe() }
+
+        try await agent.prompt("trigger compaction")
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages.count == 1)
+        #expect(text(from: loaded.messages.first).contains("event summary"))
+        #expect(loaded.transcriptMessages.count > loaded.messages.count)
+        #expect(loaded.persistedContextCount == 1)
+
+        let resolved = await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh")
+        #expect(resolved.resumed)
+        #expect(resolved.messages == loaded.messages)
+        #expect(resolved.persistedCount == loaded.persistedContextCount)
+
+        let raw = try String(contentsOf: dir.appendingPathComponent("\(id).jsonl"), encoding: .utf8)
+        #expect(raw.contains(#""type":"compaction""#))
+        #expect(raw.contains(#""contextWindow":5"#))
+        #expect(raw.contains(#""tokensBefore":"#))
     }
 }

--- a/Tests/KWWKCliTests/CompactCommandTests.swift
+++ b/Tests/KWWKCliTests/CompactCommandTests.swift
@@ -101,6 +101,7 @@ struct CompactCommandTests {
 
         let notifier = NotifyBox()
         let commits = CommitBox()
+        var recordedMessagesCompacted: Int?
         let ctx = SlashContext(
             agent: agent,
             modal: makeStubModalHost(),
@@ -108,7 +109,8 @@ struct CompactCommandTests {
             sessionId: "test-session",
             notifyBlock: { lines in for l in lines { notifier.append(l) } },
             commitScrollback: commits.collect(),
-            refreshTranscript: {}
+            refreshTranscript: {},
+            recordCompaction: { n in recordedMessagesCompacted = n }
         )
         let registry = SlashCommandRegistry()
         registerBuiltinSlashCommands(registry)
@@ -127,6 +129,7 @@ struct CompactCommandTests {
         // The durable boundary lives in scrollback now, not in the
         // transient notification area.
         #expect(commits.joined.contains("compacted"))
+        #expect(recordedMessagesCompacted == messages.count)
         // And it's shaped like a horizontal rule so it stands out when
         // the user scrolls back through history.
         #expect(commits.joined.contains("──"))


### PR DESCRIPTION
## Summary

- Add append-only `compaction` session entries and project resumable context from the latest marker.
- Persist `compactEnd(.compacted)` in `SessionRecorder` and reset the append baseline so post-compaction messages are written immediately.
- Wire manual `/compact` through the recorder and update resume bookkeeping to use projected-context counts.

## Root Cause

Sessions were stored as a flat append-only message replay. After compaction shortened `agent.state.messages`, the recorder still compared against the old persisted message count, which skipped new messages and made resume replay the full pre-compaction transcript.

## Validation

- `bash Scripts/test.sh` started successfully; its first stage `swift test --parallel --skip "$SERIAL_TEST_FILTER"` passed 587 tests.
- The script's combined second stage (`swift test --skip-build --no-parallel --filter "$SERIAL_TEST_FILTER"`) produced no output and was interrupted after hanging, so the same filter was split by suite and rerun below.
- `swift test --skip-build --no-parallel --filter WaitTaskToolTests` passed 6 tests.
- `swift test --skip-build --no-parallel --filter 'TmuxSessionManagerTests|TmuxToolTests'` passed 15 tests.
- `swift test --skip-build --no-parallel --filter BashBackgroundRunnerTests` passed 5 tests.
- `swift test --skip-build --no-parallel --filter BashToolBackgroundTests` passed 5 tests.
- `swift test --skip-build --no-parallel --filter TaskStatusToolTests` passed 8 tests.
- `swift test --skip-build --no-parallel --filter BackgroundTaskManagerTests` passed 17 tests.
- `swift test --skip-build --no-parallel --filter AgentBackgroundTests` passed 4 tests.
- `swift test --skip-build --no-parallel --filter BashToolTests` passed 4 tests.