### PR TITLE
[codex] harden SDK side-effect defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,17 @@ kwwk login        log in to an OAuth provider
 kwwk --help       show this message
 ```
 
-Credentials come from the OAuth store at `~/.kwwk/oauth.json` — run
-`kwwk login` once to register a provider (OAuth subscription like
-ChatGPT Codex, Gemini, Copilot, or Claude Code; or an API key for
+Credentials come from the OAuth store at `~/.kwwk/oauth.json`; if no login
+exists, the CLI checks supported API-key environment variables. Run
+`kwwk login` once to register a provider explicitly (OAuth subscription
+like ChatGPT Codex, Gemini, Copilot, or Claude Code; or an API key for
 Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint).
 
 Inside the TUI, `/help` lists slash commands (`/model`, `/thinking`,
 `/clear`, …). The agent ships with Bash, Read, Write, Edit, Grep, Find,
-LS, tmux, and background-task tools out of the box.
+LS, and background-task tools out of the box. SDK callers that want tmux
+must opt into `.tmux` or `.allIncludingTmux` and provide an explicit
+`TmuxSessionManager`.
 
 ---
 
@@ -70,6 +73,11 @@ Then depend on the libraries you need:
   message / tool types.
 - **`KWWKAgent`** — the turn/tool loop, built-in coding tools, hooks.
 
+The SDK does not read `~/.kwwk` or process environment variables by
+default. Pass credentials, settings, session stores, context files, and
+skill directories explicitly. The `kwwk` binary is the layer that opts into
+`~/.kwwk/*` and environment-key discovery.
+
 ### Quick start — one-shot run
 
 `Agent.runOnce` mirrors `query()` in the Python Agent SDK: a fresh agent
@@ -80,13 +88,15 @@ import KWWKAI
 import KWWKAgent
 
 // 1. Register a provider using an API key.
-await registerBuiltins(anthropic: ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"])
+let anthropicAPIKey = "sk-ant-..."
+await registerBuiltins(anthropic: anthropicAPIKey)
 
 // 2. Build a coding agent scoped to a working directory.
 let agent = await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet45,
     cwd: FileManager.default.currentDirectoryPath,
-    tools: .all
+    tools: .readOnly,
+    bashEnvironment: [:]
 ))
 
 // 3. Drive it.
@@ -117,12 +127,14 @@ let reviewer = SubagentDefinition(
 )
 
 let bg = BackgroundTaskManager()
+let shellEnvironment = ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
 let agent = await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet45,
     cwd: FileManager.default.currentDirectoryPath,
-    tools: .all,
+    tools: .standard,
     backgroundManager: bg,
-    subagents: [reviewer]
+    subagents: [reviewer],
+    bashEnvironment: shellEnvironment
 ))
 
 try await agent.prompt("Use the reviewer subagent to review Sources/KWWKAgent.")
@@ -135,8 +147,9 @@ copying prompts:
 let agent = await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet45,
     cwd: FileManager.default.currentDirectoryPath,
-    tools: .all,
-    backgroundManager: BackgroundTaskManager()
+    tools: .standard,
+    backgroundManager: BackgroundTaskManager(),
+    bashEnvironment: shellEnvironment
 ).withBuiltinSubagents([.general, .explore, .plan]))
 ```
 
@@ -146,7 +159,9 @@ SDK users can also run a subagent directly:
 let runner = SubagentRunner(
     cwd: FileManager.default.currentDirectoryPath,
     subagents: [.plan()],
-    parentModel: Models.claudeSonnet45
+    parentModel: Models.claudeSonnet45,
+    parentTools: .readOnly,
+    bashEnvironment: [:]
 )
 let result = try await runner.run(
     type: "Plan",
@@ -157,9 +172,10 @@ let result = try await runner.run(
 Subagents are fresh-context agents: they do not inherit the parent
 transcript. The parent model must put the relevant files, errors, goals,
 and constraints into the `agent` tool's `prompt`. Subagents inherit the
-parent model, thinking level, retry delay, and API key resolver, but they
-do not inherit parent hooks such as `betweenTurns`, `transformContext`,
-`convertToLlm`, `userPromptSubmit`, or tool-call hooks.
+parent model, tools when `SubagentDefinition.tools` is nil, thinking
+level, retry delay, and API key resolver, but they do not inherit parent
+hooks such as `betweenTurns`, `transformContext`, `convertToLlm`,
+`userPromptSubmit`, or tool-call hooks.
 
 Each subagent run gets its own child session id. Tools inside that
 subagent, including background-capable tools such as Bash, are scoped to
@@ -188,11 +204,11 @@ is started; their completion is delivered through the existing
 background-task notification flow.
 
 The interactive `kwwk` CLI enables a small built-in set by default:
-`general`, `Explore`, and `Plan`. `general` has wildcard tools by
-default and is used when the model omits `subagent_type`. `Explore` and
-`Plan` are read-only specialists. Use `--no-subagents` to disable them
-or `--subagents general,Explore` to enable only a subset. The SDK does
-not enable those automatically.
+`general`, `Explore`, and `Plan`. `general` inherits the parent agent's
+tools and is used when the model omits `subagent_type`. `Explore` and
+`Plan` are read-only specialists. Use `--no-subagents` to disable them or
+`--subagents general,Explore` to enable only a subset. The SDK does not
+enable those automatically.
 
 When an SDK application is done with an agent session, call
 `await agent.closeSession()` to release provider-owned resources keyed by
@@ -321,7 +337,9 @@ agent.steer(UserMessage(text: "also add tests as you go"))
 ### Providers
 
 `registerBuiltins` covers Anthropic, OpenAI (Completions + Responses),
-and Google Gemini. `Models` exposes a small curated catalog
+and Google Gemini from explicit keys. For CLI-style environment discovery,
+call `registerBuiltinsFromEnvironment(env:)` with an environment snapshot.
+`Models` exposes a small curated catalog
 (`claudeSonnet45`, `gpt5`, `gemini25Pro`, …) or you can construct
 `Model` values by hand. For OpenAI-compatible endpoints (xAI, Groq,
 OpenRouter) there are `Models.xaiGrok(id:)`, `Models.groq(id:)`,

--- a/Sources/KWWKAI/BedrockProvider.swift
+++ b/Sources/KWWKAI/BedrockProvider.swift
@@ -19,15 +19,18 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
     /// Snapshot of the environment used for region/auth resolution. Captured at
     /// init so tests can inject a deterministic environment.
     let environment: [String: String]
+    /// Whether AWS shared config/credentials files may be consulted when
+    /// `AWS_PROFILE` is present in `environment`. Disabled by default so SDK
+    /// callers do not read `~/.aws/*` unless they opt in.
+    let resolveProfileFiles: Bool
 
     public init(
         api: String = "bedrock-converse-stream",
         client: HTTPClient = URLSessionHTTPClient(),
-        region: String = ProcessInfo.processInfo.environment["AWS_REGION"]
-            ?? ProcessInfo.processInfo.environment["AWS_DEFAULT_REGION"]
-            ?? "us-east-1",
+        region: String = "us-east-1",
         service: String = "bedrock",
-        environment: [String: String] = ProcessInfo.processInfo.environment,
+        environment: [String: String] = [:],
+        resolveProfileFiles: Bool,
         credentialsProvider: (@Sendable () async -> AWSSigV4.Credentials?)? = nil
     ) {
         self.api = api
@@ -35,10 +38,12 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
         self.region = region
         self.service = service
         self.environment = environment
+        self.resolveProfileFiles = resolveProfileFiles
         self.credentialsProvider = credentialsProvider ?? {
-            // IAM static keys, then best-effort AWS_PROFILE shared-credentials.
+            // IAM static keys, then explicitly-enabled AWS_PROFILE
+            // shared-credentials.
             if let creds = BedrockCredentials.fromEnv(environment) { return creds }
-            if let profile = environment["AWS_PROFILE"], !profile.isEmpty {
+            if resolveProfileFiles, let profile = environment["AWS_PROFILE"], !profile.isEmpty {
                 return BedrockCredentials.fromProfile(profile, env: environment)
             }
             return nil
@@ -67,7 +72,8 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
         // Region: ARN > configuredRegion (env) > endpoint host (gated) >
         // profile region > us-east-1. (pi precedence ladder.)
         let profileRegion: String? = {
-            guard let p = environment["AWS_PROFILE"], !p.isEmpty else { return nil }
+            guard resolveProfileFiles,
+                  let p = environment["AWS_PROFILE"], !p.isEmpty else { return nil }
             return BedrockRegion.regionFromProfile(p, env: environment)
         }()
         let effectiveRegion = BedrockRegion.resolve(

--- a/Sources/KWWKAI/EnvAPIKeys.swift
+++ b/Sources/KWWKAI/EnvAPIKeys.swift
@@ -71,14 +71,14 @@ public enum EnvAPIKeys {
     }
 
     /// The configured env vars (non-empty) that can authenticate `provider`.
-    public static func foundEnvVars(for provider: String, env: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+    public static func foundEnvVars(for provider: String, env: [String: String] = [:]) -> [String] {
         guard let candidates = envVars[provider] else { return [] }
         return candidates.filter { (env[$0]?.isEmpty == false) }
     }
 
     /// The API key for `provider` from env, or nil. Does not cover OAuth-only
     /// providers' bearer tokens beyond the env-key form.
-    public static func apiKey(for provider: String, env: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+    public static func apiKey(for provider: String, env: [String: String] = [:]) -> String? {
         if let first = foundEnvVars(for: provider, env: env).first {
             return env[first]
         }
@@ -88,14 +88,14 @@ public enum EnvAPIKeys {
     /// Whether ambient AWS credentials that `BedrockProvider` can actually use
     /// (long-term IAM keys) are present. Profile/bearer/ECS/web-identity are
     /// recognized for reachability but not yet consumed by the SigV4 path.
-    public static func hasBedrockKeys(env: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    public static func hasBedrockKeys(env: [String: String] = [:]) -> Bool {
         (env["AWS_ACCESS_KEY_ID"]?.isEmpty == false) && (env["AWS_SECRET_ACCESS_KEY"]?.isEmpty == false)
     }
 
     /// Every provider that currently has a usable env key configured, in scan
     /// priority order (then alphabetical for the rest). Amazon Bedrock is
     /// appended when ambient AWS credentials are present.
-    public static func configuredProviders(env: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+    public static func configuredProviders(env: [String: String] = [:]) -> [String] {
         let ranked = scanPriority + envVars.keys.filter { !scanPriority.contains($0) }.sorted()
         var out = ranked.filter { !foundEnvVars(for: $0, env: env).isEmpty }
         if hasBedrockKeys(env: env) { out.append("amazon-bedrock") }
@@ -105,7 +105,7 @@ public enum EnvAPIKeys {
     /// Look up the first non-empty environment variable from `names`.
     public static func firstValue(
         of names: [String],
-        env: [String: String] = ProcessInfo.processInfo.environment
+        env: [String: String] = [:]
     ) -> String? {
         for name in names {
             if let v = env[name], !v.trimmingCharacters(in: .whitespaces).isEmpty { return v }
@@ -135,7 +135,7 @@ public enum EnvAPIKeys {
     /// Resolve Azure config from the environment (nil when no API key). Endpoint
     /// order: AZURE_OPENAI_BASE_URL > AZURE_OPENAI_ENDPOINT >
     /// https://{AZURE_OPENAI_RESOURCE_NAME}.openai.azure.com.
-    public static func azure(env: [String: String] = ProcessInfo.processInfo.environment) -> Azure? {
+    public static func azure(env: [String: String] = [:]) -> Azure? {
         guard let apiKey = firstValue(of: ["AZURE_OPENAI_API_KEY"], env: env) else { return nil }
         let apiVersion = firstValue(of: ["AZURE_OPENAI_API_VERSION"], env: env) ?? azureDefaultAPIVersion
         let rawBase: String?
@@ -173,7 +173,7 @@ public enum EnvAPIKeys {
     }
 
     /// Resolve Cloudflare credentials (nil when CLOUDFLARE_API_KEY absent).
-    public static func cloudflare(env: [String: String] = ProcessInfo.processInfo.environment) -> Cloudflare? {
+    public static func cloudflare(env: [String: String] = [:]) -> Cloudflare? {
         guard let apiKey = firstValue(of: ["CLOUDFLARE_API_KEY"], env: env) else { return nil }
         return Cloudflare(
             apiKey: apiKey,

--- a/Sources/KWWKAI/HTTPClient.swift
+++ b/Sources/KWWKAI/HTTPClient.swift
@@ -19,8 +19,8 @@ public protocol HTTPClient: Sendable {
 public struct URLSessionHTTPClient: HTTPClient {
     public let session: URLSession
 
-    public init(session: URLSession = .shared) {
-        self.session = session
+    public init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeIsolatedSession()
     }
 
     public func stream(
@@ -34,6 +34,18 @@ public struct URLSessionHTTPClient: HTTPClient {
         for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
         request.httpBody = body
         return try await streamViaDelegate(base: session, request: request)
+    }
+}
+
+private extension URLSessionHTTPClient {
+    static func makeIsolatedSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: configuration)
     }
 }
 

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -80,32 +80,41 @@ public enum OAuthError: Error, LocalizedError {
 
 // MARK: - Credential store
 
-/// Persists credentials on disk. Default location is `~/.kwwk/oauth.json` —
-/// compatible with pi's `~/.pi/agent/oauth.json` schema so users can migrate
-/// by copying the file across.
+/// Persists credentials on disk when initialized with an explicit URL.
+/// `OAuthStore()` is an in-memory empty store; the CLI opts into
+/// `~/.kwwk/oauth.json` via `defaultURL()`.
 public actor OAuthStore {
     public let url: URL
+    public let isPersistent: Bool
     private var credentials: [String: OAuthCredentials]
 
     public init(url: URL? = nil) {
         if let url {
             self.url = url
+            self.isPersistent = true
         } else {
-            let home: URL = {
-                #if targetEnvironment(macCatalyst) || os(iOS)
-                return URL(fileURLWithPath: NSHomeDirectory())
-                #else
-                return FileManager.default.homeDirectoryForCurrentUser
-                #endif
-            }()
-            self.url = home.appendingPathComponent(".kwwk").appendingPathComponent("oauth.json")
+            self.url = URL(fileURLWithPath: "/dev/null")
+            self.isPersistent = false
         }
-        if let data = try? Data(contentsOf: self.url),
+        if isPersistent,
+           let data = try? Data(contentsOf: self.url),
            let decoded = try? JSONDecoder().decode([String: OAuthCredentials].self, from: data) {
             self.credentials = decoded
         } else {
             self.credentials = [:]
         }
+    }
+
+    /// CLI-compatible OAuth store path: `~/.kwwk/oauth.json`.
+    public static func defaultURL() -> URL {
+        let home: URL = {
+            #if targetEnvironment(macCatalyst) || os(iOS)
+            return URL(fileURLWithPath: NSHomeDirectory())
+            #else
+            return FileManager.default.homeDirectoryForCurrentUser
+            #endif
+        }()
+        return home.appendingPathComponent(".kwwk").appendingPathComponent("oauth.json")
     }
 
     public func all() -> [String: OAuthCredentials] { credentials }
@@ -130,6 +139,7 @@ public actor OAuthStore {
     }
 
     private func persist() throws {
+        guard isPersistent else { return }
         let dir = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(
             at: dir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700]

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -55,11 +55,11 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         self.urlBuilder = urlBuilder ?? { model, _, fallback in
             var base = model.baseUrl.isEmpty ? fallback.absoluteString : model.baseUrl
             while base.hasSuffix("/") { base.removeLast() }
-            // Cloudflare catalog entries carry literal `{CLOUDFLARE_ACCOUNT_ID}`
-            // / `{CLOUDFLARE_GATEWAY_ID}` placeholders in `baseUrl`; expand them
-            // from the environment before building the request URL. No-op for
-            // every other provider (the tokens never appear in their baseUrls).
-            base = substituteCloudflarePlaceholders(in: base)
+            // Cloudflare catalog entries may carry literal `{CLOUDFLARE_*}`
+            // placeholders. The generic provider never reads the process
+            // environment; provider variants that support Cloudflare pass
+            // explicit values through their own URL builders.
+            base = substituteCloudflarePlaceholders(in: base, value: { _ in nil })
             // Tolerate catalog entries that bake `/v1` into baseUrl
             // (pi-mono's models.generated.ts does this for OpenAI).
             // Without this, the session baseUrl `https://api.openai.com`
@@ -1187,13 +1187,13 @@ final class OpenAICompletionsState: @unchecked Sendable {
 }
 
 /// Expand Cloudflare base-URL placeholders (`{CLOUDFLARE_ACCOUNT_ID}` /
-/// `{CLOUDFLARE_GATEWAY_ID}`) from a value source (defaults to the process
-/// environment). Mirrors pi's `resolveCloudflareBaseUrl`: the catalog stores
-/// the literal tokens in `model.baseUrl` and they are substituted at request
-/// time. Unknown/missing values collapse to the empty string.
+/// `{CLOUDFLARE_GATEWAY_ID}`) from an explicit value source. Mirrors pi's
+/// `resolveCloudflareBaseUrl`: the catalog stores the literal tokens in
+/// `model.baseUrl` and they are substituted at request time.
+/// Unknown/missing values collapse to the empty string.
 func substituteCloudflarePlaceholders(
     in baseUrl: String,
-    value: (String) -> String? = { ProcessInfo.processInfo.environment[$0] }
+    value: (String) -> String?
 ) -> String {
     guard baseUrl.contains("{CLOUDFLARE_") else { return baseUrl }
     var result = baseUrl

--- a/Sources/KWWKAI/ProviderVariants.swift
+++ b/Sources/KWWKAI/ProviderVariants.swift
@@ -83,22 +83,34 @@ public enum ProviderVariants {
     // MARK: - Cloudflare Workers AI (Completions wire)
     //
     // Workers AI exposes an OpenAI-compatible /chat/completions endpoint under
-    // an account-scoped URL. The base carries a literal `{CLOUDFLARE_ACCOUNT_ID}`
-    // placeholder in the catalog; `OpenAICompletionsProvider`'s default
-    // urlBuilder substitutes it from the environment. Auth is a Bearer key.
+    // an account-scoped URL. Catalog bases may carry a literal
+    // `{CLOUDFLARE_ACCOUNT_ID}` placeholder; this variant substitutes it from
+    // the explicit `accountId` argument. Auth is a Bearer key.
     public static func cloudflareWorkersAI(
         apiKey: String? = nil,
+        accountId: String? = nil,
         api: String = "cloudflare-workers-ai",
         baseURL: URL = URL(
             string: "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1"
         )!,
         client: HTTPClient = URLSessionHTTPClient()
     ) -> OpenAICompletionsProvider {
-        OpenAICompletionsProvider(
+        let fallbackBase = baseURL.absoluteString.trimmedSlashes
+        return OpenAICompletionsProvider(
             api: api,
             client: client,
             defaultBaseURL: baseURL,
             defaultAPIKey: apiKey,
+            urlBuilder: { model, _, fallback in
+                var base = model.baseUrl.isEmpty ? fallbackBase : model.baseUrl
+                while base.hasSuffix("/") { base.removeLast() }
+                base = substituteCloudflarePlaceholders(in: base) { token in
+                    token == "CLOUDFLARE_ACCOUNT_ID" ? accountId : nil
+                }
+                let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
+                return URL(string: "\(versioned)/chat/completions")
+                    ?? fallback.appendingPathComponent("v1/chat/completions")
+            },
             authHeaderBuilder: { key in ["Authorization": bearerHeaderValue(key)] }
         )
     }
@@ -114,17 +126,34 @@ public enum ProviderVariants {
     // `Authorization` header.
     public static func cloudflareAIGateway(
         apiKey: String? = nil,
+        accountId: String? = nil,
+        gatewayId: String? = nil,
         api: String = "cloudflare-ai-gateway",
         baseURL: URL = URL(
             string: "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat"
         )!,
         client: HTTPClient = URLSessionHTTPClient()
     ) -> OpenAICompletionsProvider {
-        OpenAICompletionsProvider(
+        let fallbackBase = baseURL.absoluteString.trimmedSlashes
+        return OpenAICompletionsProvider(
             api: api,
             client: client,
             defaultBaseURL: baseURL,
             defaultAPIKey: apiKey,
+            urlBuilder: { model, _, fallback in
+                var base = model.baseUrl.isEmpty ? fallbackBase : model.baseUrl
+                while base.hasSuffix("/") { base.removeLast() }
+                base = substituteCloudflarePlaceholders(in: base) { token in
+                    switch token {
+                    case "CLOUDFLARE_ACCOUNT_ID": return accountId
+                    case "CLOUDFLARE_GATEWAY_ID": return gatewayId
+                    default: return nil
+                    }
+                }
+                let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
+                return URL(string: "\(versioned)/chat/completions")
+                    ?? fallback.appendingPathComponent("v1/chat/completions")
+            },
             authHeaderBuilder: { key in
                 ["cf-aig-authorization": "Bearer \(key.trimmingCharacters(in: .whitespacesAndNewlines))"]
             }

--- a/Sources/KWWKAI/RegisterBuiltins.swift
+++ b/Sources/KWWKAI/RegisterBuiltins.swift
@@ -10,7 +10,7 @@ import FoundationNetworking
 /// ```swift
 /// await registerBuiltins(
 ///     anthropic: env["ANTHROPIC_API_KEY"],
-///     openai: env["OPENAI_API_KEY"],
+///     openaiResponses: env["OPENAI_API_KEY"],
 ///     google: env["GOOGLE_API_KEY"]
 /// )
 /// ```
@@ -19,11 +19,10 @@ import FoundationNetworking
 /// callers can `APIRegistry.shared.unregisterSource("kw-builtins")` in tests.
 @discardableResult
 public func registerBuiltins(
-    anthropic: String? = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"],
-    openaiCompletions: String? = ProcessInfo.processInfo.environment["OPENAI_API_KEY"],
-    openaiResponses: String? = ProcessInfo.processInfo.environment["OPENAI_API_KEY"],
-    google: String? = ProcessInfo.processInfo.environment["GOOGLE_API_KEY"]
-        ?? ProcessInfo.processInfo.environment["GEMINI_API_KEY"],
+    anthropic: String? = nil,
+    openaiCompletions: String? = nil,
+    openaiResponses: String? = nil,
+    google: String? = nil,
     sourceId: String = "kw-builtins",
     client: HTTPClient = URLSessionHTTPClient()
 ) async -> [String] {
@@ -49,6 +48,25 @@ public func registerBuiltins(
         registered.append(provider.api)
     }
     return registered
+}
+
+/// CLI-style convenience that explicitly registers built-ins from a supplied
+/// environment snapshot. Library callers should prefer `registerBuiltins(...)`
+/// and pass credentials directly.
+@discardableResult
+public func registerBuiltinsFromEnvironment(
+    env: [String: String],
+    sourceId: String = "kw-builtins",
+    client: HTTPClient = URLSessionHTTPClient()
+) async -> [String] {
+    await registerBuiltins(
+        anthropic: env["ANTHROPIC_API_KEY"],
+        openaiCompletions: env["OPENAI_API_KEY"],
+        openaiResponses: env["OPENAI_API_KEY"],
+        google: env["GOOGLE_API_KEY"] ?? env["GEMINI_API_KEY"],
+        sourceId: sourceId,
+        client: client
+    )
 }
 
 // MARK: - Model catalog (curated, not exhaustive)

--- a/Sources/KWWKAI/Settings.swift
+++ b/Sources/KWWKAI/Settings.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// User/project settings model, ported from pi's `Settings` interface in
-/// `coding-agent/src/core/settings-manager.ts`. kwwk loads a global
-/// `~/.kwwk/settings.json` and an optional project `./.kwwk/settings.json`,
-/// deep-merging the two (project wins) into a single `Settings`.
+/// `coding-agent/src/core/settings-manager.ts`. `SettingsStore` can deep-merge
+/// explicit global and project files, with project settings winning.
 ///
 /// Unknown keys are preserved verbatim in `extra` so a forward-compatible
 /// config doesn't lose data on round-trips, and so the deep-merge can recurse

--- a/Sources/KWWKAI/SettingsStore.swift
+++ b/Sources/KWWKAI/SettingsStore.swift
@@ -9,12 +9,14 @@ import Darwin
 #endif
 
 /// Resolves a single configuration string that may be a literal, an
-/// environment-variable template, or a `!`-prefixed shell command. Ported from
-/// pi's `coding-agent/src/core/resolve-config-value.ts`.
+/// environment-variable template, or, when explicitly enabled, a `!`-prefixed
+/// shell command. Ported from pi's
+/// `coding-agent/src/core/resolve-config-value.ts`.
 ///
 /// Resolution rules (matching pi):
-/// - A value beginning with `!` runs the remainder as a shell command and uses
-///   its trimmed stdout. (empty stdout → nil).
+/// - A value beginning with `!` runs the remainder as a shell command only
+///   when `allowCommands` is true, and uses its trimmed stdout. (empty stdout
+///   → nil). Command execution is disabled unless callers opt in.
 /// - Otherwise the value is a template: `$NAME` or `${NAME}` interpolate the
 ///   named environment variable. A missing variable makes the whole template
 ///   resolve to nil.
@@ -144,26 +146,35 @@ public enum ConfigValue {
     }
 
     /// Resolve `config` to its concrete value. Returns nil when an env var is
-    /// missing or a shell command fails / produces empty output.
+    /// missing, when a command reference is not explicitly allowed, or when an
+    /// allowed shell command fails / produces empty output.
     public static func resolve(
         _ config: String,
-        env: Env = ProcessInfo.processInfo.environment
+        env: Env,
+        allowCommands: Bool,
+        shell: String = "/bin/sh"
     ) -> String? {
         switch parseReference(config) {
         case .command(let command):
-            return runCommand(String(command.dropFirst()))
+            guard allowCommands else { return nil }
+            return runCommand(String(command.dropFirst()), shell: shell, environment: env)
         case .template(let parts):
             return resolveTemplate(parts, env)
         }
     }
 
-    /// Run `command` via the user's shell, returning trimmed stdout (nil on
+    /// Run `command` via the configured shell, returning trimmed stdout (nil on
     /// failure, non-zero exit, or empty output). Mirrors pi's 10s timeout.
-    static func runCommand(_ command: String, timeoutSeconds: TimeInterval = 10) -> String? {
-        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/sh"
+    static func runCommand(
+        _ command: String,
+        timeoutSeconds: TimeInterval = 10,
+        shell: String = "/bin/sh",
+        environment: Env = [:]
+    ) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
         process.arguments = ["-c", command]
+        process.environment = environment
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("kwwk-config-shell-\(UUID().uuidString)")
         FileManager.default.createFile(atPath: outputURL.path, contents: nil)
@@ -227,9 +238,11 @@ public struct SettingsLoadError: Error, Sendable, Equatable {
     }
 }
 
-/// Loads and deep-merges kwwk settings from a global and a project file. Ported
-/// from pi's `settings-manager.ts`: the global `~/.kwwk/settings.json` is the
-/// base, and a project `./.kwwk/settings.json` is layered on top (project wins).
+/// Loads and deep-merges kwwk settings from explicit file paths. The
+/// path-based API supports the CLI-style global `~/.kwwk/settings.json` base
+/// plus a project `./.kwwk/settings.json` override. The convenience
+/// `load(cwd:)` reads neither project nor global settings unless those layers
+/// are explicitly requested.
 public struct SettingsStore: Sendable {
     /// Directory name used for both the global (`~/.kwwk`) and project
     /// (`./.kwwk`) config locations.
@@ -255,7 +268,7 @@ public struct SettingsStore: Sendable {
         merged: Settings,
         global: Settings,
         project: Settings,
-        projectTrusted: Bool = true,
+        projectTrusted: Bool,
         loadErrors: [SettingsLoadError] = []
     ) {
         self.merged = merged
@@ -290,7 +303,7 @@ public struct SettingsStore: Sendable {
     public static func load(
         globalPath: URL,
         projectPath: URL?,
-        projectTrusted: Bool = true
+        projectTrusted: Bool
     ) -> SettingsStore {
         var loadErrors: [SettingsLoadError] = []
 
@@ -316,16 +329,50 @@ public struct SettingsStore: Sendable {
         )
     }
 
-    /// Convenience: load from the default `~/.kwwk` global path and the project
-    /// `.kwwk` directory under `cwd`.
+    /// Convenience: load from settings locations under `cwd` and, when
+    /// requested, the CLI-style global `~/.kwwk/settings.json` layer. Both
+    /// layers are opt-in so SDK callers do not get behavior from the process
+    /// current directory or the user's home directory by default.
     public static func load(
-        cwd: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true),
-        projectTrusted: Bool = true
+        cwd: URL,
+        includeGlobal: Bool,
+        includeProject: Bool,
+        projectTrusted: Bool
     ) -> SettingsStore {
-        load(
-            globalPath: defaultGlobalPath(),
-            projectPath: projectPath(cwd: cwd),
-            projectTrusted: projectTrusted
+        let projectPath = projectPath(cwd: cwd)
+        if includeGlobal {
+            return load(
+                globalPath: defaultGlobalPath(),
+                projectPath: includeProject ? projectPath : nil,
+                projectTrusted: projectTrusted
+            )
+        }
+
+        guard includeProject else {
+            return SettingsStore(
+                merged: .empty,
+                global: .empty,
+                project: .empty,
+                projectTrusted: projectTrusted,
+                loadErrors: []
+            )
+        }
+
+        var loadErrors: [SettingsLoadError] = []
+        let project: Settings
+        if projectTrusted {
+            let (p, projErr) = loadFileChecked(projectPath, scope: .project)
+            project = p
+            if let projErr { loadErrors.append(projErr) }
+        } else {
+            project = .empty
+        }
+        return SettingsStore(
+            merged: project,
+            global: .empty,
+            project: project,
+            projectTrusted: projectTrusted,
+            loadErrors: loadErrors
         )
     }
 

--- a/Sources/KWWKAI/WebSocketClient.swift
+++ b/Sources/KWWKAI/WebSocketClient.swift
@@ -21,8 +21,8 @@ public protocol WebSocketClient: Sendable {
 public struct URLSessionWebSocketClient: WebSocketClient {
     public let session: URLSession
 
-    public init(session: URLSession = .shared) {
-        self.session = session
+    public init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeIsolatedSession()
     }
 
     public func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection {
@@ -31,6 +31,18 @@ public struct URLSessionWebSocketClient: WebSocketClient {
         let task = session.webSocketTask(with: request)
         task.resume()
         return URLSessionWebSocketConnection(task: task)
+    }
+}
+
+private extension URLSessionWebSocketClient {
+    static func makeIsolatedSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: configuration)
     }
 }
 

--- a/Sources/KWWKAgent/Agent+Background.swift
+++ b/Sources/KWWKAgent/Agent+Background.swift
@@ -136,45 +136,35 @@ extension Agent {
     // MARK: - Private storage wiring
 
     fileprivate func appendAttachment(_ attachment: BackgroundAttachment) {
-        AgentAttachmentStore.shared.append(for: self, attachment)
+        backgroundAttachmentList.append(attachment)
     }
 
     fileprivate func removeAttachment(bridgeId: UUID) {
-        AgentAttachmentStore.shared.remove(for: self, bridgeId: bridgeId)
+        backgroundAttachmentList.remove(bridgeId: bridgeId)
     }
 
     fileprivate func backgroundAttachments() -> [BackgroundAttachment] {
-        AgentAttachmentStore.shared.list(for: self)
+        backgroundAttachmentList.list()
     }
 }
 
-/// Side-store for per-Agent attachment lists. Held as a process-wide
-/// singleton so we don't need to change `Agent`'s public shape.
-final class AgentAttachmentStore: @unchecked Sendable {
-    static let shared = AgentAttachmentStore()
-
+final class AgentBackgroundAttachmentList: @unchecked Sendable {
     private let lock = NSLock()
-    private var byAgent: [ObjectIdentifier: [BackgroundAttachment]] = [:]
+    private var attachments: [BackgroundAttachment] = []
 
-    func append(for agent: Agent, _ attachment: BackgroundAttachment) {
-        let key = ObjectIdentifier(agent)
+    func append(_ attachment: BackgroundAttachment) {
         lock.withLock {
-            byAgent[key, default: []].append(attachment)
+            attachments.append(attachment)
         }
     }
 
-    func remove(for agent: Agent, bridgeId: UUID) {
-        let key = ObjectIdentifier(agent)
+    func remove(bridgeId: UUID) {
         lock.withLock {
-            byAgent[key]?.removeAll { $0.bridgeId == bridgeId }
-            if byAgent[key]?.isEmpty == true {
-                byAgent.removeValue(forKey: key)
-            }
+            attachments.removeAll { $0.bridgeId == bridgeId }
         }
     }
 
-    func list(for agent: Agent) -> [BackgroundAttachment] {
-        let key = ObjectIdentifier(agent)
-        return lock.withLock { byAgent[key] ?? [] }
+    func list() -> [BackgroundAttachment] {
+        lock.withLock { attachments }
     }
 }

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -80,8 +80,8 @@ public struct AgentOptions: Sendable {
     public var convertToLlm: ConvertToLlmHook?
     public var transformContext: TransformContextHook?
     public var betweenTurns: BetweenTurnsHook?
-    /// Automatic context compaction is enabled by default. Pass nil to
-    /// disable it for agents that need full transcript retention.
+    /// Automatic context compaction. Disabled by default so SDK callers do
+    /// not trigger extra model calls or transcript rewrites unless requested.
     public var autoCompact: AgentAutoCompactOptions?
     public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 
@@ -103,7 +103,7 @@ public struct AgentOptions: Sendable {
         convertToLlm: ConvertToLlmHook? = nil,
         transformContext: TransformContextHook? = nil,
         betweenTurns: BetweenTurnsHook? = nil,
-        autoCompact: AgentAutoCompactOptions? = AgentAutoCompactOptions(),
+        autoCompact: AgentAutoCompactOptions? = nil,
         authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil
     ) {
         self.initialState = initialState
@@ -161,6 +161,7 @@ public final class Agent: @unchecked Sendable {
 
     private let steeringQueue: PendingMessageQueue
     private let followUpQueue: PendingMessageQueue
+    internal let backgroundAttachmentList = AgentBackgroundAttachmentList()
 
     public convenience init(
         initialState: AgentInitialState,

--- a/Sources/KWWKAgent/BackgroundTaskManager.swift
+++ b/Sources/KWWKAgent/BackgroundTaskManager.swift
@@ -9,7 +9,7 @@ import KWWKAI
 ///
 ///   let manager = BackgroundTaskManager()
 ///   let (taskId, outputFile) = await manager.spawn(
-///       runner: BashBackgroundRunner(command: "npm install"),
+///       runner: BashBackgroundRunner(command: "npm install", environment: env),
 ///       sessionId: "sess-1"
 ///   )
 ///   // … later, agent receives a `<task-notification>` user message when
@@ -82,21 +82,12 @@ public actor BackgroundTaskManager {
         if let dir = outputDir {
             self.outputDir = dir
         } else {
-            // `/tmp/kwwk-bg-<pid>`. Rationale:
-            //   - `/tmp` so these per-session scratch files don't end up in
-            //     the user's home backup / iCloud sync.
-            //   - `-<pid>` so concurrent `kwwk` processes don't interleave
-            //     output files in the same directory (would race on
-            //     `fg_<uuid>.log` allocation and make `list(taskId:)`
-            //     ambiguous across sessions).
-            //   - Foreground adopt path reuses this directory too
-            //     (see `allocateForegroundOutputFile` in BashTool.swift),
-            //     so both bg spawns and fg-flipped commands land here.
-            let pid = ProcessInfo.processInfo.processIdentifier
-            self.outputDir = URL(
-                fileURLWithPath: "/tmp/kwwk-bg-\(pid)",
-                isDirectory: true
-            )
+            // Per-manager private scratch directory under the system temp dir.
+            // Foreground adopt path reuses this directory too (see
+            // `allocateForegroundOutputFile` in BashTool.swift), so both bg
+            // spawns and fg-flipped commands land here.
+            self.outputDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kwwk-bg-\(UUID().uuidString)", isDirectory: true)
         }
     }
 
@@ -318,7 +309,8 @@ public actor BackgroundTaskManager {
     ) -> (String, URL) {
         try? FileManager.default.createDirectory(
             at: outputDir,
-            withIntermediateDirectories: true
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
         )
         var taskId: String
         repeat {
@@ -329,7 +321,11 @@ public actor BackgroundTaskManager {
             file = preset
         } else {
             file = outputDir.appendingPathComponent("\(taskId).log")
-            FileManager.default.createFile(atPath: file.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: file.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
         tasks[taskId] = Entry(
             spec: spec,

--- a/Sources/KWWKAgent/BashBackgroundRunner.swift
+++ b/Sources/KWWKAgent/BashBackgroundRunner.swift
@@ -15,7 +15,9 @@ public struct BashBackgroundRunner: BackgroundTaskRunner {
     public let command: String
     public let workDir: String?
     public let shellPath: String
-    /// Optional extra env merged on top of the inherited process env.
+    /// Exact base environment passed to the child process.
+    public let environment: [String: String]
+    /// Optional extra env merged on top of `environment`.
     public let extraEnv: [String: String]
 
     public init(
@@ -25,11 +27,13 @@ public struct BashBackgroundRunner: BackgroundTaskRunner {
         hardTimeoutSeconds: Int = 1800,
         shellPath: String = kwwkDefaultShellPath,
         label: String? = nil,
+        environment: [String: String],
         extraEnv: [String: String] = [:]
     ) {
         self.command = command
         self.workDir = workDir
         self.shellPath = shellPath
+        self.environment = environment
         self.extraEnv = extraEnv
         self.spec = BackgroundTaskSpec(
             kind: "bash",
@@ -48,12 +52,14 @@ public struct BashBackgroundRunner: BackgroundTaskRunner {
         let command = self.command
         let workDir = self.workDir
         let shellPath = self.shellPath
+        let environment = self.environment
         let extraEnv = self.extraEnv
         Task.detached {
             let outcome = BashRunnerImpl.run(
                 command: command,
                 workDir: workDir,
                 shellPath: shellPath,
+                environment: environment,
                 extraEnv: extraEnv,
                 outputFile: outputFile,
                 cancellation: cancellation
@@ -73,6 +79,7 @@ enum BashRunnerImpl {
         command: String,
         workDir: String?,
         shellPath: String,
+        environment: [String: String],
         extraEnv: [String: String],
         outputFile: URL,
         cancellation: CancellationHandle
@@ -91,6 +98,7 @@ enum BashRunnerImpl {
                 shellPath: shellPath,
                 command: effectiveCommand,
                 outputFile: outputFile,
+                environment: environment,
                 extraEnv: extraEnv
             )
         } catch {
@@ -189,9 +197,10 @@ struct SpawnedBashProcess {
         shellPath: String,
         command: String,
         outputFile: URL,
+        environment: [String: String],
         extraEnv: [String: String]
     ) throws -> SpawnedBashProcess {
-        let outputFd = open(outputFile.path, O_WRONLY | O_CREAT | O_TRUNC, 0o666)
+        let outputFd = open(outputFile.path, O_WRONLY | O_CREAT | O_TRUNC, 0o600)
         guard outputFd >= 0 else { throw SpawnError.openOutput(outputFile.path) }
         defer { close(outputFd) }
 
@@ -227,12 +236,12 @@ struct SpawnedBashProcess {
         posix_spawnattr_setflags(&attr, flags)
         posix_spawnattr_setpgroup(&attr, 0)
 
-        let argvStrings = [shellPath, "-lc", command]
+        let argvStrings = [shellPath, "-c", command]
         var argv = argvStrings.map { strdup($0) }
         argv.append(nil)
         defer { argv.compactMap { $0 }.forEach { free($0) } }
 
-        var environment = ProcessInfo.processInfo.environment
+        var environment = environment
         for (key, value) in extraEnv { environment[key] = value }
         var envp = environment.map { strdup("\($0.key)=\($0.value)") }
         envp.append(nil)

--- a/Sources/KWWKAgent/BashTool.swift
+++ b/Sources/KWWKAgent/BashTool.swift
@@ -1,18 +1,10 @@
 import Foundation
 import KWWKAI
 
-/// Platform default for the bash tool's shell path: `/bin/zsh` on macOS
-/// (matches the user's interactive environment), `/bin/bash` on everything
-/// else — zsh is rarely preinstalled on sandbox Linux images, and
-/// `Process.executableURL` surfaces "file doesn't exist" if we point at a
-/// missing binary.
-public let kwwkDefaultShellPath: String = {
-    #if os(macOS)
-    return "/bin/zsh"
-    #else
-    return "/bin/bash"
-    #endif
-}()
+/// SDK-safe default shell for command execution. CLI entry points may override
+/// this with the user's configured shell after explicitly opting into CLI
+/// ambient behavior.
+public let kwwkDefaultShellPath = "/bin/sh"
 
 public struct BashToolOptions: Sendable {
     /// Legacy pipe-based executor used when `manager` is nil. Tests can
@@ -33,12 +25,15 @@ public struct BashToolOptions: Sendable {
     /// Hard ceiling for background-task runtime (seconds). Passed to the
     /// Manager so even runaway processes eventually get cancelled.
     public var hardTimeoutSeconds: Int
-    /// Shell for the `-lc <command>` invocation (used by file-based paths;
+    /// Shell for the `-c <command>` invocation (used by file-based paths;
     /// the `operations` executor may use its own shell).
     public var shellPath: String
+    /// Exact environment passed to spawned shell processes.
+    public var environment: [String: String]
 
     public init(
-        operations: BashOperations = LocalBashOperations(),
+        environment: [String: String],
+        operations: BashOperations? = nil,
         defaultTimeoutSeconds: Int = 120,
         maxTimeoutSeconds: Int = 600,
         manager: BackgroundTaskManager? = nil,
@@ -47,7 +42,10 @@ public struct BashToolOptions: Sendable {
         hardTimeoutSeconds: Int = 1800,
         shellPath: String = kwwkDefaultShellPath
     ) {
-        self.operations = operations
+        self.operations = operations ?? LocalBashOperations(
+            shellPath: shellPath,
+            environment: environment
+        )
         self.defaultTimeoutSeconds = defaultTimeoutSeconds
         self.maxTimeoutSeconds = maxTimeoutSeconds
         self.manager = manager
@@ -55,16 +53,23 @@ public struct BashToolOptions: Sendable {
         self.autoBackgroundOnTimeout = autoBackgroundOnTimeout
         self.hardTimeoutSeconds = hardTimeoutSeconds
         self.shellPath = shellPath
+        self.environment = environment
     }
 }
 
 public struct LocalBashOperations: BashOperations {
     public let cwd: String?
     public let shellPath: String
+    public let environment: [String: String]
 
-    public init(cwd: String? = nil, shellPath: String = kwwkDefaultShellPath) {
+    public init(
+        cwd: String? = nil,
+        shellPath: String = kwwkDefaultShellPath,
+        environment: [String: String]
+    ) {
         self.cwd = cwd
         self.shellPath = shellPath
+        self.environment = environment
     }
 
     public func execute(
@@ -74,7 +79,8 @@ public struct LocalBashOperations: BashOperations {
     ) async throws -> BashExecutionResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shellPath)
-        process.arguments = ["-lc", command]
+        process.arguments = ["-c", command]
+        process.environment = environment
         if let cwd {
             process.currentDirectoryURL = URL(fileURLWithPath: cwd)
         }
@@ -139,11 +145,15 @@ private func readAll(_ handle: FileHandle) -> String {
     return String(data: data, encoding: .utf8) ?? ""
 }
 
-public func createBashTool(cwd: String, options: BashToolOptions = .init()) -> AgentTool {
+public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
     let hasManager = options.manager != nil
     let ops: BashOperations = {
         if let local = options.operations as? LocalBashOperations, local.cwd == nil {
-            return LocalBashOperations(cwd: cwd, shellPath: local.shellPath)
+            return LocalBashOperations(
+                cwd: cwd,
+                shellPath: local.shellPath,
+                environment: options.environment
+            )
         }
         return options.operations
     }()
@@ -155,6 +165,7 @@ public func createBashTool(cwd: String, options: BashToolOptions = .init()) -> A
     let autoBg = options.autoBackgroundOnTimeout
     let hardTimeoutSec = options.hardTimeoutSeconds
     let shellPath = options.shellPath
+    let environment = options.environment
 
     return AgentTool(
         name: "bash",
@@ -184,6 +195,7 @@ public func createBashTool(cwd: String, options: BashToolOptions = .init()) -> A
                     sessionId: sessionId,
                     cwd: cwd,
                     shellPath: shellPath,
+                    environment: environment,
                     hardTimeoutSeconds: hardTimeoutSec
                 )
             }
@@ -194,6 +206,7 @@ public func createBashTool(cwd: String, options: BashToolOptions = .init()) -> A
                     sessionId: sessionId,
                     cwd: cwd,
                     shellPath: shellPath,
+                    environment: environment,
                     hardTimeoutSeconds: hardTimeoutSec,
                     cancellation: cancellation
                 )
@@ -305,6 +318,7 @@ private func runBashInBackground(
     sessionId: String?,
     cwd: String,
     shellPath: String,
+    environment: [String: String],
     hardTimeoutSeconds: Int
 ) async -> AgentToolResult {
     let runner = BashBackgroundRunner(
@@ -313,7 +327,8 @@ private func runBashInBackground(
         description: input.description,
         hardTimeoutSeconds: hardTimeoutSeconds,
         shellPath: shellPath,
-        label: input.description ?? bashShortLabel(input.command)
+        label: input.description ?? bashShortLabel(input.command),
+        environment: environment
     )
     let (taskId, outputFile) = await manager.spawn(
         runner: runner,
@@ -343,6 +358,7 @@ private func runBashForegroundWithFlip(
     sessionId: String?,
     cwd: String,
     shellPath: String,
+    environment: [String: String],
     hardTimeoutSeconds: Int,
     cancellation: CancellationHandle?
 ) async throws -> AgentToolResult {
@@ -350,7 +366,8 @@ private func runBashForegroundWithFlip(
 
     let process = Process()
     process.executableURL = URL(fileURLWithPath: shellPath)
-    process.arguments = ["-lc", input.command]
+    process.arguments = ["-c", input.command]
+    process.environment = environment
     process.currentDirectoryURL = URL(fileURLWithPath: cwd)
 
     guard let writeHandle = try? FileHandle(forWritingTo: outputFile) else {
@@ -551,12 +568,16 @@ extension BackgroundTaskManager {
     fileprivate func allocateForegroundOutputFile() -> URL {
         try? FileManager.default.createDirectory(
             at: outputDir,
-            withIntermediateDirectories: true
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
         )
         let id = "fg_\(UUID().uuidString.prefix(8))"
         let url = outputDir.appendingPathComponent("\(id).log")
-        FileManager.default.createFile(atPath: url.path, contents: nil)
+        FileManager.default.createFile(
+            atPath: url.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        )
         return url
     }
 }
-

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -5,8 +5,8 @@ import KWWKAI
 /// full set, `.readOnly` for a sandboxed reviewer-style agent, or compose
 /// an arbitrary subset (`[.read, .grep, .bash]`).
 ///
-/// `.tmux` is only honored when `tmux` is on PATH; otherwise the tool is
-/// silently omitted so the model doesn't see something it can't use.
+/// `.tmux` requires an explicit `tmuxManager`; otherwise construction traps
+/// instead of probing PATH or silently omitting a requested tool.
 /// `.taskStatus` and `.waitTask` are only honored when a `backgroundManager`
 /// is supplied. `.bash` works without a manager (legacy pipe executor) —
 /// it just loses `run_in_background` and the auto-background-on-timeout flip.
@@ -28,8 +28,19 @@ public struct CodingTools: OptionSet, Sendable {
     /// Filesystem-scan only — no write, no edit, no shell, no PTY.
     public static let readOnly: CodingTools = [.read, .grep, .find, .ls]
 
-    /// Everything.
+    /// Common editing tools. Includes shell and mutation capabilities; SDK
+    /// callers must opt in explicitly when they want those effects.
+    public static let standard: CodingTools = [
+        .read, .write, .edit, .bash, .grep, .find, .ls, .taskStatus, .waitTask,
+    ]
+
+    /// Everything except tmux, which requires an explicit executable path.
     public static let all: CodingTools = [
+        .read, .write, .edit, .bash, .grep, .find, .ls, .taskStatus, .waitTask,
+    ]
+
+    /// Everything, including tmux. Requires `CodingAgentConfig.tmuxManager`.
+    public static let allIncludingTmux: CodingTools = [
         .read, .write, .edit, .bash, .grep, .find, .ls, .taskStatus, .waitTask, .tmux,
     ]
 }
@@ -44,6 +55,12 @@ public struct CodingAgentConfig: Sendable {
     /// If nil, a default system prompt is synthesized. Pass a non-nil string
     /// to fully override.
     public var systemPrompt: String?
+    /// Project/user context files to inject into the synthesized system prompt.
+    /// Empty by default so library callers do not implicitly read from `cwd`.
+    public var contextFiles: [(path: String, content: String)]
+    /// Skill directories to scan for `<available_skills>`. Empty by default so
+    /// library callers do not implicitly read project or user config.
+    public var skillDirectories: [String]
     /// When non-nil, wired into both the bash tool (for
     /// `run_in_background` + auto-background-on-timeout) and the
     /// agent's notification bridge (so `<task-notification>` user messages
@@ -60,25 +77,39 @@ public struct CodingAgentConfig: Sendable {
     /// the background on this deadline when a `backgroundManager` is attached.
     public var bashDefaultTimeoutSeconds: Int
     public var bashMaxTimeoutSeconds: Int
+    /// Exact environment passed to bash tool processes. Empty by default so
+    /// SDK callers do not expose host process environment variables.
+    public var bashEnvironment: [String: String]
+    /// Shell used by the bash tool.
+    public var bashShellPath: String
+    /// Explicit tmux manager used only when `tools` contains `.tmux`.
+    public var tmuxManager: TmuxSessionManager?
 
     public init(
         model: Model,
         cwd: String,
-        tools: CodingTools = .all,
+        tools: CodingTools,
         systemPrompt: String? = nil,
+        contextFiles: [(path: String, content: String)] = [],
+        skillDirectories: [String] = [],
         backgroundManager: BackgroundTaskManager? = nil,
         subagents: [SubagentDefinition] = [],
         sessionId: String = UUID().uuidString,
         authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
         autoCompactThreshold: Double? = 0.75,
         autoCompactConfig: AgentContextCompactionConfig = .init(),
+        bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
-        bashMaxTimeoutSeconds: Int = 600
+        bashMaxTimeoutSeconds: Int = 600,
+        bashShellPath: String = kwwkDefaultShellPath,
+        tmuxManager: TmuxSessionManager? = nil
     ) {
         self.model = model
         self.cwd = cwd
         self.tools = tools
         self.systemPrompt = systemPrompt
+        self.contextFiles = contextFiles
+        self.skillDirectories = skillDirectories
         self.backgroundManager = backgroundManager
         self.subagents = subagents
         self.sessionId = sessionId
@@ -87,6 +118,9 @@ public struct CodingAgentConfig: Sendable {
         self.autoCompactConfig = autoCompactConfig
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.bashEnvironment = bashEnvironment
+        self.bashShellPath = bashShellPath
+        self.tmuxManager = tmuxManager
     }
 }
 
@@ -112,8 +146,9 @@ public extension CodingAgentConfig {
 /// let agent = await makeCodingAgent(CodingAgentConfig(
 ///     model: model,
 ///     cwd: "/Users/me/project",
-///     tools: .all,
-///     backgroundManager: BackgroundTaskManager()
+///     tools: .standard,
+///     backgroundManager: BackgroundTaskManager(),
+///     bashEnvironment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
 /// ))
 /// try await agent.prompt("list the swift files")
 /// ```
@@ -124,6 +159,13 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
     let cwd = config.cwd
     let bgManager = config.backgroundManager
     let sessionId = config.sessionId
+    let autoCompact = config.autoCompactThreshold.map {
+        AgentAutoCompactOptions(
+            threshold: $0,
+            config: config.autoCompactConfig,
+            backgroundManager: bgManager
+        )
+    }
 
     var tools = await buildCodingToolList(
         cwd: cwd,
@@ -131,13 +173,18 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         backgroundManager: bgManager,
         sessionId: sessionId,
         bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
-        bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds
+        bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds,
+        bashEnvironment: config.bashEnvironment,
+        bashShellPath: config.bashShellPath,
+        tmuxManager: config.tmuxManager
     )
     let subagentParent = SubagentParentBox(
         fallbackModel: config.model,
+        fallbackTools: config.tools,
         fallbackThinkingLevel: .off,
         fallbackThinkingBudgets: nil,
         fallbackMaxRetryDelayMs: nil,
+        fallbackAutoCompact: autoCompact,
         fallbackAuthResolver: config.authResolver
     )
     if !config.subagents.isEmpty {
@@ -147,15 +194,18 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
             backgroundManager: bgManager,
             sessionId: sessionId,
             parentSnapshot: { subagentParent.snapshot() },
+            bashEnvironment: config.bashEnvironment,
             bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
-            bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds
+            bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds,
+            bashShellPath: config.bashShellPath,
+            tmuxManager: config.tmuxManager
         ))
     }
 
     let systemPrompt = config.systemPrompt ?? buildSystemPrompt(SystemPromptOptions(
         cwd: cwd,
-        contextFiles: loadProjectContextFiles(cwd: cwd),
-        availableSkills: Skills.discover(cwd: cwd).skills
+        contextFiles: config.contextFiles,
+        availableSkills: Skills.load(directories: config.skillDirectories).skills
     ))
 
     let agent = Agent(options: AgentOptions(
@@ -165,13 +215,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
             tools: tools
         ),
         sessionId: sessionId,
-        autoCompact: config.autoCompactThreshold.map {
-            AgentAutoCompactOptions(
-                threshold: $0,
-                config: config.autoCompactConfig,
-                backgroundManager: bgManager
-            )
-        },
+        autoCompact: autoCompact,
         authResolver: config.authResolver
     ))
     subagentParent.attach(agent)
@@ -189,7 +233,10 @@ internal func buildCodingToolList(
     backgroundManager: BackgroundTaskManager?,
     sessionId: String?,
     bashDefaultTimeoutSeconds: Int = 120,
-    bashMaxTimeoutSeconds: Int = 600
+    bashMaxTimeoutSeconds: Int = 600,
+    bashEnvironment: [String: String],
+    bashShellPath: String = kwwkDefaultShellPath,
+    tmuxManager: TmuxSessionManager? = nil
 ) async -> [AgentTool] {
     var tools: [AgentTool] = []
     if selected.contains(.read)  { tools.append(createReadTool(cwd: cwd)) }
@@ -197,11 +244,13 @@ internal func buildCodingToolList(
     if selected.contains(.edit)  { tools.append(createEditTool(cwd: cwd)) }
     if selected.contains(.bash) {
         tools.append(createBashTool(cwd: cwd, options: BashToolOptions(
+            environment: bashEnvironment,
             defaultTimeoutSeconds: bashDefaultTimeoutSeconds,
             maxTimeoutSeconds: bashMaxTimeoutSeconds,
             manager: backgroundManager,
             sessionId: sessionId,
-            autoBackgroundOnTimeout: true
+            autoBackgroundOnTimeout: true,
+            shellPath: bashShellPath
         )))
     }
     if selected.contains(.grep) { tools.append(createGrepTool(cwd: cwd)) }
@@ -213,9 +262,18 @@ internal func buildCodingToolList(
     if selected.contains(.waitTask), let backgroundManager {
         tools.append(createWaitTaskTool(manager: backgroundManager, sessionId: sessionId))
     }
-    if selected.contains(.tmux),
-       let tmuxTool = await createTmuxTool(bgManager: backgroundManager, sessionId: sessionId) {
-        tools.append(tmuxTool)
+    if selected.contains(.tmux) {
+        guard let tmuxManager else {
+            preconditionFailure("CodingTools.tmux requires an explicit TmuxSessionManager")
+        }
+        if let tmuxTool = await createTmuxTool(
+            manager: tmuxManager,
+            cwd: cwd,
+            bgManager: backgroundManager,
+            sessionId: sessionId
+        ) {
+            tools.append(tmuxTool)
+        }
     }
     return tools
 }
@@ -223,7 +281,7 @@ internal func buildCodingToolList(
 /// Load project context files (`AGENTS.md`, `CLAUDE.md`) from `cwd` if present.
 /// Returned in a stable order; missing or empty files are skipped. These are
 /// injected into the system prompt under `# Project Context`.
-internal func loadProjectContextFiles(cwd: String) -> [(path: String, content: String)] {
+public func loadProjectContextFiles(cwd: String) -> [(path: String, content: String)] {
     let candidates = ["AGENTS.md", "CLAUDE.md"]
     var files: [(path: String, content: String)] = []
     for name in candidates {

--- a/Sources/KWWKAgent/EditTool.swift
+++ b/Sources/KWWKAgent/EditTool.swift
@@ -3,7 +3,9 @@ import KWWKAI
 
 public struct EditToolOptions: Sendable {
     public var operations: EditOperations
-    public init(operations: EditOperations = LocalEditOperations()) {
+    public init(
+        operations: EditOperations = LocalEditOperations()
+    ) {
         self.operations = operations
     }
 }

--- a/Sources/KWWKAgent/FindTool.swift
+++ b/Sources/KWWKAgent/FindTool.swift
@@ -3,7 +3,9 @@ import KWWKAI
 
 public struct FindToolOptions: Sendable {
     public var operations: FindOperations
-    public init(operations: FindOperations = LocalFindOperations()) {
+    public init(
+        operations: FindOperations = LocalFindOperations()
+    ) {
         self.operations = operations
     }
 }
@@ -38,10 +40,12 @@ public func createFindTool(cwd: String, options: FindToolOptions = .init()) -> A
                   case .string(let pattern) = obj["pattern"] ?? .null else {
                 throw CodingToolError.invalidArgument("find: `pattern` is required")
             }
-            let root: String = {
-                if case .string(let p) = obj["path"] ?? .null { return PathUtils.resolveToCwd(p, cwd: cwd) }
-                return cwd
-            }()
+            let root: String
+            if case .string(let p) = obj["path"] ?? .null {
+                root = PathUtils.resolveToCwd(p, cwd: cwd)
+            } else {
+                root = cwd
+            }
             let limit: Int? = {
                 if case .int(let v) = obj["limit"] ?? .null { return v }
                 if case .double(let v) = obj["limit"] ?? .null { return Int(v) }

--- a/Sources/KWWKAgent/GrepTool.swift
+++ b/Sources/KWWKAgent/GrepTool.swift
@@ -3,7 +3,9 @@ import KWWKAI
 
 public struct GrepToolOptions: Sendable {
     public var operations: GrepOperations
-    public init(operations: GrepOperations = LocalGrepOperations()) {
+    public init(
+        operations: GrepOperations = LocalGrepOperations()
+    ) {
         self.operations = operations
     }
 }
@@ -126,7 +128,9 @@ public func createGrepTool(cwd: String, options: GrepToolOptions = .init()) -> A
                 throw CodingToolError.invalidArgument("grep: `pattern` is required")
             }
             let path: String
-            if case .string(let p) = obj["path"] ?? .null { path = PathUtils.resolveToCwd(p, cwd: cwd) }
+            if case .string(let p) = obj["path"] ?? .null {
+                path = PathUtils.resolveToCwd(p, cwd: cwd)
+            }
             else { path = cwd }
 
             let ignoreCase: Bool = {

--- a/Sources/KWWKAgent/LSTool.swift
+++ b/Sources/KWWKAgent/LSTool.swift
@@ -3,7 +3,9 @@ import KWWKAI
 
 public struct LSToolOptions: Sendable {
     public var operations: LSOperations
-    public init(operations: LSOperations = LocalLSOperations()) {
+    public init(
+        operations: LSOperations = LocalLSOperations()
+    ) {
         self.operations = operations
     }
 }
@@ -55,12 +57,12 @@ public func createLSTool(cwd: String, options: LSToolOptions = .init()) -> Agent
         parameters: parameters,
         execute: { _, args, cancellation, _ in
             try cancellation?.throwIfCancelled()
-            let path: String = {
-                if case .object(let obj) = args, case .string(let p) = obj["path"] ?? .null {
-                    return PathUtils.resolveToCwd(p, cwd: cwd)
-                }
-                return cwd
-            }()
+            let path: String
+            if case .object(let obj) = args, case .string(let p) = obj["path"] ?? .null {
+                path = PathUtils.resolveToCwd(p, cwd: cwd)
+            } else {
+                path = cwd
+            }
             let limit: Int? = {
                 if case .object(let obj) = args {
                     if case .int(let v) = obj["limit"] ?? .null { return v }

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -1,7 +1,9 @@
 import Foundation
 import KWWKAI
 
-/// Append-only JSONL session persistence under `~/.kwwk/sessions/<id>.jsonl`.
+/// Append-only JSONL session persistence. `SessionStore()` is disabled and
+/// does not touch disk; the CLI opts into `~/.kwwk/sessions` via
+/// `defaultDirectory()`.
 ///
 /// Mirrors pi's `packages/agent/src/harness/session` storage in spirit but
 /// keeps a flat append-only log instead of pi's branching entry tree: each
@@ -25,24 +27,32 @@ public actor SessionStore {
     /// non-backward-compatible way; `load` rejects unknown versions.
     public static let version = 1
 
-    /// Directory holding `<id>.jsonl` files. Defaults to `~/.kwwk/sessions`.
+    /// Directory holding `<id>.jsonl` files when persistence is enabled.
     public let directory: URL
+    public let isPersistent: Bool
 
     public init(directory: URL? = nil) {
         if let directory {
             self.directory = directory
+            self.isPersistent = true
         } else {
-            let home: URL = {
-                #if targetEnvironment(macCatalyst) || os(iOS)
-                return URL(fileURLWithPath: NSHomeDirectory())
-                #else
-                return FileManager.default.homeDirectoryForCurrentUser
-                #endif
-            }()
-            self.directory = home
-                .appendingPathComponent(".kwwk")
-                .appendingPathComponent("sessions")
+            self.directory = URL(fileURLWithPath: "/dev/null")
+            self.isPersistent = false
         }
+    }
+
+    /// CLI-compatible session directory: `~/.kwwk/sessions`.
+    public static func defaultDirectory() -> URL {
+        let home: URL = {
+            #if targetEnvironment(macCatalyst) || os(iOS)
+            return URL(fileURLWithPath: NSHomeDirectory())
+            #else
+            return FileManager.default.homeDirectoryForCurrentUser
+            #endif
+        }()
+        return home
+            .appendingPathComponent(".kwwk")
+            .appendingPathComponent("sessions")
     }
 
     // MARK: - Entry model
@@ -186,6 +196,7 @@ public actor SessionStore {
         case unsupportedVersion(found: Int, expected: Int)
         case notFound(String)
         case invalidId(String)
+        case storageDisabled
     }
 
     // MARK: - Paths
@@ -200,11 +211,13 @@ public actor SessionStore {
     }
 
     private func path(for id: String) throws -> URL {
+        guard isPersistent else { throw SessionStoreError.storageDisabled }
         guard Self.isValidSessionId(id) else { throw SessionStoreError.invalidId(id) }
         return directory.appendingPathComponent("\(id).jsonl")
     }
 
     private func ensureDirectory() throws {
+        guard isPersistent else { throw SessionStoreError.storageDisabled }
         try FileManager.default.createDirectory(
             at: directory,
             withIntermediateDirectories: true
@@ -365,6 +378,7 @@ public actor SessionStore {
     /// All sessions on disk, newest activity first. Unreadable / malformed
     /// files are skipped rather than aborting the listing.
     public func list() -> [SessionInfo] {
+        guard isPersistent else { return [] }
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: directory,

--- a/Sources/KWWKAgent/Skills.swift
+++ b/Sources/KWWKAgent/Skills.swift
@@ -242,16 +242,24 @@ public enum Skills {
         return p + "/"
     }
 
-    /// Default skill directories, in precedence order: project-local `.kwwk`,
-    /// the user-global `~/.kwwk`, and a `.claude/skills` directory if the
-    /// project uses one. Missing directories are skipped.
-    public static func defaultDirectories(cwd: String) -> [String] {
+    /// Default skill directories, in precedence order. User-global
+    /// `~/.kwwk/skills` is opt-in so library callers do not read user config
+    /// unless requested.
+    public static func defaultDirectories(
+        cwd: String,
+        includeUserDirectory: Bool = false
+    ) -> [String] {
         let cwdNS = cwd as NSString
         var dirs: [String] = [
             cwdNS.appendingPathComponent(".kwwk/skills"),
-            (NSHomeDirectory() as NSString).appendingPathComponent(".kwwk/skills"),
             cwdNS.appendingPathComponent(".claude/skills"),
         ]
+        if includeUserDirectory {
+            dirs.insert(
+                (NSHomeDirectory() as NSString).appendingPathComponent(".kwwk/skills"),
+                at: 1
+            )
+        }
         // De-dup while preserving order (e.g. cwd == home edge case).
         var seen: Set<String> = []
         dirs = dirs.filter { seen.insert($0).inserted }
@@ -259,8 +267,11 @@ public enum Skills {
     }
 
     /// Discover skills from the default directories for `cwd`.
-    public static func discover(cwd: String) -> (skills: [Skill], diagnostics: [SkillDiagnostic]) {
-        load(directories: defaultDirectories(cwd: cwd))
+    public static func discover(
+        cwd: String,
+        includeUserDirectory: Bool = false
+    ) -> (skills: [Skill], diagnostics: [SkillDiagnostic]) {
+        load(directories: defaultDirectories(cwd: cwd, includeUserDirectory: includeUserDirectory))
     }
 
     /// Load skills from the given directories. Each directory is walked

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -5,20 +5,27 @@ public func createAgentTool(
     cwd: String,
     subagents: [SubagentDefinition],
     parentModel: Model,
+    parentTools: CodingTools,
     parentThinkingLevel: ThinkingLevel = .off,
     parentThinkingBudgets: ThinkingBudgets? = nil,
     parentMaxRetryDelayMs: Int? = nil,
+    parentAutoCompact: AgentAutoCompactOptions? = nil,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
     authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
-    bashMaxTimeoutSeconds: Int = 600
+    bashMaxTimeoutSeconds: Int = 600,
+    bashShellPath: String = kwwkDefaultShellPath,
+    tmuxManager: TmuxSessionManager? = nil
 ) -> AgentTool {
     let snapshot = SubagentParentSnapshot(
         model: parentModel,
+        tools: parentTools,
         thinkingLevel: parentThinkingLevel,
         thinkingBudgets: parentThinkingBudgets,
         maxRetryDelayMs: parentMaxRetryDelayMs,
+        autoCompact: parentAutoCompact,
         authResolver: authResolver
     )
     return _createAgentTool(
@@ -27,8 +34,11 @@ public func createAgentTool(
         backgroundManager: backgroundManager,
         sessionId: sessionId,
         parentSnapshot: { snapshot },
+        bashEnvironment: bashEnvironment,
         bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+        bashShellPath: bashShellPath,
+        tmuxManager: tmuxManager
     )
 }
 
@@ -36,17 +46,23 @@ public func createAgentTool(
     cwd: String,
     subagents: [SubagentDefinition],
     parentAgent: Agent,
+    parentTools: CodingTools,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
     fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
-    bashMaxTimeoutSeconds: Int = 600
+    bashMaxTimeoutSeconds: Int = 600,
+    bashShellPath: String = kwwkDefaultShellPath,
+    tmuxManager: TmuxSessionManager? = nil
 ) -> AgentTool {
     let parentBox = SubagentParentBox(
         fallbackModel: parentAgent.state.model,
+        fallbackTools: parentTools,
         fallbackThinkingLevel: parentAgent.state.thinkingLevel,
         fallbackThinkingBudgets: parentAgent.thinkingBudgets,
         fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
+        fallbackAutoCompact: parentAgent.autoCompact,
         fallbackAuthResolver: parentAgent.authResolver ?? fallbackAuthResolver
     )
     parentBox.attach(parentAgent)
@@ -56,16 +72,21 @@ public func createAgentTool(
         backgroundManager: backgroundManager,
         sessionId: sessionId,
         parentSnapshot: { parentBox.snapshot() },
+        bashEnvironment: bashEnvironment,
         bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+        bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+        bashShellPath: bashShellPath,
+        tmuxManager: tmuxManager
     )
 }
 
 internal struct SubagentParentSnapshot: Sendable {
     var model: Model
+    var tools: CodingTools
     var thinkingLevel: ThinkingLevel
     var thinkingBudgets: ThinkingBudgets?
     var maxRetryDelayMs: Int?
+    var autoCompact: AgentAutoCompactOptions?
     var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 }
 
@@ -73,22 +94,28 @@ internal final class SubagentParentBox: @unchecked Sendable {
     private let lock = NSLock()
     private weak var agent: Agent?
     private let fallbackModel: Model
+    private let fallbackTools: CodingTools
     private let fallbackThinkingLevel: ThinkingLevel
     private let fallbackThinkingBudgets: ThinkingBudgets?
     private let fallbackMaxRetryDelayMs: Int?
+    private let fallbackAutoCompact: AgentAutoCompactOptions?
     private let fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
 
     init(
         fallbackModel: Model,
+        fallbackTools: CodingTools,
         fallbackThinkingLevel: ThinkingLevel,
         fallbackThinkingBudgets: ThinkingBudgets?,
         fallbackMaxRetryDelayMs: Int?,
+        fallbackAutoCompact: AgentAutoCompactOptions?,
         fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
     ) {
         self.fallbackModel = fallbackModel
+        self.fallbackTools = fallbackTools
         self.fallbackThinkingLevel = fallbackThinkingLevel
         self.fallbackThinkingBudgets = fallbackThinkingBudgets
         self.fallbackMaxRetryDelayMs = fallbackMaxRetryDelayMs
+        self.fallbackAutoCompact = fallbackAutoCompact
         self.fallbackAuthResolver = fallbackAuthResolver
     }
 
@@ -101,17 +128,21 @@ internal final class SubagentParentBox: @unchecked Sendable {
             guard let agent else {
                 return SubagentParentSnapshot(
                     model: fallbackModel,
+                    tools: fallbackTools,
                     thinkingLevel: fallbackThinkingLevel,
                     thinkingBudgets: fallbackThinkingBudgets,
                     maxRetryDelayMs: fallbackMaxRetryDelayMs,
+                    autoCompact: fallbackAutoCompact,
                     authResolver: fallbackAuthResolver
                 )
             }
             return SubagentParentSnapshot(
                 model: agent.state.model,
+                tools: fallbackTools,
                 thinkingLevel: agent.state.thinkingLevel,
                 thinkingBudgets: agent.thinkingBudgets,
                 maxRetryDelayMs: agent.maxRetryDelayMs,
+                autoCompact: agent.autoCompact,
                 authResolver: agent.authResolver ?? fallbackAuthResolver
             )
         }
@@ -124,8 +155,11 @@ internal func _createAgentTool(
     backgroundManager: BackgroundTaskManager?,
     sessionId: String?,
     parentSnapshot: @escaping @Sendable () -> SubagentParentSnapshot,
+    bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
-    bashMaxTimeoutSeconds: Int = 600
+    bashMaxTimeoutSeconds: Int = 600,
+    bashShellPath: String = kwwkDefaultShellPath,
+    tmuxManager: TmuxSessionManager? = nil
 ) -> AgentTool {
     let registry = SubagentRegistry(subagents)
     let parameters: JSONValue = .object([
@@ -186,7 +220,10 @@ internal func _createAgentTool(
                 backgroundManager: backgroundManager,
                 childSessionId: childSessionId,
                 bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-                bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+                bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+                bashEnvironment: bashEnvironment,
+                bashShellPath: bashShellPath,
+                tmuxManager: tmuxManager
             )
             let shouldRunBackground = input.runInBackground ?? definition.runInBackgroundByDefault
             if shouldRunBackground {
@@ -453,7 +490,7 @@ private func buildAgentToolDescription(registry: SubagentRegistry) -> String {
 }
 
 private func subagentToolsDescription(_ tools: CodingTools?) -> String {
-    guard let tools else { return "All tools" }
+    guard let tools else { return "Inherits parent tools" }
     var names: [String] = []
     if tools.contains(.read) { names.append("read") }
     if tools.contains(.write) { names.append("write") }
@@ -528,25 +565,35 @@ public struct SubagentRunner: Sendable {
     private var parentSnapshot: @Sendable () -> SubagentParentSnapshot
     private var bashDefaultTimeoutSeconds: Int
     private var bashMaxTimeoutSeconds: Int
+    private var bashEnvironment: [String: String]
+    private var bashShellPath: String
+    private var tmuxManager: TmuxSessionManager?
 
     public init(
         cwd: String,
         subagents: [SubagentDefinition],
         parentModel: Model,
+        parentTools: CodingTools,
         parentThinkingLevel: ThinkingLevel = .off,
         parentThinkingBudgets: ThinkingBudgets? = nil,
         parentMaxRetryDelayMs: Int? = nil,
+        parentAutoCompact: AgentAutoCompactOptions? = nil,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
         authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
-        bashMaxTimeoutSeconds: Int = 600
+        bashMaxTimeoutSeconds: Int = 600,
+        bashShellPath: String = kwwkDefaultShellPath,
+        tmuxManager: TmuxSessionManager? = nil
     ) {
         let snapshot = SubagentParentSnapshot(
             model: parentModel,
+            tools: parentTools,
             thinkingLevel: parentThinkingLevel,
             thinkingBudgets: parentThinkingBudgets,
             maxRetryDelayMs: parentMaxRetryDelayMs,
+            autoCompact: parentAutoCompact,
             authResolver: authResolver
         )
         self.cwd = cwd
@@ -556,23 +603,32 @@ public struct SubagentRunner: Sendable {
         self.parentSnapshot = { snapshot }
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.bashEnvironment = bashEnvironment
+        self.bashShellPath = bashShellPath
+        self.tmuxManager = tmuxManager
     }
 
     public init(
         cwd: String,
         subagents: [SubagentDefinition],
         parentAgent: Agent,
+        parentTools: CodingTools,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
         fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
-        bashMaxTimeoutSeconds: Int = 600
+        bashMaxTimeoutSeconds: Int = 600,
+        bashShellPath: String = kwwkDefaultShellPath,
+        tmuxManager: TmuxSessionManager? = nil
     ) {
         let parentBox = SubagentParentBox(
             fallbackModel: parentAgent.state.model,
+            fallbackTools: parentTools,
             fallbackThinkingLevel: parentAgent.state.thinkingLevel,
             fallbackThinkingBudgets: parentAgent.thinkingBudgets,
             fallbackMaxRetryDelayMs: parentAgent.maxRetryDelayMs,
+            fallbackAutoCompact: parentAgent.autoCompact,
             fallbackAuthResolver: parentAgent.authResolver ?? fallbackAuthResolver
         )
         parentBox.attach(parentAgent)
@@ -583,6 +639,9 @@ public struct SubagentRunner: Sendable {
         self.parentSnapshot = { parentBox.snapshot() }
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.bashEnvironment = bashEnvironment
+        self.bashShellPath = bashShellPath
+        self.tmuxManager = tmuxManager
     }
 
     public func run(
@@ -662,7 +721,10 @@ public struct SubagentRunner: Sendable {
             backgroundManager: backgroundManager,
             childSessionId: makeSubagentSessionId(parent: parentSessionId, name: definition.name),
             bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+            bashEnvironment: bashEnvironment,
+            bashShellPath: bashShellPath,
+            tmuxManager: tmuxManager
         )
     }
 }
@@ -750,6 +812,9 @@ private struct SubagentInvocationRunner: Sendable {
     var childSessionId: String
     var bashDefaultTimeoutSeconds: Int
     var bashMaxTimeoutSeconds: Int
+    var bashEnvironment: [String: String]
+    var bashShellPath: String
+    var tmuxManager: TmuxSessionManager?
 
     func run(
         cancellation: CancellationHandle?,
@@ -782,14 +847,17 @@ private struct SubagentInvocationRunner: Sendable {
             definitionModel: definition.model,
             toolOverride: modelOverride
         )
-        let selectedTools = definition.tools ?? .all
+        let selectedTools = definition.tools ?? parent.tools
         let tools = await buildCodingToolList(
             cwd: cwd,
             selected: selectedTools,
             backgroundManager: backgroundManager,
             sessionId: childSessionId,
             bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds
+            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+            bashEnvironment: bashEnvironment,
+            bashShellPath: bashShellPath,
+            tmuxManager: tmuxManager
         )
         let systemPrompt = buildSubagentSystemPrompt(
             definition: definition,
@@ -806,7 +874,10 @@ private struct SubagentInvocationRunner: Sendable {
             sessionId: childSessionId,
             thinkingBudgets: parent.thinkingBudgets,
             maxRetryDelayMs: parent.maxRetryDelayMs,
-            autoCompact: AgentAutoCompactOptions(backgroundManager: backgroundManager),
+            autoCompact: inheritedAutoCompact(
+                parent.autoCompact,
+                backgroundManager: backgroundManager
+            ),
             authResolver: parent.authResolver
         ))
         let progress = SubagentProgressEmitter(
@@ -957,13 +1028,19 @@ private func resolveModelString(_ raw: String, parent: Model) -> Model {
     if let sameProvider = ModelsCatalog.model(provider: parent.provider, id: value) {
         return adoptRuntimeFields(from: parent, into: sameProvider)
     }
-    if let anyProvider = ModelsCatalog.all.first(where: { $0.id == value }) {
-        return anyProvider
-    }
     var fallback = parent
     fallback.id = value
     fallback.name = value
     return fallback
+}
+
+private func inheritedAutoCompact(
+    _ parent: AgentAutoCompactOptions?,
+    backgroundManager: BackgroundTaskManager?
+) -> AgentAutoCompactOptions? {
+    guard var inherited = parent else { return nil }
+    inherited.backgroundManager = backgroundManager
+    return inherited
 }
 
 private func adoptRuntimeFields(from current: Model, into picked: Model) -> Model {

--- a/Sources/KWWKAgent/TmuxSessionManager.swift
+++ b/Sources/KWWKAgent/TmuxSessionManager.swift
@@ -13,13 +13,9 @@ import KWWKAI
 ///   - `send-keys` and `capture-pane` are the only primitives needed — the
 ///     model doesn't need raw byte control.
 ///
-/// Availability is probed lazily via `tmux -V`. If tmux isn't on PATH, the
-/// manager still constructs but `isAvailable` returns false and
-/// `createTmuxTool` returns nil — existing bash / background flows stay fully
-/// functional.
+/// Availability is probed lazily via `<tmuxPath> -V`. `tmuxPath` must be an
+/// explicit executable path; the SDK does not search PATH on behalf of callers.
 public actor TmuxSessionManager {
-    public static let shared = TmuxSessionManager()
-
     public struct PaneInfo: Sendable, Codable {
         public let paneId: String
         public let name: String
@@ -38,14 +34,14 @@ public actor TmuxSessionManager {
     private var panes: [String: PaneInfo] = [:]
 
     /// - Parameters:
-    ///   - tmuxPath: Resolved via PATH when bare (the default).
+    ///   - tmuxPath: Explicit path to the tmux executable.
     ///   - socketName: Defaults to `kw-<pid>` so multiple kw processes
     ///     don't collide on the same socket. Tests override for isolation.
     ///   - sessionName: tmux session name under the socket. Defaults to
     ///     `"kw"`; tests override so parallel suites don't hit
     ///     `duplicate session` errors.
     public init(
-        tmuxPath: String = "tmux",
+        tmuxPath: String,
         socketName: String? = nil,
         sessionName: String = "kw"
     ) {
@@ -250,7 +246,7 @@ public actor TmuxSessionManager {
         probed = true
         available = result.exitCode == 0
         if !available {
-            throw TmuxError.unavailable("tmux not found on PATH. Install with `brew install tmux` or `apt install tmux`.")
+            throw TmuxError.unavailable("tmux unavailable at \(tmuxPath)")
         }
     }
 
@@ -261,19 +257,8 @@ public actor TmuxSessionManager {
     }
 
     nonisolated static func runProcessSync(executable: String, args: [String]) -> ProcResult {
-        // `Process` resolves bare executable names via the PATH env when
-        // `launchPath` is set; using the resolved path URL is more robust.
         let process = Process()
-        if executable.contains("/") {
-            process.executableURL = URL(fileURLWithPath: executable)
-        } else {
-            // Find the binary on PATH.
-            if let resolved = Self.whichOnPath(executable) {
-                process.executableURL = URL(fileURLWithPath: resolved)
-            } else {
-                return ProcResult(exitCode: 127, stdout: "", stderr: "\(executable) not found")
-            }
-        }
+        process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
@@ -295,16 +280,6 @@ public actor TmuxSessionManager {
         )
     }
 
-    private static func whichOnPath(_ executable: String) -> String? {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
-        for dir in path.split(separator: ":").map(String.init) {
-            let candidate = "\(dir)/\(executable)"
-            if FileManager.default.isExecutableFile(atPath: candidate) {
-                return candidate
-            }
-        }
-        return nil
-    }
 }
 
 public struct ProcResult: Sendable {
@@ -349,4 +324,3 @@ private func deriveName(from command: String) -> String {
     let base = (first as NSString).lastPathComponent
     return base
 }
-

--- a/Sources/KWWKAgent/TmuxTool.swift
+++ b/Sources/KWWKAgent/TmuxTool.swift
@@ -2,9 +2,9 @@ import Foundation
 import KWWKAI
 
 /// Exposes `TmuxSessionManager` to the agent as a single multiplexed tool.
-/// The tool is only meaningful when tmux is available on PATH — the factory
-/// returns nil otherwise so the agent doesn't see a tool it can't actually
-/// use.
+/// The tool is only meaningful when the caller supplied a `TmuxSessionManager`
+/// whose explicit `tmuxPath` is executable. The factory returns nil otherwise
+/// so the agent doesn't see a tool it can't actually use.
 ///
 /// Schema (five actions):
 /// ```json
@@ -15,7 +15,8 @@ import KWWKAI
 /// { "action": "list" }
 /// ```
 public func createTmuxTool(
-    manager: TmuxSessionManager = .shared,
+    manager: TmuxSessionManager,
+    cwd: String,
     bgManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil
 ) async -> AgentTool? {
@@ -94,10 +95,12 @@ public func createTmuxTool(
                 guard case .string(let command) = obj["command"] ?? .null else {
                     throw CodingToolError.invalidArgument("tmux: `command` is required for action=start")
                 }
-                let workDir: String? = {
-                    if case .string(let s) = obj["work_dir"] ?? .null { return s }
-                    return nil
-                }()
+                let workDir: String?
+                if case .string(let s) = obj["work_dir"] ?? .null {
+                    workDir = PathUtils.resolveToCwd(s, cwd: cwd)
+                } else {
+                    workDir = cwd
+                }
                 let name: String? = {
                     if case .string(let s) = obj["name"] ?? .null { return s }
                     return nil
@@ -243,4 +246,3 @@ public func createTmuxTool(
         }
     )
 }
-

--- a/Sources/KWWKAgent/TrustManager.swift
+++ b/Sources/KWWKAgent/TrustManager.swift
@@ -4,10 +4,9 @@ import Foundation
 ///
 /// A project directory is "trusted" once the user has opted in to loading its
 /// project-local configuration (`.kwwk/commands`, custom prompts, etc.). The
-/// decision is persisted in `~/.kwwk/trust.json`, a flat map of
-/// `absolute-dir → bool`. A directory inherits the decision of the nearest
-/// ancestor that has an explicit entry, so trusting a parent folder once trusts
-/// every project beneath it.
+/// decision can be persisted in a JSON file, a flat map of `absolute-dir →
+/// bool`. `TrustManager()` is disabled/empty and does not touch disk; the CLI
+/// opts into `~/.kwwk/trust.json` via `defaultStoreURL()`.
 ///
 /// This type only exposes the storage + check API. UI wiring (prompting the
 /// user the first time an untrusted project is opened) is left to the CLI as a
@@ -23,8 +22,9 @@ public enum TrustStoreError: Error, Equatable {
 }
 
 public final class TrustManager {
-    /// Location of the JSON store. Defaults to `~/.kwwk/trust.json`.
+    /// Location of the JSON store when persistence is enabled.
     public let storeURL: URL
+    public let isPersistent: Bool
 
     /// The error from the most recent load, if the store was malformed. The
     /// convenience (non-throwing) API fails safe and records the error here so
@@ -35,18 +35,25 @@ public final class TrustManager {
     public init(storeURL: URL? = nil) {
         if let storeURL {
             self.storeURL = storeURL
+            self.isPersistent = true
         } else {
-            let home: URL = {
-                #if targetEnvironment(macCatalyst) || os(iOS)
-                return URL(fileURLWithPath: NSHomeDirectory())
-                #else
-                return FileManager.default.homeDirectoryForCurrentUser
-                #endif
-            }()
-            self.storeURL = home
-                .appendingPathComponent(".kwwk")
-                .appendingPathComponent("trust.json")
+            self.storeURL = URL(fileURLWithPath: "/dev/null")
+            self.isPersistent = false
         }
+    }
+
+    /// CLI-compatible trust store path: `~/.kwwk/trust.json`.
+    public static func defaultStoreURL() -> URL {
+        let home: URL = {
+            #if targetEnvironment(macCatalyst) || os(iOS)
+            return URL(fileURLWithPath: NSHomeDirectory())
+            #else
+            return FileManager.default.homeDirectoryForCurrentUser
+            #endif
+        }()
+        return home
+            .appendingPathComponent(".kwwk")
+            .appendingPathComponent("trust.json")
     }
 
     // MARK: - Public API
@@ -159,6 +166,10 @@ public final class TrustManager {
     /// must not collapse to `{}`. Records `lastLoadError` as a side-effect so the
     /// non-throwing API can surface it.
     private func readChecked() throws -> [String: Bool] {
+        guard isPersistent else {
+            lastLoadError = nil
+            return [:]
+        }
         // Missing / unreadable file → empty, ok (matches pi missing→{}).
         guard FileManager.default.fileExists(atPath: storeURL.path) else {
             lastLoadError = nil
@@ -195,6 +206,7 @@ public final class TrustManager {
     }
 
     private func write(_ data: [String: Bool]) {
+        guard isPersistent else { return }
         let dir = storeURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(
             at: dir, withIntermediateDirectories: true

--- a/Sources/KWWKAgent/WriteTool.swift
+++ b/Sources/KWWKAgent/WriteTool.swift
@@ -3,7 +3,9 @@ import KWWKAI
 
 public struct WriteToolOptions: Sendable {
     public var operations: WriteOperations
-    public init(operations: WriteOperations = LocalWriteOperations()) {
+    public init(
+        operations: WriteOperations = LocalWriteOperations()
+    ) {
         self.operations = operations
     }
 }

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -53,7 +53,7 @@ func resolveAgentAuth(
     modelOverride: String? = nil,
     context1m: Bool = false
 ) async throws -> ResolvedAuth {
-    let store = OAuthStore()
+    let store = OAuthStore(url: OAuthStore.defaultURL())
     let all = await store.all()
 
     // Pick the single entry. If the store somehow holds multiple (legacy
@@ -87,7 +87,10 @@ func resolveAgentAuth(
     // matching pi. An exported OPENROUTER_API_KEY / GROQ_API_KEY / etc. (or
     // ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY) runs kwwk without
     // an interactive `kwwk login`.
-    if let env = await resolveEnvAuth(modelOverride: modelOverride) {
+    if let env = await resolveEnvAuth(
+        modelOverride: modelOverride,
+        environment: ProcessInfo.processInfo.environment
+    ) {
         return env
     }
 
@@ -98,7 +101,10 @@ func resolveAgentAuth(
 /// `provider/model` override; otherwise scans providers in priority order and
 /// uses the first one whose env key is set and whose wire protocol kwwk can
 /// already speak. Returns nil when nothing is configured / supported.
-func resolveEnvAuth(modelOverride: String?) async -> ResolvedAuth? {
+func resolveEnvAuth(
+    modelOverride: String?,
+    environment: [String: String]
+) async -> ResolvedAuth? {
     // Split an explicit `provider/model` override.
     var forcedProvider: String?
     var forcedId: String? = modelOverride
@@ -110,14 +116,19 @@ func resolveEnvAuth(modelOverride: String?) async -> ResolvedAuth? {
         }
     }
 
-    let candidates: [String] = forcedProvider.map { [$0] } ?? EnvAPIKeys.configuredProviders()
+    let candidates: [String] = forcedProvider.map { [$0] }
+        ?? EnvAPIKeys.configuredProviders(env: environment)
     for provider in candidates {
         // Amazon Bedrock authenticates via ambient AWS credentials, not a
         // single API key — register the SigV4-backed BedrockProvider directly.
         if provider == "amazon-bedrock" {
-            guard EnvAPIKeys.hasBedrockKeys() else { continue }
+            guard EnvAPIKeys.hasBedrockKeys(env: environment) else { continue }
             guard let model = pickEnvModel(provider: provider, id: forcedId) else { continue }
-            await APIRegistry.shared.register(BedrockProvider(region: bedrockRegion(for: model)))
+            await APIRegistry.shared.register(BedrockProvider(
+                region: bedrockRegion(for: model, environment: environment),
+                environment: environment,
+                resolveProfileFiles: true
+            ))
             return ResolvedAuth(
                 model: model,
                 modelLabel: "\(model.id) · Amazon Bedrock (env)",
@@ -127,18 +138,20 @@ func resolveEnvAuth(modelOverride: String?) async -> ResolvedAuth? {
         // Azure OpenAI / Cloudflare authenticate via a key plus extra config
         // (endpoint / account+gateway ids) and ride bespoke ProviderVariants.
         if provider == "azure-openai-responses" {
-            guard let azure = EnvAPIKeys.azure() else { continue }
+            guard let azure = EnvAPIKeys.azure(env: environment) else { continue }
             return await registerAzureEnv(azure, modelOverride: forcedId)
         }
         if provider == "cloudflare-ai-gateway" {
-            guard let cf = EnvAPIKeys.cloudflare(), cf.accountId != nil, cf.gatewayId != nil else { continue }
+            guard let cf = EnvAPIKeys.cloudflare(env: environment),
+                  cf.accountId != nil,
+                  cf.gatewayId != nil else { continue }
             return await registerCloudflareEnv(cf, gateway: true, modelOverride: forcedId)
         }
         if provider == "cloudflare-workers-ai" {
-            guard let cf = EnvAPIKeys.cloudflare(), cf.accountId != nil else { continue }
+            guard let cf = EnvAPIKeys.cloudflare(env: environment), cf.accountId != nil else { continue }
             return await registerCloudflareEnv(cf, gateway: false, modelOverride: forcedId)
         }
-        guard let key = EnvAPIKeys.apiKey(for: provider), !key.isEmpty else { continue }
+        guard let key = EnvAPIKeys.apiKey(for: provider, env: environment), !key.isEmpty else { continue }
         guard let model = pickEnvModel(provider: provider, id: forcedId) else { continue }
         guard await registerEnvProvider(for: model, apiKey: key) else { continue }
         let label = "\(model.id) · \(EnvAPIKeys.displayName(for: provider)) (env)"
@@ -169,9 +182,16 @@ private func registerAzureEnv(_ azure: EnvAPIKeys.Azure, modelOverride: String?)
 private func registerCloudflareEnv(_ cf: EnvAPIKeys.Cloudflare, gateway: Bool, modelOverride: String?) async -> ResolvedAuth {
     let providerId = gateway ? "cloudflare-ai-gateway" : "cloudflare-workers-ai"
     if gateway {
-        await APIRegistry.shared.register(ProviderVariants.cloudflareAIGateway(apiKey: cf.apiKey))
+        await APIRegistry.shared.register(ProviderVariants.cloudflareAIGateway(
+            apiKey: cf.apiKey,
+            accountId: cf.accountId,
+            gatewayId: cf.gatewayId
+        ))
     } else {
-        await APIRegistry.shared.register(ProviderVariants.cloudflareWorkersAI(apiKey: cf.apiKey))
+        await APIRegistry.shared.register(ProviderVariants.cloudflareWorkersAI(
+            apiKey: cf.apiKey,
+            accountId: cf.accountId
+        ))
     }
     let fallbackBase = gateway
         ? "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat"
@@ -202,15 +222,15 @@ private func registerCloudflareEnv(_ cf: EnvAPIKeys.Cloudflare, gateway: Bool, m
 /// Derive the AWS region for a Bedrock model from its catalog baseUrl host
 /// (`bedrock-runtime.<region>.amazonaws.com`), falling back to AWS_REGION /
 /// us-east-1. Keeps EU/APAC-hosted models from being misrouted to us-east-1.
-private func bedrockRegion(for model: Model) -> String {
+private func bedrockRegion(for model: Model, environment: [String: String]) -> String {
     if let host = URL(string: model.baseUrl)?.host {
         let parts = host.split(separator: ".")
         if parts.count >= 3, parts[0] == "bedrock-runtime" {
             return String(parts[1])
         }
     }
-    return ProcessInfo.processInfo.environment["AWS_REGION"]
-        ?? ProcessInfo.processInfo.environment["AWS_DEFAULT_REGION"]
+    return environment["AWS_REGION"]
+        ?? environment["AWS_DEFAULT_REGION"]
         ?? "us-east-1"
 }
 

--- a/Sources/KWWKCli/CLIAmbient.swift
+++ b/Sources/KWWKCli/CLIAmbient.swift
@@ -1,0 +1,40 @@
+import Foundation
+import KWWKAgent
+
+func cliShellPath(environment: [String: String]) -> String {
+    guard let shell = environment["SHELL"],
+          shell.hasPrefix("/"),
+          FileManager.default.isExecutableFile(atPath: shell) else {
+        return kwwkDefaultShellPath
+    }
+    return shell
+}
+
+func cliTmuxManager(environment: [String: String]) throws -> TmuxSessionManager {
+    guard let tmuxPath = executableNamed("tmux", environment: environment) else {
+        throw CLIAmbientError.tmuxNotFound
+    }
+    return TmuxSessionManager(tmuxPath: tmuxPath)
+}
+
+private func executableNamed(_ name: String, environment: [String: String]) -> String? {
+    let path = environment["PATH"] ?? ""
+    for dir in path.split(separator: ":").map(String.init) {
+        let candidate = (dir as NSString).appendingPathComponent(name)
+        if FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+    }
+    return nil
+}
+
+enum CLIAmbientError: Error, LocalizedError {
+    case tmuxNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .tmuxNotFound:
+            return "tmux tools were requested, but no executable named `tmux` was found in PATH."
+        }
+    }
+}

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -23,7 +23,7 @@ func runCodingTUIInternal(
 
     // Resolve session persistence up front: a fresh id by default, or a
     // stored transcript when `--resume` / `--session` was passed.
-    let sessionStore = SessionStore()
+    let sessionStore = SessionStore(directory: SessionStore.defaultDirectory())
     // `--resume` opens an interactive picker across all projects; resolve the
     // user's choice to a concrete session id before loading. Cancelling exits
     // cleanly (pi parity: "No session selected", exit 0).
@@ -39,15 +39,24 @@ func runCodingTUIInternal(
     let resolvedResume = await sessionStore.resolveResume(effectiveResume, cwd: cwd)
     let sessionId = resolvedResume.sessionId
 
+    let environment = ProcessInfo.processInfo.environment
+    let tmuxManager = tools.contains(.tmux)
+        ? try cliTmuxManager(environment: environment)
+        : nil
     let agent = await makeCodingAgent(CodingAgentConfig(
         model: model,
         cwd: cwd,
         tools: tools,
+        contextFiles: loadProjectContextFiles(cwd: cwd),
+        skillDirectories: Skills.defaultDirectories(cwd: cwd, includeUserDirectory: true),
         backgroundManager: bgManager,
         subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
         sessionId: sessionId,
         authResolver: authResolver,
-        autoCompactThreshold: autoCompactThreshold
+        autoCompactThreshold: autoCompactThreshold,
+        bashEnvironment: environment,
+        bashShellPath: cliShellPath(environment: environment),
+        tmuxManager: tmuxManager
     ))
 
     // Seed the transcript from disk when resuming so the model continues
@@ -329,7 +338,7 @@ func runCodingTUIInternal(
     // the invocation args and submit it as an ordinary prompt. Project-local
     // commands are loaded only when the project is trusted — an untrusted
     // checkout must not be able to inject a template that gets sent to the model.
-    let projectTrusted = TrustManager().isTrusted(cwd)
+    let projectTrusted = TrustManager(storeURL: TrustManager.defaultStoreURL()).isTrusted(cwd)
     CustomSlashCommandLoader.register(into: slashRegistry, cwd: cwd, trustProject: projectTrusted)
     let slashContext = SlashContext(
         agent: agent,
@@ -559,7 +568,7 @@ func runCodingTUIInternal(
         pollTask.cancel()
         await agent.abortAndKillBackgroundTasks()
         await agent.closeSession()
-        await TmuxSessionManager.shared.teardown()
+        await tmuxManager?.teardown()
     }
 
     do {

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -15,8 +15,8 @@ import KWWKAgent
 ///     silent non-zero exit;
 ///   - exit code is `0` when the model reached a clean stop, `1` otherwise.
 ///
-/// Credentials are resolved from the OAuth store exactly like
-/// `runCodingTUIInternal` — whichever provider `kwwk login` last wrote wins.
+/// Credentials are resolved exactly like `runCodingTUIInternal`: the CLI checks
+/// `~/.kwwk/oauth.json` first, then supported API-key environment variables.
 ///
 /// `@MainActor` matches the TUI entry point. The runtime impact is zero:
 /// `kwwk -p` is one-shot and the main actor isn't serving UI work.
@@ -38,19 +38,28 @@ func runHeadlessInternal(
 
     // Resolve session persistence: a fresh id by default, or a stored
     // transcript when `--resume` / `--session` was passed.
-    let store = SessionStore()
+    let store = SessionStore(directory: SessionStore.defaultDirectory())
     let resolvedResume = await store.resolveResume(resume, cwd: cwd)
     let sessionId = resolvedResume.sessionId
 
+    let environment = ProcessInfo.processInfo.environment
+    let tmuxManager = tools.contains(.tmux)
+        ? try cliTmuxManager(environment: environment)
+        : nil
     let agent = await makeCodingAgent(CodingAgentConfig(
         model: resolved.model,
         cwd: cwd,
         tools: tools,
+        contextFiles: loadProjectContextFiles(cwd: cwd),
+        skillDirectories: Skills.defaultDirectories(cwd: cwd, includeUserDirectory: true),
         backgroundManager: bgManager,
         subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
         sessionId: sessionId,
         authResolver: resolved.authResolver,
-        autoCompactThreshold: autoCompactThreshold
+        autoCompactThreshold: autoCompactThreshold,
+        bashEnvironment: environment,
+        bashShellPath: cliShellPath(environment: environment),
+        tmuxManager: tmuxManager
     ))
     agent.state.thinkingLevel = thinkingLevel
 
@@ -124,6 +133,7 @@ func runHeadlessInternal(
         try await agent.prompt(text)
     } catch {
         await agent.closeSession()
+        await tmuxManager?.teardown()
         let msg = (error as? LocalizedError)?.errorDescription ?? "\(error)"
         writeStderr("kwwk: \(msg)\n")
         return 1
@@ -131,6 +141,7 @@ func runHeadlessInternal(
 
     let stop = box.lock.withLock { box.finalStopReason }
     await agent.closeSession()
+    await tmuxManager?.teardown()
     return stop == .stop ? 0 : 1
 }
 

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -12,12 +12,15 @@ public enum KWWK {
     /// current working directory).
     ///
     /// Credentials are resolved automatically from the OAuth store
-    /// (`~/.kwwk/oauth.json`). Throws `AuthResolveError.noCredentials`
-    /// with a message pointing at `kwwk login` if none are configured.
+    /// (`~/.kwwk/oauth.json`) and then supported API-key environment
+    /// variables. Throws `AuthResolveError.noCredentials` with a message
+    /// pointing at `kwwk login` if none are configured.
     ///
     /// `tools` controls which coding tools the agent is given. Default is
-    /// `.all` — read/write/edit/bash/grep/find/ls/task_status/wait_task +
-    /// optional tmux. Pass `.readOnly` for a sandboxed reviewer-style agent.
+    /// `.all` — read/write/edit/bash/grep/find/ls/task_status/wait_task.
+    /// Pass `.readOnly` for a sandboxed reviewer-style agent. If `tools`
+    /// contains `.tmux`, this CLI wrapper resolves `tmux` from `PATH` and
+    /// passes the explicit executable path into the SDK.
     ///
     /// `autoCompactThreshold` fires a silent `/compact` (summarize the
     /// transcript → replace with a recap) once the turn's reported
@@ -70,10 +73,10 @@ public enum KWWK {
     ///     one-line message to stderr;
     ///   - returns `0` on a clean stop, `1` on error / aborted / length-capped.
     ///
-    /// Credentials are resolved the same way as `runCodingTUI` (from the
-    /// OAuth store at `~/.kwwk/oauth.json`). Throws
-    /// `AuthResolveError.noCredentials` with a hint pointing at `kwwk login`
-    /// if none are configured.
+    /// Credentials are resolved the same way as `runCodingTUI`: the OAuth
+    /// store at `~/.kwwk/oauth.json` first, then supported API-key
+    /// environment variables. Throws `AuthResolveError.noCredentials` with
+    /// a hint pointing at `kwwk login` if none are configured.
     public static func runHeadless(
         prompt: String,
         cwd: String? = nil,

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -317,7 +317,7 @@ private func runOAuthFlow(providerId: String) async throws {
 /// `GitHubCopilotOAuthProvider.refresh`); we prefer that over the
 /// Individual default so policy POSTs hit the correct tier.
 private func runCopilotPolicyEnable() async {
-    let store = OAuthStore()
+    let store = OAuthStore(url: OAuthStore.defaultURL())
     let manager = OAuthManager(store: store)
     let sessionToken: String
     do {
@@ -396,7 +396,7 @@ private func persistExclusive(
     _ credentials: OAuthCredentials,
     providerId: String
 ) async throws {
-    let store = OAuthStore()
+    let store = OAuthStore(url: OAuthStore.defaultURL())
     let previous = await store.all().keys.filter { $0 != providerId }.sorted()
     try await store.setExclusive(credentials, for: providerId)
     let path = await store.url.path

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -104,9 +104,9 @@ struct KwwkCLI {
         Sessions are persisted to ~/.kwwk/sessions/<id>.jsonl as an
         append-only log and replayed on resume.
 
-        Credentials are read from the OAuth store at ~/.kwwk/oauth.json.
-        Run `kwwk login` once to register a provider (OAuth subscription
-        or API key).
+        Credentials are read from the OAuth store at ~/.kwwk/oauth.json,
+        with supported API-key environment variables as a fallback. Run
+        `kwwk login` once to register a provider explicitly.
         """)
     }
 

--- a/Tests/KWWKAITests/AWSSigV4Tests.swift
+++ b/Tests/KWWKAITests/AWSSigV4Tests.swift
@@ -168,6 +168,7 @@ struct BedrockProviderTests {
         let provider = BedrockProvider(
             client: client,
             region: "us-east-1",
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         let s = provider.stream(
@@ -200,6 +201,7 @@ struct BedrockProviderTests {
         let provider = BedrockProvider(
             client: client,
             region: "us-east-1",
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         let s = provider.stream(
@@ -235,6 +237,7 @@ struct BedrockProviderTests {
             client: client,
             region: "us-west-2",
             environment: ["AWS_REGION": "us-west-2"],
+            resolveProfileFiles: false,
             credentialsProvider: {
                 AWSSigV4.Credentials(accessKeyId: "AKID", secretAccessKey: "SECRET")
             }
@@ -266,6 +269,7 @@ struct BedrockProviderTests {
         let provider = BedrockProvider(
             client: client,
             region: "us-east-1",
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         _ = provider.stream(
@@ -313,6 +317,7 @@ struct BedrockProviderTests {
         let provider = BedrockProvider(
             client: client,
             region: "us-east-1",
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         let s = provider.stream(

--- a/Tests/KWWKAITests/AzureCloudflareTests.swift
+++ b/Tests/KWWKAITests/AzureCloudflareTests.swift
@@ -170,14 +170,18 @@ struct AzureCloudflareTests {
     @Test("Workers AI variant substitutes account id placeholder into request URL")
     func workersAIURLSubstitution() async throws {
         let client = StubSSEClient(body: Self.openaiCompletionsSSE)
-        let provider = ProviderVariants.cloudflareWorkersAI(apiKey: "cf-key", client: client)
+        let provider = ProviderVariants.cloudflareWorkersAI(
+            apiKey: "cf-key",
+            accountId: "acctABC",
+            client: client
+        )
         // model.baseUrl carries the literal placeholder; urlBuilder must expand it.
         let model = Model(
             id: "@cf/x/y",
             name: "y",
             api: "cloudflare-workers-ai",
             provider: "cloudflare-workers-ai",
-            baseUrl: "https://api.cloudflare.com/client/v4/accounts/acctABC/ai/v1"
+            baseUrl: "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1"
         )
         _ = provider.stream(
             model: model,

--- a/Tests/KWWKAITests/BedrockHardeningTests.swift
+++ b/Tests/KWWKAITests/BedrockHardeningTests.swift
@@ -270,6 +270,7 @@ struct BedrockCacheAndAuthTests {
             client: client,
             region: "us-east-1",
             environment: env,
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         _ = provider.stream(
@@ -286,6 +287,64 @@ struct BedrockCacheAndAuthTests {
     private static func decode(_ client: ByteStubClient) throws -> [String: Any] {
         let data = client.lastRequest?.body ?? Data()
         return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    @Test("AWS profile files are explicit opt-in")
+    func profileFilesAreExplicitOptIn() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bedrock-profile-opt-in-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let credentials = dir.appendingPathComponent("credentials")
+        try """
+        [work]
+        aws_access_key_id = PROFILEKEY
+        aws_secret_access_key = PROFILESECRET
+        """.write(to: credentials, atomically: true, encoding: .utf8)
+
+        let config = dir.appendingPathComponent("config")
+        try "[profile work]\nregion = eu-west-1\n".write(to: config, atomically: true, encoding: .utf8)
+
+        let env = [
+            "AWS_PROFILE": "work",
+            "AWS_SHARED_CREDENTIALS_FILE": credentials.path,
+            "AWS_CONFIG_FILE": config.path,
+        ]
+
+        let blockedClient = ByteStubClient(body: Self.endFrames())
+        let blockedProvider = BedrockProvider(
+            client: blockedClient,
+            environment: env,
+            resolveProfileFiles: false
+        )
+        var terminal: AssistantMessage?
+        for await event in blockedProvider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: nil
+        ) {
+            if case .error(_, let err) = event { terminal = err }
+        }
+        #expect(blockedClient.lastRequest == nil)
+        #expect(terminal?.errorMessage == "AWS credentials unavailable")
+
+        let allowedClient = ByteStubClient(body: Self.endFrames())
+        let allowedProvider = BedrockProvider(
+            client: allowedClient,
+            environment: env,
+            resolveProfileFiles: true
+        )
+        _ = allowedProvider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: nil
+        )
+        for _ in 0..<200 where allowedClient.lastRequest == nil {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(allowedClient.lastRequest?.url.host == "bedrock-runtime.eu-west-1.amazonaws.com")
+        #expect(allowedClient.lastRequest?.headers["authorization"]?.contains("Credential=PROFILEKEY/") == true)
     }
 
     @Test("no cache points when cacheRetention is nil/none")
@@ -422,6 +481,7 @@ struct BedrockCacheAndAuthTests {
             client: client,
             region: "us-east-1",
             environment: ["AWS_BEARER_TOKEN_BEDROCK": "abc123"],
+            resolveProfileFiles: false,
             // No IAM creds available — bearer path must not require them.
             credentialsProvider: { nil }
         )
@@ -525,6 +585,7 @@ struct BedrockCacheAndAuthTests {
             client: client,
             region: "us-east-1",
             environment: env,
+            resolveProfileFiles: false,
             credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
         )
         let out = provider.stream(
@@ -588,6 +649,7 @@ struct BedrockCacheAndAuthTests {
         let provider = BedrockProvider(
             client: client, region: "us-east-1",
             environment: ["AWS_BEARER_TOKEN_BEDROCK": "abc", "AWS_BEDROCK_SKIP_AUTH": "1"],
+            resolveProfileFiles: false,
             credentialsProvider: { nil })
         _ = provider.stream(model: Self.model,
             context: Context(messages: [.user(UserMessage(text: "hi"))]), options: nil)

--- a/Tests/KWWKAITests/EnvAPIKeysTests.swift
+++ b/Tests/KWWKAITests/EnvAPIKeysTests.swift
@@ -4,6 +4,14 @@ import Testing
 
 @Suite("Env API keys")
 struct EnvAPIKeysTests {
+    @Test("default lookup uses an empty environment")
+    func defaultLookupIsEmpty() {
+        #expect(EnvAPIKeys.apiKey(for: "openai") == nil)
+        #expect(EnvAPIKeys.configuredProviders().isEmpty)
+        #expect(EnvAPIKeys.azure() == nil)
+        #expect(EnvAPIKeys.cloudflare() == nil)
+    }
+
     @Test("resolves provider keys from an injected environment")
     func resolvesKeys() {
         let env = [

--- a/Tests/KWWKAITests/LiveCodexStreamTest.swift
+++ b/Tests/KWWKAITests/LiveCodexStreamTest.swift
@@ -25,7 +25,7 @@ struct LiveCodexStreamTests {
         guard let entry = json["openai-codex"] as? [String: Any] else { return }
         _ = entry
 
-        let store = OAuthStore()
+        let store = OAuthStore(url: OAuthStore.defaultURL())
         let manager = OAuthManager(store: store)
         let accessToken = try await manager.apiKey(for: "openai-codex")
         let refreshed = await store.get("openai-codex")
@@ -97,7 +97,7 @@ struct LiveCodexStreamTests {
 
         // Refresh the access token so we have a fresh one before the
         // stream call. The manager also stashes the `accountId` JWT claim.
-        let store = OAuthStore()
+        let store = OAuthStore(url: OAuthStore.defaultURL())
         let manager = OAuthManager(store: store)
         let accessToken: String
         do {

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -39,6 +39,20 @@ final class StubResponseClient: HTTPClient, @unchecked Sendable {
 
 @Suite("OAuth credentials + store")
 struct OAuthStoreTests {
+    @Test("default store is in-memory and does not reopen credentials") func defaultStoreIsMemoryOnly() async throws {
+        let a = OAuthStore()
+        #expect(await a.isPersistent == false)
+        try await a.set(
+            OAuthCredentials(access: "A", refresh: "R", expires: 10),
+            for: "test"
+        )
+        #expect(await a.get("test")?.access == "A")
+
+        let b = OAuthStore()
+        #expect(await b.isPersistent == false)
+        #expect(await b.get("test") == nil)
+    }
+
     @Test("store persists credentials across instances") func persist() async throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")

--- a/Tests/KWWKAITests/SettingsStoreTests.swift
+++ b/Tests/KWWKAITests/SettingsStoreTests.swift
@@ -26,7 +26,9 @@ struct SettingsStoreTests {
         let dir = tempDir()
         let store = SettingsStore.load(
             globalPath: dir.appendingPathComponent("global.json"),
-            projectPath: dir.appendingPathComponent("project.json"))
+            projectPath: dir.appendingPathComponent("project.json"),
+            projectTrusted: true
+        )
         #expect(store.merged == .empty)
         #expect(store.merged.defaultModel == nil)
         #expect(store.merged.resolvedThinkingLevel == .off)
@@ -85,6 +87,29 @@ struct SettingsStoreTests {
         #expect(store.merged.defaultModel == "g")
     }
 
+    @Test("cwd convenience requires explicit project scope")
+    func cwdConvenienceRequiresProjectScope() {
+        let dir = tempDir()
+        let project = SettingsStore.projectPath(cwd: dir)
+        write(#"{"defaultModel":"from-project"}"#, to: project)
+
+        let empty = SettingsStore.load(
+            cwd: dir,
+            includeGlobal: false,
+            includeProject: false,
+            projectTrusted: true
+        )
+        #expect(empty.merged == .empty)
+
+        let loaded = SettingsStore.load(
+            cwd: dir,
+            includeGlobal: false,
+            includeProject: true,
+            projectTrusted: true
+        )
+        #expect(loaded.merged.defaultModel == "from-project")
+    }
+
     // MARK: deep-merge precedence
 
     @Test("project settings override global; unset keys fall through")
@@ -95,7 +120,7 @@ struct SettingsStoreTests {
         write(#"{"defaultModel":"global-model","theme":"dark","defaultProvider":"openai"}"#, to: globalURL)
         write(#"{"defaultModel":"project-model","defaultThinkingLevel":"high"}"#, to: projectURL)
 
-        let store = SettingsStore.load(globalPath: globalURL, projectPath: projectURL)
+        let store = SettingsStore.load(globalPath: globalURL, projectPath: projectURL, projectTrusted: true)
         // Project wins.
         #expect(store.merged.defaultModel == "project-model")
         #expect(store.merged.defaultThinkingLevel == .high)
@@ -112,7 +137,7 @@ struct SettingsStoreTests {
         write(#"{"retry":{"enabled":true,"maxRetries":3}}"#, to: globalURL)
         write(#"{"retry":{"maxRetries":5}}"#, to: projectURL)
 
-        let store = SettingsStore.load(globalPath: globalURL, projectPath: projectURL)
+        let store = SettingsStore.load(globalPath: globalURL, projectPath: projectURL, projectTrusted: true)
         guard case .object(let retry)? = store.merged.extra["retry"] else {
             Issue.record("retry not preserved as object")
             return
@@ -136,22 +161,22 @@ struct SettingsStoreTests {
     @Test("env templates expand from the provided environment")
     func envExpansion() {
         let env = ["TOKEN": "abc123", "HOST": "example.com"]
-        #expect(ConfigValue.resolve("${TOKEN}", env: env) == "abc123")
-        #expect(ConfigValue.resolve("$TOKEN", env: env) == "abc123")
-        #expect(ConfigValue.resolve("https://$HOST/api", env: env) == "https://example.com/api")
-        #expect(ConfigValue.resolve("Bearer ${TOKEN}", env: env) == "Bearer abc123")
+        #expect(ConfigValue.resolve("${TOKEN}", env: env, allowCommands: false) == "abc123")
+        #expect(ConfigValue.resolve("$TOKEN", env: env, allowCommands: false) == "abc123")
+        #expect(ConfigValue.resolve("https://$HOST/api", env: env, allowCommands: false) == "https://example.com/api")
+        #expect(ConfigValue.resolve("Bearer ${TOKEN}", env: env, allowCommands: false) == "Bearer abc123")
     }
 
     @Test("missing env var makes the template resolve to nil")
     func envMissing() {
-        #expect(ConfigValue.resolve("${NOPE_NOT_SET}", env: [:]) == nil)
-        #expect(ConfigValue.resolve("prefix-${NOPE}", env: [:]) == nil)
+        #expect(ConfigValue.resolve("${NOPE_NOT_SET}", env: [:], allowCommands: false) == nil)
+        #expect(ConfigValue.resolve("prefix-${NOPE}", env: [:], allowCommands: false) == nil)
     }
 
     @Test("dollar escapes and literals")
     func envEscapes() {
-        #expect(ConfigValue.resolve("$$5.00", env: [:]) == "$5.00")
-        #expect(ConfigValue.resolve("plain literal", env: [:]) == "plain literal")
+        #expect(ConfigValue.resolve("$$5.00", env: [:], allowCommands: false) == "$5.00")
+        #expect(ConfigValue.resolve("plain literal", env: [:], allowCommands: false) == "plain literal")
         #expect(ConfigValue.envVarNames("${A}-${B}-${A}") == ["A", "B"])
     }
 
@@ -160,15 +185,22 @@ struct SettingsStoreTests {
     @Test("bang prefix runs a shell command and uses trimmed stdout")
     func shellExpansion() {
         #expect(ConfigValue.isCommand("!echo hi"))
-        #expect(ConfigValue.resolve("!echo hello-world") == "hello-world")
+        #expect(ConfigValue.resolve("!echo hello-world", env: [:], allowCommands: true) == "hello-world")
         // Trimming of trailing newline.
-        #expect(ConfigValue.resolve("!printf '  spaced  \n'") == "spaced")
+        #expect(ConfigValue.resolve("!printf '  spaced  \n'", env: [:], allowCommands: true) == "spaced")
+        #expect(ConfigValue.resolve("!echo blocked", env: [:], allowCommands: false) == nil)
+    }
+
+    @Test("shell command expansion uses only the provided environment")
+    func shellExpansionEnv() {
+        #expect(ConfigValue.resolve("!printf \"$TOKEN\"", env: ["TOKEN": "abc123"], allowCommands: true) == "abc123")
+        #expect(ConfigValue.resolve("!printf \"$TOKEN\"", env: [:], allowCommands: true) == nil)
     }
 
     @Test("failing command resolves to nil")
     func shellFailure() {
-        #expect(ConfigValue.resolve("!exit 1") == nil)
-        #expect(ConfigValue.resolve("!true") == nil) // empty stdout -> nil
+        #expect(ConfigValue.resolve("!exit 1", env: [:], allowCommands: true) == nil)
+        #expect(ConfigValue.resolve("!true", env: [:], allowCommands: true) == nil) // empty stdout -> nil
     }
 
     @Test("shell command resolution times out")

--- a/Tests/KWWKAgentTests/AgentTests.swift
+++ b/Tests/KWWKAgentTests/AgentTests.swift
@@ -58,7 +58,7 @@ struct AgentInitTests {
         #expect(agent.state.streamingMessage == nil)
         #expect(agent.state.pendingToolCalls.isEmpty)
         #expect(agent.state.errorMessage == nil)
-        #expect(agent.autoCompact?.threshold == 0.75)
+        #expect(agent.autoCompact == nil)
     }
 
     @Test("honours custom initial state")
@@ -75,19 +75,17 @@ struct AgentInitTests {
         #expect(agent.state.thinkingLevel == .low)
     }
 
-    @Test("auto compact can be explicitly disabled")
-    func autoCompactCanBeDisabled() async throws {
+    @Test("auto compact can be explicitly enabled")
+    func autoCompactCanBeEnabled() async throws {
         let registration = await registerFauxProvider()
         defer { registration.unregister() }
 
         let agent = Agent(options: AgentOptions(
             initialState: AgentInitialState(model: registration.getModel()),
-            autoCompact: nil
+            autoCompact: AgentAutoCompactOptions(threshold: 0.5)
         ))
 
-        if case .some = agent.autoCompact {
-            Issue.record("expected autoCompact to be disabled")
-        }
+        #expect(agent.autoCompact?.threshold == 0.5)
     }
 
     @Test("state setters do not emit events")
@@ -129,11 +127,49 @@ struct AgentInitTests {
             model: registration.getModel(),
             cwd: FileManager.default.temporaryDirectory.path,
             tools: [],
-            sessionId: "stable-session"
+            sessionId: "stable-session",
+            bashEnvironment: [:]
         ))
 
         #expect(agent.sessionId == "stable-session")
         #expect(agent.autoCompact?.threshold == 0.75)
+    }
+
+    @Test("coding agent does not scan skill directories unless configured")
+    func codingAgentSkillDirectoriesAreExplicit() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-agent-skills-\(UUID().uuidString)")
+        let skillsRoot = root.appendingPathComponent(".kwwk/skills")
+        let skillDir = skillsRoot.appendingPathComponent("greeter")
+        try FileManager.default.createDirectory(at: skillDir, withIntermediateDirectories: true)
+        try """
+        ---
+        name: greeter
+        description: Greets people
+        ---
+        Body.
+        """.write(to: skillDir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let defaultAgent = await makeCodingAgent(CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: root.path,
+            tools: [],
+            bashEnvironment: [:]
+        ))
+        #expect(!defaultAgent.state.systemPrompt.contains("<name>greeter</name>"))
+
+        let configuredAgent = await makeCodingAgent(CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: root.path,
+            tools: [],
+            skillDirectories: [skillsRoot.path],
+            bashEnvironment: [:]
+        ))
+        #expect(configuredAgent.state.systemPrompt.contains("<name>greeter</name>"))
     }
 }
 

--- a/Tests/KWWKAgentTests/BashBackgroundTests.swift
+++ b/Tests/KWWKAgentTests/BashBackgroundTests.swift
@@ -55,7 +55,8 @@ struct BashBackgroundRunnerTests {
         let runner = BashBackgroundRunner(
             command: "echo hello-bg-runner",
             workDir: nil,
-            description: "echo test"
+            description: "echo test",
+            environment: testBashEnvironment
         )
         let (taskId, file) = await manager.spawn(runner: runner, sessionId: "s1")
         let done = await awaitUntil(3000) {
@@ -81,7 +82,7 @@ struct BashBackgroundRunnerTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "exit 3")
+        let runner = BashBackgroundRunner(command: "exit 3", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner)
         let done = await awaitUntil(3000) {
             let s = await manager.get(taskId)
@@ -101,7 +102,7 @@ struct BashBackgroundRunnerTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "sleep 30")
+        let runner = BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         // Allow process to start.
         try? await Task.sleep(nanoseconds: 50_000_000)
@@ -127,7 +128,8 @@ struct BashBackgroundRunnerTests {
         // The shell backgrounds a grandchild `sleep`, records its pid, then
         // blocks. Killing the task must reap the whole process group.
         let runner = BashBackgroundRunner(
-            command: "sleep 30 & echo $! > \(pidFile.path); sleep 30"
+            command: "sleep 30 & echo $! > \(pidFile.path); sleep 30",
+            environment: testBashEnvironment
         )
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
 
@@ -161,6 +163,7 @@ struct BashBackgroundRunnerTests {
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let runner = BashBackgroundRunner(
             command: "echo $KW_BGTEST_VAR",
+            environment: testBashEnvironment,
             extraEnv: ["KW_BGTEST_VAR": "extraenv-works"]
         )
         let (taskId, file) = await manager.spawn(runner: runner, sessionId: "s1")
@@ -188,6 +191,7 @@ struct BashToolBackgroundTests {
         defer { try? FileManager.default.removeItem(at: cwdDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
             manager: manager,
             sessionId: "s1"
         ))
@@ -235,6 +239,7 @@ struct BashToolBackgroundTests {
         defer { try? FileManager.default.removeItem(at: cwdDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
             defaultTimeoutSeconds: 30,
             manager: manager,
             sessionId: "s1",
@@ -264,7 +269,10 @@ struct BashToolBackgroundTests {
         let cwdDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: cwdDir) }
         let manager = BackgroundTaskManager(outputDir: makeTempDir())
-        let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(manager: manager))
+        let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
+            manager: manager
+        ))
         await #expect(throws: Error.self) {
             _ = try await tool.execute(
                 "call-1",
@@ -283,6 +291,7 @@ struct BashToolBackgroundTests {
         let manager = BackgroundTaskManager(outputDir: outputDir)
         // Soft default 2s, cap 3s. A request for 9999s should be clamped to 3s.
         let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
             defaultTimeoutSeconds: 2,
             maxTimeoutSeconds: 3,
             manager: manager,
@@ -315,6 +324,7 @@ struct BashToolBackgroundTests {
         defer { try? FileManager.default.removeItem(at: cwdDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
             defaultTimeoutSeconds: 1,      // soft timeout = 1s
             manager: manager,
             sessionId: "sF",
@@ -370,7 +380,7 @@ struct TaskStatusToolTests {
             .appendingPathComponent("kw-bgstatus-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "sleep 10")
+        let runner = BashBackgroundRunner(command: "sleep 10", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         try? await Task.sleep(nanoseconds: 50_000_000)
 
@@ -392,7 +402,7 @@ struct TaskStatusToolTests {
             .appendingPathComponent("kw-bgstatus-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "echo hi")
+        let runner = BashBackgroundRunner(command: "echo hi", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         let done = await awaitUntil(3000) {
             let s = await manager.get(taskId)
@@ -420,7 +430,7 @@ struct TaskStatusToolTests {
             .appendingPathComponent("kw-bgstatus-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "sleep 30")
+        let runner = BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         try? await Task.sleep(nanoseconds: 50_000_000)
 
@@ -474,7 +484,7 @@ struct TaskStatusToolTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "echo done")
+        let runner = BashBackgroundRunner(command: "echo done", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         let done = await awaitUntil(3000) {
             let s = await manager.get(taskId)
@@ -519,7 +529,7 @@ struct TaskStatusToolTests {
             .appendingPathComponent("kw-bgstatus-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "echo hi")
+        let runner = BashBackgroundRunner(command: "echo hi", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "sA")
         _ = await awaitUntil(3000) {
             let s = await manager.get(taskId)

--- a/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
+++ b/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
@@ -30,6 +30,7 @@ struct BuiltinSubagentDefinitionTests {
             selection: [.general, .explore]
         )
         #expect(readOnly.map(\.name) == ["general", "Explore"])
+        #expect(readOnly.first { $0.name == "general" }?.tools == nil)
 
         let selected = SubagentDefinition.builtins(
             for: .all,
@@ -51,7 +52,8 @@ struct BuiltinSubagentDefinitionTests {
         let base = CodingAgentConfig(
             model: .init(id: "m", name: "m", api: "a", provider: "p"),
             cwd: "/tmp",
-            tools: .all
+            tools: .all,
+            bashEnvironment: testBashEnvironment
         )
 
         let configured = base.withBuiltinSubagents(.general.union(.plan))

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -48,6 +48,20 @@ struct ReadToolTests {
         }
     }
 
+    @Test("allows explicit paths outside cwd")
+    func allowsOutsideCwd() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outsideDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let outside = outsideDir.appendingPathComponent("secret.txt")
+        try write("secret", to: outside)
+
+        let tool = createReadTool(cwd: dir.path)
+        let result = try await tool.execute("call-outside", ["path": .string(outside.path)], nil, nil)
+        #expect(textOutput(result) == "secret")
+    }
+
     @Test("truncates files exceeding line limit")
     func truncatesByLines() async throws {
         let dir = makeTempDir()
@@ -177,6 +191,23 @@ struct WriteToolTests {
         #expect(textOutput(result).contains("Successfully wrote"))
         #expect(FileManager.default.fileExists(atPath: file.path))
     }
+
+    @Test("allows explicit writes outside cwd")
+    func allowsOutsideCwd() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outsideDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let outside = outsideDir.appendingPathComponent("out.txt")
+
+        let tool = createWriteTool(cwd: dir.path)
+        _ = try await tool.execute(
+            "call-outside",
+            ["path": .string(outside.path), "content": .string("outside")],
+            nil, nil
+        )
+        #expect(try String(contentsOf: outside, encoding: .utf8) == "outside")
+    }
 }
 
 @Suite("Edit tool")
@@ -229,6 +260,27 @@ struct EditToolTests {
         }
     }
 
+    @Test("allows explicit edits outside cwd")
+    func allowsOutsideCwd() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outsideDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let outside = outsideDir.appendingPathComponent("edit.txt")
+        try write("secret", to: outside)
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("secret"), "newText": .string("changed")])
+        ])
+        _ = try await tool.execute(
+            "call-outside",
+            .object(["path": .string(outside.path), "edits": edits]),
+            nil, nil
+        )
+        #expect(try String(contentsOf: outside, encoding: .utf8) == "changed")
+    }
+
     @Test("fails when oldText matches multiple locations")
     func ambiguousOldText() async throws {
         let dir = makeTempDir()
@@ -278,7 +330,10 @@ struct BashToolTests {
     func simpleCommand() async throws {
         let dir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let tool = createBashTool(cwd: dir.path)
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
         let result = try await tool.execute(
             "call-1",
             ["command": .string("echo hello-kw")],
@@ -287,11 +342,30 @@ struct BashToolTests {
         #expect(textOutput(result).contains("hello-kw"))
     }
 
+    @Test("uses only the explicit environment")
+    func explicitEnvironmentOnly() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
+        let result = try await tool.execute(
+            "call-env",
+            ["command": .string("printf '<%s>' \"$HOME\"")],
+            nil, nil
+        )
+        #expect(textOutput(result) == "<>")
+    }
+
     @Test("surfaces non-zero exit code as an error")
     func exitCodeFailure() async throws {
         let dir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let tool = createBashTool(cwd: dir.path)
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
         await #expect(throws: Error.self) {
             _ = try await tool.execute(
                 "call-2",
@@ -305,7 +379,10 @@ struct BashToolTests {
     func cancels() async throws {
         let dir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let tool = createBashTool(cwd: dir.path)
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
         let cancel = CancellationHandle()
         Task { @Sendable in
             try? await Task.sleep(nanoseconds: 20_000_000)

--- a/Tests/KWWKAgentTests/SessionStoreTests.swift
+++ b/Tests/KWWKAgentTests/SessionStoreTests.swift
@@ -34,6 +34,16 @@ struct SessionStoreTests {
         ))
     }
 
+    @Test("default store is disabled and does not touch disk")
+    func defaultStoreDisabled() async throws {
+        let store = SessionStore()
+        #expect(await store.isPersistent == false)
+        #expect(await store.list().isEmpty)
+        await #expect(throws: SessionStore.SessionStoreError.self) {
+            _ = try await store.create(id: "disabled", cwd: "/tmp")
+        }
+    }
+
     @Test("round-trip: append then load preserves order and content")
     func roundTrip() async throws {
         let (store, dir) = tempStore()

--- a/Tests/KWWKAgentTests/SubagentToolTests.swift
+++ b/Tests/KWWKAgentTests/SubagentToolTests.swift
@@ -15,7 +15,8 @@ struct SubagentToolTests {
         let withoutSubagents = await makeCodingAgent(CodingAgentConfig(
             model: faux.getModel(),
             cwd: cwd.path,
-            tools: .readOnly
+            tools: .readOnly,
+            bashEnvironment: [:]
         ))
         #expect(!withoutSubagents.state.tools.contains { $0.name == "agent" })
 
@@ -23,7 +24,8 @@ struct SubagentToolTests {
             model: faux.getModel(),
             cwd: cwd.path,
             tools: .readOnly,
-            subagents: [minimalSubagent()]
+            subagents: [minimalSubagent()],
+            bashEnvironment: [:]
         ))
         #expect(withSubagents.state.tools.contains { $0.name == "agent" })
     }
@@ -35,7 +37,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         await #expect(throws: Error.self) {
@@ -67,7 +71,9 @@ struct SubagentToolTests {
                 ),
                 minimalSubagent(),
             ],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await tool.execute(
@@ -84,8 +90,8 @@ struct SubagentToolTests {
         #expect(detailString(result, "subagent_type") == "general")
     }
 
-    @Test("definition without tools uses wildcard coding tools")
-    func omittedToolsUsesWildcard() async throws {
+    @Test("definition without tools inherits parent coding tools")
+    func omittedToolsInheritsParentTools() async throws {
         let faux = await registerFauxProvider()
         defer { faux.unregister() }
         let capture = SubagentContextCapture()
@@ -101,13 +107,15 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent(tools: nil)],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .standard,
+            bashEnvironment: testBashEnvironment
         )
 
         _ = try await tool.execute(
             "call-1",
             .object([
-                "description": .string("wildcard tools"),
+                "description": .string("inherited tools"),
                 "prompt": .string("inspect tools"),
                 "subagent_type": .string("mini"),
             ]),
@@ -116,9 +124,11 @@ struct SubagentToolTests {
         )
 
         let snapshot = await capture.snapshot()
+        #expect(snapshot.toolNames.contains("read"))
         #expect(snapshot.toolNames.contains("write"))
         #expect(snapshot.toolNames.contains("edit"))
         #expect(snapshot.toolNames.contains("bash"))
+        #expect(snapshot.toolNames.contains("grep"))
         #expect(!snapshot.toolNames.contains("agent"))
     }
 
@@ -130,7 +140,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await tool.execute(
@@ -169,7 +181,9 @@ struct SubagentToolTests {
         let runner = SubagentRunner(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await runner.run(type: "mini", prompt: "answer directly")
@@ -189,8 +203,10 @@ struct SubagentToolTests {
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
             parentModel: faux.getModel(),
+            parentTools: .readOnly,
             backgroundManager: manager,
-            sessionId: "sdk-parent"
+            sessionId: "sdk-parent",
+            bashEnvironment: testBashEnvironment
         )
 
         let started = try await runner.startBackground(
@@ -222,7 +238,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await tool.execute(
@@ -272,7 +290,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
         let agent = Agent(initialState: AgentInitialState(
             model: faux.getModel(),
@@ -339,7 +359,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
         let agent = Agent(initialState: AgentInitialState(
             model: faux.getModel(),
@@ -398,7 +420,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent(tools: .all)],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         _ = try await tool.execute(
@@ -436,7 +460,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [definition],
-            parentModel: parent
+            parentModel: parent,
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
 
         let definitionResult = try await tool.execute(
@@ -465,6 +491,41 @@ struct SubagentToolTests {
         #expect(detailString(toolOverrideResult, "model") == "tool-model")
     }
 
+    @Test("tool-call model override cannot switch provider through the global catalog")
+    func modelOverrideStaysOnParentProvider() async throws {
+        guard let foreign = ModelsCatalog.models(for: "openai").first else {
+            Issue.record("expected bundled OpenAI catalog models")
+            return
+        }
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            models: [FauxModelDefinition(id: "parent-model")]
+        ))
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("same provider result"))])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent()],
+            parentModel: faux.getModel(id: "parent-model")!,
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
+        )
+
+        let result = try await tool.execute(
+            "call-cross-provider-model",
+            .object([
+                "description": .string("foreign model id"),
+                "prompt": .string("use parent provider"),
+                "subagent_type": .string("mini"),
+                "model": .string(foreign.id),
+            ]),
+            nil,
+            nil
+        )
+
+        #expect(resultText(result).contains("same provider result"))
+        #expect(detailString(result, "model") == foreign.id)
+    }
+
     @Test("public agent tool overload reads live parent agent state")
     func publicOverloadReadsLiveParentState() async throws {
         let faux = await registerFauxProvider(RegisterFauxProviderOptions(
@@ -480,7 +541,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentAgent: parentAgent
+            parentAgent: parentAgent,
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
         parentAgent.state.model = faux.getModel(id: "live-parent")!
         faux.setResponses([.message(fauxAssistantMessage("live model result"))])
@@ -511,8 +574,10 @@ struct SubagentToolTests {
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
             parentModel: faux.getModel(),
+            parentTools: .readOnly,
             backgroundManager: manager,
-            sessionId: "s1"
+            sessionId: "s1",
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await tool.execute(
@@ -580,8 +645,10 @@ struct SubagentToolTests {
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent(tools: [.bash])],
             parentModel: faux.getModel(),
+            parentTools: .readOnly,
             backgroundManager: manager,
-            sessionId: "parent-session"
+            sessionId: "parent-session",
+            bashEnvironment: testBashEnvironment
         )
 
         let result = try await tool.execute(
@@ -621,7 +688,9 @@ struct SubagentToolTests {
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
-            parentModel: faux.getModel()
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
         )
         let cancellation = CancellationHandle()
 
@@ -664,7 +733,9 @@ struct SubagentToolTests {
             cwd: FileManager.default.currentDirectoryPath,
             subagents: [minimalSubagent()],
             parentModel: model,
-            sessionId: parentSessionId
+            parentTools: .readOnly,
+            sessionId: parentSessionId,
+            bashEnvironment: testBashEnvironment
         )
         let cancellation = CancellationHandle()
 

--- a/Tests/KWWKAgentTests/TestSupport.swift
+++ b/Tests/KWWKAgentTests/TestSupport.swift
@@ -1,0 +1,3 @@
+let testBashEnvironment = [
+    "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+]

--- a/Tests/KWWKAgentTests/TmuxToolTests.swift
+++ b/Tests/KWWKAgentTests/TmuxToolTests.swift
@@ -3,11 +3,23 @@ import Testing
 @testable import KWWKAgent
 @testable import KWWKAI
 
-/// Tmux tests are gated on `tmux` being installed on PATH. When it isn't,
+/// Tmux tests explicitly resolve `tmux` from PATH. When it isn't,
 /// every test quietly returns — the bash + background path doesn't depend on
 /// tmux so this shouldn't block CI on machines without it.
+private func resolvedTmuxPath() -> String? {
+    let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    for dir in path.split(separator: ":").map(String.init) {
+        let candidate = "\(dir)/tmux"
+        if FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+    }
+    return nil
+}
+
 private func tmuxAvailable() async -> Bool {
-    await TmuxSessionManager().isAvailable
+    guard let tmuxPath = resolvedTmuxPath() else { return false }
+    return await TmuxSessionManager(tmuxPath: tmuxPath).isAvailable
 }
 
 private func makeSessionManager() -> TmuxSessionManager {
@@ -15,6 +27,7 @@ private func makeSessionManager() -> TmuxSessionManager {
     // collide with `duplicate session: kw`.
     let id = UUID().uuidString.prefix(8)
     return TmuxSessionManager(
+        tmuxPath: resolvedTmuxPath()!,
         socketName: "kw-test-\(id)",
         sessionName: "t\(id)"
     )
@@ -127,7 +140,10 @@ struct TmuxToolTests {
     func gatedByAvailability() async {
         // Simulate by passing a manager with a bogus path.
         let bogus = TmuxSessionManager(tmuxPath: "/definitely-not-a-real-path/tmux-nope")
-        let tool = await createTmuxTool(manager: bogus)
+        let tool = await createTmuxTool(
+            manager: bogus,
+            cwd: FileManager.default.currentDirectoryPath
+        )
         #expect(tool == nil)
     }
 
@@ -137,7 +153,12 @@ struct TmuxToolTests {
         // host; we reach directly into a tool with a real manager only if
         // tmux is available.
         guard await tmuxAvailable() else { return }
-        guard let tool = await createTmuxTool() else { return }
+        let manager = makeSessionManager()
+        defer { Task { await manager.teardown() } }
+        guard let tool = await createTmuxTool(
+            manager: manager,
+            cwd: FileManager.default.currentDirectoryPath
+        ) else { return }
         await #expect(throws: Error.self) {
             _ = try await tool.execute(
                 "call-1",
@@ -150,7 +171,12 @@ struct TmuxToolTests {
     @Test("start without command throws")
     func startMissingCommand() async throws {
         guard await tmuxAvailable() else { return }
-        guard let tool = await createTmuxTool() else { return }
+        let manager = makeSessionManager()
+        defer { Task { await manager.teardown() } }
+        guard let tool = await createTmuxTool(
+            manager: manager,
+            cwd: FileManager.default.currentDirectoryPath
+        ) else { return }
         await #expect(throws: Error.self) {
             _ = try await tool.execute(
                 "call-1",
@@ -165,7 +191,10 @@ struct TmuxToolTests {
         guard await tmuxAvailable() else { return }
         let manager = makeSessionManager()
         defer { Task { await manager.teardown() } }
-        guard let tool = await createTmuxTool(manager: manager) else { return }
+        guard let tool = await createTmuxTool(
+            manager: manager,
+            cwd: FileManager.default.currentDirectoryPath
+        ) else { return }
         let result = try await tool.execute(
             "call-1",
             .object(["action": .string("list")]),
@@ -181,7 +210,10 @@ struct TmuxToolTests {
         guard await tmuxAvailable() else { return }
         let manager = makeSessionManager()
         defer { Task { await manager.teardown() } }
-        guard let tool = await createTmuxTool(manager: manager) else {
+        guard let tool = await createTmuxTool(
+            manager: manager,
+            cwd: FileManager.default.currentDirectoryPath
+        ) else {
             Issue.record("tmux available but tool factory returned nil")
             return
         }
@@ -234,6 +266,7 @@ struct TmuxToolTests {
         let bgManager = BackgroundTaskManager(outputDir: outputDir)
         guard let tool = await createTmuxTool(
             manager: tmuxMgr,
+            cwd: outputDir.path,
             bgManager: bgManager,
             sessionId: "s1"
         ) else {
@@ -266,6 +299,7 @@ struct TmuxToolTests {
         let bgManager = BackgroundTaskManager(outputDir: outputDir)
         guard let tool = await createTmuxTool(
             manager: tmuxMgr,
+            cwd: outputDir.path,
             bgManager: bgManager,
             sessionId: "s1"
         ) else { return }
@@ -315,6 +349,7 @@ struct TmuxToolTests {
         let bgManager = BackgroundTaskManager(outputDir: outputDir)
         guard let tmuxTool = await createTmuxTool(
             manager: tmuxMgr,
+            cwd: outputDir.path,
             bgManager: bgManager,
             sessionId: "s1"
         ) else { return }

--- a/Tests/KWWKAgentTests/TrustManagerTests.swift
+++ b/Tests/KWWKAgentTests/TrustManagerTests.swift
@@ -12,6 +12,17 @@ struct TrustManagerTests {
         return (TrustManager(storeURL: url), dir)
     }
 
+    @Test("default manager is disabled and empty")
+    func defaultManagerDisabled() {
+        let mgr = TrustManager()
+        let project = "/tmp/kwwk-default-\(UUID().uuidString.prefix(6))"
+        #expect(mgr.isPersistent == false)
+        #expect(mgr.decision(project) == nil)
+        mgr.trust(project)
+        #expect(mgr.decision(project) == nil)
+        #expect(mgr.isTrusted(project) == false)
+    }
+
     @Test("unknown dir is untrusted with no decision")
     func unknownIsUntrusted() {
         let (mgr, dir) = tempStore()

--- a/Tests/KWWKAgentTests/WaitTaskToolTests.swift
+++ b/Tests/KWWKAgentTests/WaitTaskToolTests.swift
@@ -11,7 +11,7 @@ struct WaitTaskToolTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "echo quick")
+        let runner = BashBackgroundRunner(command: "echo quick", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         let done = await awaitUntil(3000) {
             let s = await manager.get(taskId)
@@ -44,7 +44,10 @@ struct WaitTaskToolTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "sleep 0.3 && echo slow-done")
+        let runner = BashBackgroundRunner(
+            command: "sleep 0.3 && echo slow-done",
+            environment: testBashEnvironment
+        )
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
 
         let tool = createWaitTaskTool(manager: manager, sessionId: "s1")
@@ -70,7 +73,7 @@ struct WaitTaskToolTests {
         let outputDir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
-        let runner = BashBackgroundRunner(command: "sleep 30")
+        let runner = BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment)
         let (taskId, _) = await manager.spawn(runner: runner, sessionId: "s1")
         defer { Task { try? await manager.kill(taskId) } }
         try? await Task.sleep(nanoseconds: 50_000_000)
@@ -101,7 +104,7 @@ struct WaitTaskToolTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let (taskId, _) = await manager.spawn(
-            runner: BashBackgroundRunner(command: "sleep 30"),
+            runner: BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment),
             sessionId: "sA"
         )
         defer { Task { try? await manager.kill(taskId) } }
@@ -123,7 +126,7 @@ struct WaitTaskToolTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let (taskId, _) = await manager.spawn(
-            runner: BashBackgroundRunner(command: "sleep 30"),
+            runner: BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment),
             sessionId: "s1"
         )
         defer { Task { try? await manager.kill(taskId) } }
@@ -155,7 +158,7 @@ struct WaitTaskToolTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let (taskId, _) = await manager.spawn(
-            runner: BashBackgroundRunner(command: "sleep 30"),
+            runner: BashBackgroundRunner(command: "sleep 30", environment: testBashEnvironment),
             sessionId: "s1"
         )
         defer { Task { try? await manager.kill(taskId) } }


### PR DESCRIPTION
## Summary

- Harden SDK defaults so library callers do not implicitly read `~/.kwwk`, process environment, project context files, or skill directories unless they opt in.
- Make side-effecting surfaces explicit: bash environment/shell wiring, tmux manager/cwd wiring, coding tools, parent tools for subagents, and selected persistence paths.
- Remove `PathAccessPolicy` path-jail behavior, keep CLI bash environment inheritance, and make subagents with omitted tools inherit parent tools.
- Disable low-level Agent auto-compaction by default, prevent subagent model overrides from switching providers via the global catalog, and move background attachments off a process-global store.

## Impact

SDK callers now get fewer ambient filesystem, environment, global-state, and network side effects by default. CLI entry points continue to opt into CLI behavior explicitly, including `~/.kwwk` persistence, project context loading, user skills, and inherited shell environment.

## Validation

- `git diff --check`
- `swift test`