### PR TITLE
[codex] Improve edit tool parity

### DIFF
--- a/Sources/KWWKAgent/CodingTools.swift
+++ b/Sources/KWWKAgent/CodingTools.swift
@@ -56,6 +56,7 @@ public protocol WriteOperations: Sendable {
 public protocol EditOperations: Sendable {
     func readFile(_ absolutePath: String) async throws -> Data
     func writeFile(_ absolutePath: String, content: Data) async throws
+    func access(_ absolutePath: String) async throws
 }
 
 public protocol BashOperations: Sendable {
@@ -163,5 +164,11 @@ public struct ReadToolDetails: Sendable, Codable, Equatable {
 
 public struct EditToolDetails: Sendable, Codable, Equatable {
     public var diff: String
-    public init(diff: String) { self.diff = diff }
+    public var patch: String?
+    public var firstChangedLine: Int?
+    public init(diff: String, patch: String? = nil, firstChangedLine: Int? = nil) {
+        self.diff = diff
+        self.patch = patch
+        self.firstChangedLine = firstChangedLine
+    }
 }

--- a/Sources/KWWKAgent/EditDiff.swift
+++ b/Sources/KWWKAgent/EditDiff.swift
@@ -328,74 +328,236 @@ public enum EditDiff {
 
     // MARK: - Diff output
 
-    /// Compute a simple unified-style diff (not strictly RFC conformant). Good
-    /// enough for display + tests that check for added/removed tokens.
-    public static func generateDiff(old: String, new: String, contextLines: Int = 3) -> String {
-        let oldLines = old.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        let newLines = new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        let ops = lcsDiff(oldLines, newLines)
-        var out: [String] = []
-        var oldNum = 1
-        var newNum = 1
+    public struct DiffStringResult: Sendable, Equatable {
+        public var diff: String
+        public var firstChangedLine: Int?
 
-        for op in ops {
+        public init(diff: String, firstChangedLine: Int? = nil) {
+            self.diff = diff
+            self.firstChangedLine = firstChangedLine
+        }
+    }
+
+    /// Backwards-compatible display diff wrapper.
+    public static func generateDiff(old: String, new: String, contextLines: Int = 3) -> String {
+        generateDiffString(old: old, new: new, contextLines: contextLines).diff
+    }
+
+    /// Generate a display-oriented diff with line numbers and folded context,
+    /// mirroring pi's `generateDiffString`.
+    public static func generateDiffString(
+        old: String,
+        new: String,
+        contextLines: Int = 4
+    ) -> DiffStringResult {
+        let oldLines = old.components(separatedBy: "\n")
+        let newLines = new.components(separatedBy: "\n")
+        let ops = lineDiff(oldLines, newLines)
+        let ranges = changedRanges(in: ops, contextLines: contextLines)
+        let firstChangedLine = ops.compactMap { op -> Int? in
             switch op {
-            case .equal(let line):
-                out.append("  \(pad(newNum)) \(line)")
-                oldNum += 1
-                newNum += 1
-            case .delete(let line):
-                out.append("- \(pad(oldNum)) \(line)")
-                oldNum += 1
-            case .insert(let line):
-                out.append("+ \(pad(newNum)) \(line)")
-                newNum += 1
+            case .equal:
+                return nil
+            case .delete, .insert:
+                return op.newLine
+            }
+        }.first
+
+        guard !ranges.isEmpty else {
+            return DiffStringResult(diff: "", firstChangedLine: firstChangedLine)
+        }
+
+        var out: [String] = []
+        let width = max(String(max(oldLines.count, newLines.count)).count, 1)
+        var previousUpper = 0
+
+        for range in ranges {
+            if range.lowerBound > previousUpper {
+                out.append(skipLine(width: width))
+            }
+            for op in ops[range] {
+                out.append(formatDisplayOp(op, width: width))
+            }
+            previousUpper = range.upperBound
+        }
+        if previousUpper < ops.count {
+            out.append(skipLine(width: width))
+        }
+
+        return DiffStringResult(diff: out.joined(separator: "\n"), firstChangedLine: firstChangedLine)
+    }
+
+    /// Generate a standard unified patch (`---`, `+++`, `@@`) for tools that
+    /// need machine-readable patch details in addition to the display diff.
+    public static func generateUnifiedPatch(
+        path: String,
+        old: String,
+        new: String,
+        contextLines: Int = 4
+    ) -> String {
+        let oldLines = old.components(separatedBy: "\n")
+        let newLines = new.components(separatedBy: "\n")
+        let ops = lineDiff(oldLines, newLines)
+        let ranges = changedRanges(in: ops, contextLines: contextLines)
+        var out = ["--- \(path)", "+++ \(path)"]
+
+        for range in ranges {
+            let hunk = Array(ops[range])
+            let oldLen = hunk.filter(\.consumesOld).count
+            let newLen = hunk.filter(\.consumesNew).count
+            guard let first = hunk.first else { continue }
+            let oldStart = oldLen == 0 ? max(0, first.oldLine - 1) : first.oldLine
+            let newStart = newLen == 0 ? max(0, first.newLine - 1) : first.newLine
+            out.append("@@ -\(patchRange(start: oldStart, length: oldLen)) +\(patchRange(start: newStart, length: newLen)) @@")
+            for op in hunk {
+                out.append(formatPatchOp(op))
             }
         }
-        _ = contextLines
+
         return out.joined(separator: "\n")
     }
 
-    private static func pad(_ n: Int) -> String {
-        String(format: "%4d", n)
-    }
-
     private enum DiffOp {
-        case equal(String)
-        case delete(String)
-        case insert(String)
+        case equal(line: String, oldLine: Int, newLine: Int)
+        case delete(line: String, oldLine: Int, newLine: Int)
+        case insert(line: String, oldLine: Int, newLine: Int)
+
+        var oldLine: Int {
+            switch self {
+            case .equal(_, let oldLine, _), .delete(_, let oldLine, _), .insert(_, let oldLine, _):
+                return oldLine
+            }
+        }
+
+        var newLine: Int {
+            switch self {
+            case .equal(_, _, let newLine), .delete(_, _, let newLine), .insert(_, _, let newLine):
+                return newLine
+            }
+        }
+
+        var consumesOld: Bool {
+            switch self {
+            case .equal, .delete:
+                return true
+            case .insert:
+                return false
+            }
+        }
+
+        var consumesNew: Bool {
+            switch self {
+            case .equal, .insert:
+                return true
+            case .delete:
+                return false
+            }
+        }
+
+        var line: String {
+            switch self {
+            case .equal(let line, _, _), .delete(let line, _, _), .insert(let line, _, _):
+                return line
+            }
+        }
     }
 
-    private static func lcsDiff(_ a: [String], _ b: [String]) -> [DiffOp] {
-        let n = a.count
-        let m = b.count
-        var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
-        for i in stride(from: n - 1, through: 0, by: -1) {
-            for j in stride(from: m - 1, through: 0, by: -1) {
-                if a[i] == b[j] {
-                    dp[i][j] = dp[i + 1][j + 1] + 1
-                } else {
-                    dp[i][j] = max(dp[i + 1][j], dp[i][j + 1])
-                }
+    private static func lineDiff(_ oldLines: [String], _ newLines: [String]) -> [DiffOp] {
+        let difference = newLines.difference(from: oldLines)
+        var removals: [Int: String] = [:]
+        var insertions: [Int: String] = [:]
+        for change in difference {
+            switch change {
+            case .remove(let offset, let element, _):
+                removals[offset] = element
+            case .insert(let offset, let element, _):
+                insertions[offset] = element
             }
         }
 
-        var i = 0, j = 0
+        var oldIndex = 0
+        var newIndex = 0
         var ops: [DiffOp] = []
-        while i < n && j < m {
-            if a[i] == b[j] {
-                ops.append(.equal(a[i]))
-                i += 1; j += 1
-            } else if dp[i + 1][j] >= dp[i][j + 1] {
-                ops.append(.delete(a[i]))
-                i += 1
-            } else {
-                ops.append(.insert(b[j]))
-                j += 1
+        while oldIndex < oldLines.count || newIndex < newLines.count {
+            if let removed = removals[oldIndex] {
+                ops.append(.delete(line: removed, oldLine: oldIndex + 1, newLine: newIndex + 1))
+                oldIndex += 1
+                continue
+            }
+            if let inserted = insertions[newIndex] {
+                ops.append(.insert(line: inserted, oldLine: oldIndex + 1, newLine: newIndex + 1))
+                newIndex += 1
+                continue
+            }
+            if oldIndex < oldLines.count && newIndex < newLines.count {
+                ops.append(.equal(line: oldLines[oldIndex], oldLine: oldIndex + 1, newLine: newIndex + 1))
+                oldIndex += 1
+                newIndex += 1
+                continue
+            }
+            if oldIndex < oldLines.count {
+                ops.append(.delete(line: oldLines[oldIndex], oldLine: oldIndex + 1, newLine: newIndex + 1))
+                oldIndex += 1
+                continue
+            }
+            if newIndex < newLines.count {
+                ops.append(.insert(line: newLines[newIndex], oldLine: oldIndex + 1, newLine: newIndex + 1))
+                newIndex += 1
             }
         }
-        while i < n { ops.append(.delete(a[i])); i += 1 }
-        while j < m { ops.append(.insert(b[j])); j += 1 }
         return ops
+    }
+
+    private static func changedRanges(in ops: [DiffOp], contextLines: Int) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        for index in ops.indices where !isEqual(ops[index]) {
+            let lower = max(ops.startIndex, index - contextLines)
+            let upper = min(ops.endIndex, index + contextLines + 1)
+            if let last = ranges.last, lower <= last.upperBound {
+                ranges[ranges.count - 1] = last.lowerBound..<max(last.upperBound, upper)
+            } else {
+                ranges.append(lower..<upper)
+            }
+        }
+        return ranges
+    }
+
+    private static func isEqual(_ op: DiffOp) -> Bool {
+        if case .equal = op { return true }
+        return false
+    }
+
+    private static func formatDisplayOp(_ op: DiffOp, width: Int) -> String {
+        switch op {
+        case .equal(let line, let oldLine, _):
+            return " \(pad(oldLine, width: width)) \(line)"
+        case .delete(let line, let oldLine, _):
+            return "-\(pad(oldLine, width: width)) \(line)"
+        case .insert(let line, _, let newLine):
+            return "+\(pad(newLine, width: width)) \(line)"
+        }
+    }
+
+    private static func formatPatchOp(_ op: DiffOp) -> String {
+        switch op {
+        case .equal:
+            return " \(op.line)"
+        case .delete:
+            return "-\(op.line)"
+        case .insert:
+            return "+\(op.line)"
+        }
+    }
+
+    private static func patchRange(start: Int, length: Int) -> String {
+        length == 1 ? "\(start)" : "\(start),\(length)"
+    }
+
+    private static func skipLine(width: Int) -> String {
+        " \(String(repeating: " ", count: width)) ..."
+    }
+
+    private static func pad(_ n: Int, width: Int) -> String {
+        String(format: "%\(width)d", n)
     }
 }

--- a/Sources/KWWKAgent/EditTool.swift
+++ b/Sources/KWWKAgent/EditTool.swift
@@ -24,24 +24,48 @@ public struct LocalEditOperations: EditOperations {
         try content.write(to: URL(fileURLWithPath: absolutePath), options: .atomic)
     }
     public func access(_ absolutePath: String) async throws {
+        try checkPOSIXAccess(absolutePath, mode: editAccessExistsMode)
+
         var isDirectory: ObjCBool = false
-        if !FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDirectory) {
-            throw POSIXError(.ENOENT)
-        }
-        if isDirectory.boolValue {
+        if FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDirectory), isDirectory.boolValue {
             throw POSIXError(.EISDIR)
         }
-        #if canImport(Darwin)
-        let accessResult = Darwin.access(absolutePath, R_OK | W_OK)
-        #elseif canImport(Glibc)
-        let accessResult = Glibc.access(absolutePath, R_OK | W_OK)
-        #else
-        let accessResult = FileManager.default.isReadableFile(atPath: absolutePath)
+
+        try checkPOSIXAccess(absolutePath, mode: editAccessReadWriteMode)
+    }
+}
+
+#if canImport(Darwin) || canImport(Glibc)
+private let editAccessExistsMode: Int32 = F_OK
+private let editAccessReadWriteMode: Int32 = R_OK | W_OK
+#else
+private let editAccessExistsMode: Int32 = 0
+private let editAccessReadWriteMode: Int32 = 6
+#endif
+
+private func checkPOSIXAccess(_ absolutePath: String, mode: Int32) throws {
+    #if canImport(Darwin)
+    let accessResult = Darwin.access(absolutePath, mode)
+    #elseif canImport(Glibc)
+    let accessResult = Glibc.access(absolutePath, mode)
+    #else
+    let accessResult: Int32
+    if mode == editAccessExistsMode {
+        accessResult = FileManager.default.fileExists(atPath: absolutePath) ? 0 : -1
+    } else {
+        accessResult = FileManager.default.isReadableFile(atPath: absolutePath)
             && FileManager.default.isWritableFile(atPath: absolutePath) ? 0 : -1
+    }
+    #endif
+    if accessResult != 0 {
+        #if canImport(Darwin)
+        let errorCode = errno
+        #elseif canImport(Glibc)
+        let errorCode = errno
+        #else
+        let errorCode = mode == editAccessExistsMode ? ENOENT : EACCES
         #endif
-        if accessResult != 0 {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EACCES)
-        }
+        throw POSIXError(POSIXErrorCode(rawValue: errorCode) ?? .EACCES)
     }
 }
 

--- a/Sources/KWWKAgent/EditTool.swift
+++ b/Sources/KWWKAgent/EditTool.swift
@@ -1,5 +1,10 @@
 import Foundation
 import KWWKAI
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 public struct EditToolOptions: Sendable {
     public var operations: EditOperations
@@ -17,6 +22,26 @@ public struct LocalEditOperations: EditOperations {
     }
     public func writeFile(_ absolutePath: String, content: Data) async throws {
         try content.write(to: URL(fileURLWithPath: absolutePath), options: .atomic)
+    }
+    public func access(_ absolutePath: String) async throws {
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDirectory) {
+            throw POSIXError(.ENOENT)
+        }
+        if isDirectory.boolValue {
+            throw POSIXError(.EISDIR)
+        }
+        #if canImport(Darwin)
+        let accessResult = Darwin.access(absolutePath, R_OK | W_OK)
+        #elseif canImport(Glibc)
+        let accessResult = Glibc.access(absolutePath, R_OK | W_OK)
+        #else
+        let accessResult = FileManager.default.isReadableFile(atPath: absolutePath)
+            && FileManager.default.isWritableFile(atPath: absolutePath) ? 0 : -1
+        #endif
+        if accessResult != 0 {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EACCES)
+        }
     }
 }
 
@@ -45,7 +70,7 @@ public func createEditTool(cwd: String, options: EditToolOptions = .init()) -> A
         label: "edit",
         description: "Edit a file using exact text replacement. Each oldText must match a unique, non-overlapping region.",
         parameters: parameters,
-        execute: { _, args, cancellation, _ in
+        execute: { _, args, cancellation, onUpdate in
             try cancellation?.throwIfCancelled()
             guard case .object(let obj) = args,
                   case .string(let rawPath) = obj["path"] ?? .null else {
@@ -67,12 +92,15 @@ public func createEditTool(cwd: String, options: EditToolOptions = .init()) -> A
 
             let absolutePath = PathUtils.resolveToCwd(rawPath, cwd: cwd)
             return try await FileMutationQueue.shared.run(absolutePath) {
-                let buffer: Data
                 do {
-                    buffer = try await ops.readFile(absolutePath)
+                    try await ops.access(absolutePath)
                 } catch {
-                    throw CodingToolError.fileNotFound(rawPath)
+                    throw CodingToolError.runtime(
+                        "Could not edit file: \(rawPath). \(editAccessErrorDescription(error))."
+                    )
                 }
+
+                let buffer = try await ops.readFile(absolutePath)
                 guard let raw = String(data: buffer, encoding: .utf8) else {
                     throw CodingToolError.invalidArgument("edit: file is not valid UTF-8")
                 }
@@ -83,17 +111,76 @@ public func createEditTool(cwd: String, options: EditToolOptions = .init()) -> A
                 let applied = try EditDiff.applyEdits(to: normalized, edits: edits, path: rawPath)
                 try cancellation?.throwIfCancelled()
 
+                let diffResult = EditDiff.generateDiffString(old: applied.baseContent, new: applied.newContent)
+                let patch = EditDiff.generateUnifiedPatch(
+                    path: rawPath,
+                    old: applied.baseContent,
+                    new: applied.newContent
+                )
+                let details = editDetails(diff: diffResult.diff, patch: patch, firstChangedLine: diffResult.firstChangedLine)
+                let display = editDisplayLines(
+                    summary: "Previewing \(edits.count) replacement(s) in \(rawPath).",
+                    diff: diffResult.diff
+                )
+                onUpdate?(AgentToolResult(
+                    content: [.text(TextContent(text: "Previewing \(edits.count) replacement(s) in \(rawPath)."))],
+                    details: details,
+                    uiDisplay: display
+                ))
+                try cancellation?.throwIfCancelled()
+
                 let final = bom + EditDiff.restoreLineEndings(applied.newContent, ending: ending)
                 try await ops.writeFile(absolutePath, content: Data(final.utf8))
 
-                let diff = EditDiff.generateDiff(old: applied.baseContent, new: applied.newContent)
+                let summary = "Successfully replaced \(edits.count) block(s) in \(rawPath)."
                 return AgentToolResult(
                     content: [.text(TextContent(
-                        text: "Successfully replaced \(edits.count) block(s) in \(rawPath)."
+                        text: summary
                     ))],
-                    details: .object(["diff": .string(diff)])
+                    details: details,
+                    uiDisplay: editDisplayLines(summary: summary, diff: diffResult.diff)
                 )
             }
         }
     )
+}
+
+private func editDetails(diff: String, patch: String, firstChangedLine: Int?) -> JSONValue {
+    var details: [String: JSONValue] = [
+        "diff": .string(diff),
+        "patch": .string(patch),
+    ]
+    if let firstChangedLine {
+        details["firstChangedLine"] = .int(firstChangedLine)
+    }
+    return .object(details)
+}
+
+private func editDisplayLines(summary: String, diff: String) -> [String] {
+    var lines = [summary]
+    if !diff.isEmpty {
+        lines.append(contentsOf: diff.components(separatedBy: "\n"))
+    }
+    return lines
+}
+
+private func editAccessErrorDescription(_ error: Error) -> String {
+    if let posix = error as? POSIXError {
+        return "Error code: \(posixErrorCodeName(posix.code.rawValue))"
+    }
+    if let localized = error as? LocalizedError, let description = localized.errorDescription, !description.isEmpty {
+        return description
+    }
+    return String(describing: error)
+}
+
+private func posixErrorCodeName(_ code: Int32) -> String {
+    switch code {
+    case ENOENT: return "ENOENT"
+    case EACCES: return "EACCES"
+    case EPERM: return "EPERM"
+    case ENOTDIR: return "ENOTDIR"
+    case EISDIR: return "EISDIR"
+    default: return "POSIX(\(code))"
+    }
 }

--- a/Sources/KWWKAgent/PathUtils.swift
+++ b/Sources/KWWKAgent/PathUtils.swift
@@ -6,7 +6,7 @@ public enum PathUtils {
             + (0x2000...0x200A).map(UInt32.init)
     )
 
-    /// Resolve a possibly-relative path against `cwd` and expand leading `~`.
+    /// Resolve a possibly-relative path against `cwd`, expanding only `~` and `~/...`.
     public static func resolveToCwd(_ path: String, cwd: String) -> String {
         let p = expandPath(path)
         let resolved: String

--- a/Sources/KWWKAgent/PathUtils.swift
+++ b/Sources/KWWKAgent/PathUtils.swift
@@ -1,16 +1,49 @@
 import Foundation
 
 public enum PathUtils {
+    private static let unicodeSpaceScalars = Set<UInt32>(
+        [UInt32(0x00A0), UInt32(0x202F), UInt32(0x205F), UInt32(0x3000)]
+            + (0x2000...0x200A).map(UInt32.init)
+    )
+
     /// Resolve a possibly-relative path against `cwd` and expand leading `~`.
     public static func resolveToCwd(_ path: String, cwd: String) -> String {
-        var p = path
-        if p.hasPrefix("~") {
-            let home = NSHomeDirectory()
-            let suffix = p.dropFirst()
-            p = home + suffix
+        let p = expandPath(path)
+        let resolved: String
+        if p.hasPrefix("/") {
+            resolved = p
+        } else {
+            let base = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
+            resolved = "\(base)/\(p)"
         }
-        if (p as NSString).isAbsolutePath { return p }
-        return (cwd as NSString).appendingPathComponent(p)
+        return URL(fileURLWithPath: resolved).standardized.path
+    }
+
+    /// Normalize model/user path spelling the same way pi's `expandPath` does:
+    /// strip a leading `@`, normalize Unicode spaces, and expand `~`/`~/...`.
+    public static func expandPath(_ path: String) -> String {
+        var p = path.hasPrefix("@") ? String(path.dropFirst()) : path
+        p = normalizeUnicodeSpaces(p)
+        if p == "~" {
+            return NSHomeDirectory()
+        }
+        if p.hasPrefix("~/") {
+            return NSHomeDirectory() + String(p.dropFirst())
+        }
+        return p
+    }
+
+    public static func normalizeUnicodeSpaces(_ path: String) -> String {
+        var out = ""
+        out.reserveCapacity(path.count)
+        for scalar in path.unicodeScalars {
+            if unicodeSpaceScalars.contains(scalar.value) {
+                out.append(" ")
+            } else {
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out
     }
 
     /// Detect a supported image MIME type by sniffing leading magic bytes.

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -220,22 +220,33 @@ struct EditToolTests {
         try write("Hello, world!", to: file)
 
         let tool = createEditTool(cwd: dir.path)
+        let updates = EditUpdateCapture()
         let edits: JSONValue = .array([
             .object(["oldText": .string("world"), "newText": .string("testing")])
         ])
         let result = try await tool.execute(
             "call-1",
             .object(["path": .string(file.path), "edits": edits]),
-            nil, nil
+            nil,
+            { updates.record($0) }
         )
 
         #expect(textOutput(result).contains("Successfully replaced"))
         if case .object(let details) = result.details ?? .null,
-           case .string(let diff) = details["diff"] ?? .null {
+           case .string(let diff) = details["diff"] ?? .null,
+           case .string(let patch) = details["patch"] ?? .null,
+           case .int(let firstChangedLine) = details["firstChangedLine"] ?? .null {
             #expect(diff.contains("testing"))
+            #expect(patch.contains("--- \(file.path)"))
+            #expect(patch.contains("+++ \(file.path)"))
+            #expect(firstChangedLine == 1)
         } else {
-            Issue.record("expected diff in details")
+            Issue.record("expected diff, patch, and firstChangedLine in details")
         }
+        let previewDisplays = updates.uiDisplays()
+        #expect(previewDisplays.contains(where: { $0.contains("Previewing 1 replacement") }))
+        #expect(previewDisplays.contains(where: { $0.contains("testing") }))
+        #expect(result.uiDisplay?.contains(where: { $0.contains("Successfully replaced") }) == true)
         let after = try String(contentsOf: file, encoding: .utf8)
         #expect(after == "Hello, testing!")
     }
@@ -257,6 +268,51 @@ struct EditToolTests {
                 .object(["path": .string(file.path), "edits": edits]),
                 nil, nil
             )
+        }
+    }
+
+    @Test("missing target error includes POSIX code")
+    func missingTargetIncludesPOSIXCode() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let missing = dir.appendingPathComponent("missing.txt")
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("hello"), "newText": .string("world")])
+        ])
+        do {
+            _ = try await tool.execute(
+                "call-missing-target",
+                .object(["path": .string(missing.path), "edits": edits]),
+                nil, nil
+            )
+            Issue.record("expected missing target to throw")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+            #expect(message.contains("Could not edit file: \(missing.path). Error code: ENOENT."))
+        }
+    }
+
+    @Test("directory target error includes POSIX code")
+    func directoryTargetIncludesPOSIXCode() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("hello"), "newText": .string("world")])
+        ])
+        do {
+            _ = try await tool.execute(
+                "call-directory-target",
+                .object(["path": .string(dir.path), "edits": edits]),
+                nil, nil
+            )
+            Issue.record("expected directory target to throw")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+            #expect(message.contains("Could not edit file: \(dir.path). Error code: EISDIR."))
         }
     }
 
@@ -321,6 +377,67 @@ struct EditToolTests {
         #expect(textOutput(result).contains("Successfully replaced 2 block(s)"))
         let after = try String(contentsOf: file, encoding: .utf8)
         #expect(after == "ALPHA\nbeta\nGAMMA\ndelta\n")
+    }
+
+    @Test("collapses large unchanged gaps in displayed diff")
+    func collapsedLargeGapDiff() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("large-gap.txt")
+        let lines = (1...600).map { "line \(String(format: "%03d", $0))" }
+        try write(lines.joined(separator: "\n") + "\n", to: file)
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("line 100\n"), "newText": .string("LINE 100\n")]),
+            .object(["oldText": .string("line 300\n"), "newText": .string("LINE 300\n")]),
+            .object(["oldText": .string("line 500\n"), "newText": .string("LINE 500\n")]),
+        ])
+        let result = try await tool.execute(
+            "call-large-gap",
+            .object(["path": .string(file.path), "edits": edits]),
+            nil, nil
+        )
+
+        guard case .object(let details) = result.details ?? .null,
+              case .string(let diff) = details["diff"] ?? .null else {
+            Issue.record("expected diff in details")
+            return
+        }
+        #expect(diff.contains("LINE 100"))
+        #expect(diff.contains("LINE 300"))
+        #expect(diff.contains("LINE 500"))
+        #expect(diff.contains("..."))
+        #expect(!diff.contains("line 250"))
+        #expect(diff.components(separatedBy: "\n").count < 60)
+    }
+}
+
+@Suite("Path utilities")
+struct PathUtilsTests {
+    @Test("resolveToCwd strips at-prefix and normalizes unicode spaces")
+    func stripsAtPrefixAndNormalizesSpaces() {
+        let resolved = PathUtils.resolveToCwd("@nested\u{00A0}dir/file.txt", cwd: "/tmp/root")
+        #expect(resolved == "/tmp/root/nested dir/file.txt")
+    }
+
+    @Test("resolveToCwd expands tilde only for tilde paths")
+    func expandsTildePaths() {
+        #expect(PathUtils.resolveToCwd("~/file.txt", cwd: "/tmp").hasPrefix(NSHomeDirectory()))
+        #expect(PathUtils.resolveToCwd("~not-home/file.txt", cwd: "/tmp") == "/tmp/~not-home/file.txt")
+    }
+}
+
+private final class EditUpdateCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var updates: [AgentToolResult] = []
+
+    func record(_ update: AgentToolResult) {
+        lock.withLock { updates.append(update) }
+    }
+
+    func uiDisplays() -> [String] {
+        lock.withLock { updates.flatMap { $0.uiDisplay ?? [] } }
     }
 }
 

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -322,10 +322,11 @@ struct EditToolTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let file = dir.appendingPathComponent("no-access.txt")
         try write("hello", to: file)
-        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: file.path)
-        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path) }
 
-        let tool = createEditTool(cwd: dir.path)
+        let tool = createEditTool(
+            cwd: dir.path,
+            options: EditToolOptions(operations: AccessDeniedEditOperations())
+        )
         let edits: JSONValue = .array([
             .object(["oldText": .string("hello"), "newText": .string("world")])
         ])
@@ -464,6 +465,21 @@ private final class EditUpdateCapture: @unchecked Sendable {
 
     func uiDisplays() -> [String] {
         lock.withLock { updates.flatMap { $0.uiDisplay ?? [] } }
+    }
+}
+
+private struct AccessDeniedEditOperations: EditOperations {
+    func readFile(_ absolutePath: String) async throws -> Data {
+        Issue.record("readFile should not be called after access fails")
+        return Data()
+    }
+
+    func writeFile(_ absolutePath: String, content: Data) async throws {
+        Issue.record("writeFile should not be called after access fails")
+    }
+
+    func access(_ absolutePath: String) async throws {
+        throw POSIXError(.EACCES)
     }
 }
 

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -316,6 +316,32 @@ struct EditToolTests {
         }
     }
 
+    @Test("permission target error includes POSIX code")
+    func permissionTargetIncludesPOSIXCode() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("no-access.txt")
+        try write("hello", to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: file.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path) }
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("hello"), "newText": .string("world")])
+        ])
+        do {
+            _ = try await tool.execute(
+                "call-permission-target",
+                .object(["path": .string(file.path), "edits": edits]),
+                nil, nil
+            )
+            Issue.record("expected permission target to throw")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+            #expect(message.contains("Could not edit file: \(file.path). Error code: EACCES."))
+        }
+    }
+
     @Test("allows explicit edits outside cwd")
     func allowsOutsideCwd() async throws {
         let dir = makeTempDir()


### PR DESCRIPTION
## What changed

- Added edit-tool preflight access checks with POSIX-style error reporting for missing files, directories, and permission failures.
- Added live edit preview updates and final UI display lines with structured diff metadata.
- Reworked edit diff generation to include folded unchanged context, `firstChangedLine`, and unified patch details.
- Brought path handling closer to pi behavior by stripping leading `@`, normalizing Unicode spaces, and expanding only `~` / `~/...` paths.
- Added tests for preview details, folded diffs, POSIX errors, and path normalization edge cases.

## Why

This closes the remaining parity gaps between kwwk's edit tool and pi's edit behavior around preview rendering, structured diff data, access errors, and model/user path spelling tolerance.

## Validation

- `swift test --filter KWWKAgentTests.EditToolTests`
- `swift test`