### PR TITLE
Multi-provider auth: simultaneous logins + cross-provider /login and /model

### DIFF
--- a/Sources/KWWKAI/APIRegistry.swift
+++ b/Sources/KWWKAI/APIRegistry.swift
@@ -16,21 +16,50 @@ public protocol APIProviderSessionLifecycle: Sendable {
     func closeSession(sessionId: String) async
 }
 
-/// A globally addressable registry of `APIProvider` instances, keyed by
-/// `api` string. Registrations can be tagged with an opaque `sourceId` so
-/// groups of providers can be removed together.
+/// A globally addressable registry of `APIProvider` instances.
+///
+/// Two dispatch layers coexist so that multiple logged-in providers can share
+/// one wire protocol without clobbering each other:
+///
+///   - **Flat**, keyed by `api` string. This is the single-login / env-key
+///     path — one provider per wire protocol.
+///   - **Provider-scoped**, keyed by `(providerScope, api)`. When several
+///     accounts speak the same wire (e.g. Anthropic-OAuth and GitHub-Copilot's
+///     Claude models both ride `anthropic-messages`, with different tokens and
+///     headers), each registers under its own `providerScope` — the model's
+///     `provider` field. Dispatch prefers a scoped match and falls back to the
+///     flat map, so existing single-login behavior is unchanged.
+///
+/// Registrations can be tagged with an opaque `sourceId` so groups of
+/// providers can be removed together.
 public actor APIRegistry {
     public static let shared = APIRegistry()
 
     private var providers: [String: APIProvider] = [:]
+    /// `providerScope → api → provider`. Populated when `register` is given a
+    /// `scope`. Looked up first by `stream`, keyed on `model.provider`.
+    private var scoped: [String: [String: APIProvider]] = [:]
+    /// `sourceId → set of "scope\u{1}api"` (scope empty for flat entries), so a
+    /// source can be torn down across both maps.
     private var bySource: [String: Set<String>] = [:]
 
     public init() {}
 
-    public func register(_ provider: APIProvider, sourceId: String? = nil) {
-        providers[provider.api] = provider
-        if let sourceId {
-            bySource[sourceId, default: []].insert(provider.api)
+    /// Register `provider`. Without `scope`, it lands in the flat map keyed by
+    /// its `api` (legacy behavior). With `scope`, it also lands in the
+    /// provider-scoped map under `(scope, api)` so it can coexist with other
+    /// providers sharing the same wire `api`.
+    public func register(_ provider: APIProvider, scope: String? = nil, sourceId: String? = nil) {
+        if let scope, !scope.isEmpty {
+            scoped[scope, default: [:]][provider.api] = provider
+            if let sourceId {
+                bySource[sourceId, default: []].insert("\(scope)\u{1}\(provider.api)")
+            }
+        } else {
+            providers[provider.api] = provider
+            if let sourceId {
+                bySource[sourceId, default: []].insert("\u{1}\(provider.api)")
+            }
         }
     }
 
@@ -38,23 +67,45 @@ public actor APIRegistry {
         providers[api]
     }
 
+    /// Resolve the provider for a model: prefer a provider-scoped match on
+    /// `(scope, api)`, then fall back to the flat `api` map.
+    public func provider(scope: String, api: String) -> APIProvider? {
+        scoped[scope]?[api] ?? providers[api]
+    }
+
     public func unregister(api: String) {
         providers.removeValue(forKey: api)
         for key in bySource.keys {
-            bySource[key]?.remove(api)
+            bySource[key]?.remove("\u{1}\(api)")
+        }
+    }
+
+    public func unregisterScope(_ scope: String) {
+        scoped.removeValue(forKey: scope)
+        for key in bySource.keys {
+            bySource[key] = bySource[key]?.filter { !$0.hasPrefix("\(scope)\u{1}") }
         }
     }
 
     public func unregisterSource(_ sourceId: String) {
-        guard let apis = bySource.removeValue(forKey: sourceId) else { return }
-        for api in apis {
-            providers.removeValue(forKey: api)
+        guard let keys = bySource.removeValue(forKey: sourceId) else { return }
+        for key in keys {
+            guard let sep = key.firstIndex(of: "\u{1}") else { continue }
+            let scope = String(key[..<sep])
+            let api = String(key[key.index(after: sep)...])
+            if scope.isEmpty {
+                providers.removeValue(forKey: api)
+            } else {
+                scoped[scope]?.removeValue(forKey: api)
+                if scoped[scope]?.isEmpty == true { scoped.removeValue(forKey: scope) }
+            }
         }
     }
 
     public func closeSession(sessionId: String) async {
         guard !sessionId.isEmpty else { return }
-        let snapshot = Array(providers.values)
+        var snapshot = Array(providers.values)
+        for byApi in scoped.values { snapshot.append(contentsOf: byApi.values) }
         for provider in snapshot {
             guard let lifecycle = provider as? APIProviderSessionLifecycle else { continue }
             await lifecycle.closeSession(sessionId: sessionId)
@@ -69,7 +120,7 @@ public enum ProviderNotFoundError: Error, Equatable {
 /// Top-level streaming entry point. Looks up the registered provider for the
 /// model's `api` and delegates to it. Throws if no provider is registered.
 public func stream(model: Model, context: Context, options: StreamOptions? = nil) async throws -> AssistantMessageStream {
-    guard let provider = await APIRegistry.shared.provider(for: model.api) else {
+    guard let provider = await APIRegistry.shared.provider(scope: model.provider, api: model.api) else {
         throw ProviderNotFoundError.api(model.api)
     }
     return provider.stream(model: model, context: context, options: options)

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -125,14 +125,6 @@ public actor OAuthStore {
         try persist()
     }
 
-    /// Replace the entire store with a single provider's credentials. Used by
-    /// `kwwk login` to enforce a single active provider — logging in with a
-    /// new provider drops any previously-saved ones in one atomic write.
-    public func setExclusive(_ credentials: OAuthCredentials, for providerId: String) throws {
-        self.credentials = [providerId: credentials]
-        try persist()
-    }
-
     public func remove(_ providerId: String) throws {
         credentials.removeValue(forKey: providerId)
         try persist()

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -10,6 +10,27 @@ struct ResolvedAuth: Sendable {
     /// `authResolver` that calls back into `OAuthManager.apiKey(for:)` so
     /// tokens refresh on demand. Nil for static api-key providers.
     let authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    /// Every provider registered this session, so `/model` can list + switch
+    /// across all logged-in accounts. Single-login / env auth yields one slot.
+    let providerSlots: [ProviderSlot]
+    /// The mutable resolver map the agent's `authResolver` delegates to, so
+    /// `/login` can add a provider mid-session. Nil for the single-provider
+    /// helper paths that don't own one.
+    let authResolvers: SessionAuthResolvers?
+
+    init(
+        model: Model,
+        modelLabel: String,
+        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        providerSlots: [ProviderSlot] = [],
+        authResolvers: SessionAuthResolvers? = nil
+    ) {
+        self.model = model
+        self.modelLabel = modelLabel
+        self.authResolver = authResolver
+        self.providerSlots = providerSlots
+        self.authResolvers = authResolvers
+    }
 }
 
 enum AuthResolveError: Error, LocalizedError {
@@ -56,32 +77,11 @@ func resolveAgentAuth(
     let store = OAuthStore(url: OAuthStore.defaultURL())
     let all = await store.all()
 
-    // Pick the single entry. If the store somehow holds multiple (legacy
-    // files from before `setExclusive`), prefer OAuth subscriptions over
-    // raw API keys so users on both don't silently land on the wrong one.
-    if let providerId = pickStoredProvider(from: all),
-       let creds = all[providerId] {
-        switch providerId {
-        case "openai-codex":
-            return await registerCodex(store: store, creds: creds, modelOverride: modelOverride)
-        case "anthropic":
-            return await registerAnthropicOAuth(
-                store: store, creds: creds,
-                modelOverride: modelOverride, context1m: context1m
-            )
-        case "anthropic-api-key":
-            return await registerAnthropicAPIKey(creds: creds, modelOverride: modelOverride)
-        case "openai-api-key":
-            return await registerOpenAIAPIKey(creds: creds, modelOverride: modelOverride)
-        case "openai-compatible":
-            return try await registerOpenAICompatible(creds: creds, modelOverride: modelOverride)
-        case "google-api-key":
-            return await registerGoogleAPIKey(creds: creds, modelOverride: modelOverride)
-        case "github-copilot":
-            return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride)
-        default:
-            throw AuthResolveError.unsupportedProvider(providerId)
-        }
+    if !all.isEmpty {
+        return try await registerAllStored(
+            store: store, all: all,
+            modelOverride: modelOverride, context1m: context1m
+        )
     }
 
     // No stored login: fall back to environment API keys (lowest priority),
@@ -92,10 +92,180 @@ func resolveAgentAuth(
         modelOverride: modelOverride,
         environment: ProcessInfo.processInfo.environment
     ) {
-        return env
+        // Give `/model` a single slot for the env provider so it can still
+        // list that provider's catalog, and a resolver actor so a later
+        // `/login` can add a stored provider mid-session.
+        let slot = ProviderSlot(
+            storeId: "env:\(env.model.provider)",
+            catalogProvider: catalogProvider(forCatalogKey: env.model.provider),
+            displayName: providerDisplayName(forStoreId: "env:\(env.model.provider)"),
+            template: env.model
+        )
+        let authResolvers = SessionAuthResolvers()
+        if let r = env.authResolver {
+            await authResolvers.set(scope: env.model.provider, r)
+        }
+        return ResolvedAuth(
+            model: env.model,
+            modelLabel: env.modelLabel,
+            authResolver: authResolvers.delegatingResolver(),
+            providerSlots: [slot],
+            authResolvers: authResolvers
+        )
     }
 
     throw AuthResolveError.noCredentials
+}
+
+/// For env-auth the model's `provider` is already the catalog key (e.g.
+/// `openai`, `google`, `anthropic`), except the Codex variant. Normalize it.
+private func catalogProvider(forCatalogKey key: String) -> String {
+    key == "chatgpt-codex" ? "openai-codex" : key
+}
+
+/// Register **every** stored provider on `APIRegistry.shared` (each scoped by
+/// its `model.provider` so same-wire providers don't clobber each other), and
+/// return a `ResolvedAuth` whose model is the *active* provider's default and
+/// whose `authResolver` is a **unified** closure that dispatches by
+/// `model.provider` across all logged-in accounts. `/model` can then switch to
+/// any registered provider's models mid-session and requests route to the
+/// right credentials.
+///
+/// Active-provider selection:
+///   - `modelOverride` of the form `provider/id` activates that provider (if
+///     logged in) with model `id`.
+///   - Otherwise the highest-priority logged-in provider is active, and a bare
+///     `modelOverride` names its model.
+private func registerAllStored(
+    store: OAuthStore,
+    all: [String: OAuthCredentials],
+    modelOverride: String?,
+    context1m: Bool
+) async throws -> ResolvedAuth {
+    let order = storedProviderOrder(all)
+
+    // Split an explicit `provider/model` override and resolve which logged-in
+    // store id it targets (prefer the priority order on ambiguity, e.g.
+    // `anthropic/...` with both OAuth and API-key logins → OAuth).
+    var forcedStoreId: String?
+    var activeModelId: String? = modelOverride
+    if let mo = modelOverride, let slash = mo.firstIndex(of: "/") {
+        let prefix = String(mo[..<slash])
+        if let sid = order.first(where: { catalogProvider(forStoreId: $0) == prefix }) {
+            forcedStoreId = sid
+            activeModelId = String(mo[mo.index(after: slash)...])
+        }
+    }
+    let activeStoreId = forcedStoreId ?? order.first
+
+    // Register each provider once. Skip a later provider whose `model.provider`
+    // scope is already taken (same-vendor dual login, e.g. Anthropic OAuth +
+    // Anthropic API key both scope to `anthropic`) — priority order keeps the
+    // preferred one.
+    let authResolvers = SessionAuthResolvers()
+    var seenScopes: Set<String> = []
+    var slots: [ProviderSlot] = []
+    var active: ResolvedAuth?
+
+    for storeId in order {
+        guard all[storeId] != nil else { continue }
+        let scope = modelProviderScope(forStoreId: storeId)
+        if seenScopes.contains(scope) {
+            FileHandle.standardError.write(Data(
+                "kwwk: '\(storeId)' shares the '\(scope)' provider slot with an already-registered login; skipping.\n".utf8
+            ))
+            continue
+        }
+        let mo = storeId == activeStoreId ? activeModelId : nil
+        guard let resolved = try await registerStored(
+            storeId: storeId, store: store, modelOverride: mo, context1m: context1m
+        ) else { continue }
+        seenScopes.insert(scope)
+        if let r = resolved.authResolver {
+            await authResolvers.set(scope: resolved.model.provider, r)
+        }
+        slots.append(ProviderSlot(
+            storeId: storeId,
+            catalogProvider: catalogProvider(forStoreId: storeId),
+            displayName: providerDisplayName(forStoreId: storeId),
+            template: resolved.model
+        ))
+        if storeId == activeStoreId { active = resolved }
+    }
+
+    guard let active else { throw AuthResolveError.noCredentials }
+
+    // The agent holds one stable delegating closure; static-only sessions get
+    // a resolver that always returns nil (providers use baked keys), which
+    // still lets a later `/login` install an OAuth provider.
+    return ResolvedAuth(
+        model: active.model,
+        modelLabel: active.modelLabel,
+        authResolver: authResolvers.delegatingResolver(),
+        providerSlots: slots,
+        authResolvers: authResolvers
+    )
+}
+
+/// Register one stored provider on `APIRegistry.shared` (scoped by its
+/// `model.provider`) and return its `ResolvedAuth` (default model + optional
+/// per-provider resolver). Shared by launch-time `registerAllStored` and the
+/// in-session `/login` path. Returns nil for unwired store ids or missing
+/// credentials (logging a notice for the former).
+func registerStored(
+    storeId: String,
+    store: OAuthStore,
+    modelOverride: String?,
+    context1m: Bool
+) async throws -> ResolvedAuth? {
+    guard let creds = await store.get(storeId) else { return nil }
+    switch storeId {
+    case "openai-codex":
+        return await registerCodex(store: store, creds: creds, modelOverride: modelOverride)
+    case "anthropic":
+        return await registerAnthropicOAuth(
+            store: store, creds: creds, modelOverride: modelOverride, context1m: context1m
+        )
+    case "anthropic-api-key":
+        return await registerAnthropicAPIKey(creds: creds, modelOverride: modelOverride)
+    case "openai-api-key":
+        return await registerOpenAIAPIKey(creds: creds, modelOverride: modelOverride)
+    case "openai-compatible":
+        return try await registerOpenAICompatible(creds: creds, modelOverride: modelOverride)
+    case "google-api-key":
+        return await registerGoogleAPIKey(creds: creds, modelOverride: modelOverride)
+    case "github-copilot":
+        return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride)
+    default:
+        FileHandle.standardError.write(Data(
+            "kwwk: stored credentials for '\(storeId)' aren't wired up; skipping.\n".utf8
+        ))
+        return nil
+    }
+}
+
+/// Register a single freshly-logged-in provider mid-session: scoped provider
+/// on `APIRegistry`, resolver into `authResolvers`, and a `ProviderSlot` for
+/// `/model`. Returns nil if the provider isn't stored / wired up.
+@MainActor
+func registerStoredProviderLive(
+    storeId: String,
+    authResolvers: SessionAuthResolvers,
+    context1m: Bool = false
+) async -> ProviderSlot? {
+    let store = OAuthStore(url: OAuthStore.defaultURL())
+    guard let resolved = try? await registerStored(
+        storeId: storeId, store: store, modelOverride: nil, context1m: context1m
+    ) else { return nil }
+    if let r = resolved.authResolver {
+        await authResolvers.set(scope: resolved.model.provider, r)
+    }
+    return ProviderSlot(
+        storeId: storeId,
+        catalogProvider: catalogProvider(forStoreId: storeId),
+        displayName: providerDisplayName(forStoreId: storeId),
+        template: resolved.model
+    )
 }
 
 /// Resolve a session from environment-variable API keys. Honors a
@@ -307,21 +477,57 @@ private func registerEnvProvider(api: String, provider: String, apiKey: String) 
     }
 }
 
-/// Deterministic priority order when the store holds more than one entry.
-/// OAuth subscriptions first, then api keys, then wrappers we don't yet
-/// support (they'll surface a clear error rather than a silent miss).
-private func pickStoredProvider(from all: [String: OAuthCredentials]) -> String? {
-    let priority = [
-        "openai-codex",
-        "anthropic",
-        "anthropic-api-key",
-        "openai-api-key",
-        "openai-compatible",
-        "google-api-key",
-        "github-copilot",
-    ]
-    for id in priority where all[id] != nil { return id }
-    return all.keys.sorted().first
+/// Deterministic priority order for the stored provider ids that are actually
+/// present. OAuth subscriptions first, then api keys; the first entry is the
+/// default *active* provider at launch, and the order also breaks same-scope
+/// ties (e.g. Anthropic OAuth wins over Anthropic API key). Unknown ids sort
+/// last so they surface a clear "not wired up" notice rather than a silent
+/// miss.
+private let storedProviderPriority = [
+    "openai-codex",
+    "anthropic",
+    "anthropic-api-key",
+    "openai-api-key",
+    "openai-compatible",
+    "google-api-key",
+    "github-copilot",
+]
+
+func storedProviderOrder(_ all: [String: OAuthCredentials]) -> [String] {
+    var order = storedProviderPriority.filter { all[$0] != nil }
+    let extras = all.keys.filter { !storedProviderPriority.contains($0) }.sorted()
+    order.append(contentsOf: extras)
+    return order
+}
+
+/// The `model.provider` scope a stored provider registers under on
+/// `APIRegistry` — the key `stream` dispatches on. Several store ids collapse
+/// onto the same catalog provider (`anthropic` OAuth and `anthropic-api-key`
+/// both drive Anthropic's `anthropic-messages` wire), so this is intentionally
+/// many-to-one; `registerAllStored` skips the later of any collision.
+func modelProviderScope(forStoreId storeId: String) -> String {
+    switch storeId {
+    case "openai-codex": return "chatgpt-codex"
+    case "anthropic", "anthropic-api-key": return "anthropic"
+    case "openai-api-key": return "openai"
+    case "google-api-key": return "google"
+    case "openai-compatible": return "openai-compatible"
+    default: return storeId  // github-copilot, and any future 1:1 ids
+    }
+}
+
+/// The `ModelsCatalog.byProvider` key holding a stored provider's models —
+/// used to list a provider's models for `/model` and to match a
+/// `provider/model` launch override to a logged-in account.
+func catalogProvider(forStoreId storeId: String) -> String {
+    switch storeId {
+    case "openai-codex": return "openai-codex"
+    case "anthropic", "anthropic-api-key": return "anthropic"
+    case "openai-api-key": return "openai"
+    case "google-api-key": return "google"
+    case "openai-compatible": return "openai-compatible"
+    default: return storeId  // github-copilot
+    }
 }
 
 // MARK: - Codex (OAuth)
@@ -347,7 +553,7 @@ private func registerCodex(
         accessToken: nil,
         accountId: accountId,
         originator: "kwwk"
-    ))
+    ), scope: "chatgpt-codex")
 
     let modelId = modelOverride ?? "gpt-5.5"
     let catalogEntry = ModelsCatalog.model(provider: "openai-codex", id: modelId)
@@ -396,7 +602,7 @@ private func registerAnthropicOAuth(
     await APIRegistry.shared.register(ProviderVariants.anthropicOAuth(
         accessToken: nil,
         beta: beta
-    ))
+    ), scope: "anthropic")
 
     let modelId = modelOverride ?? "claude-opus-4-8"
     let catalog = ModelsCatalog.model(provider: "anthropic", id: modelId)
@@ -460,17 +666,17 @@ private func registerGitHubCopilot(
         sessionToken: nil,
         integrationID: "vscode-chat",
         baseURL: baseURL
-    ))
+    ), scope: "github-copilot")
     await APIRegistry.shared.register(ProviderVariants.githubCopilotAnthropic(
         sessionToken: nil,
         integrationID: "vscode-chat",
         baseURL: baseURL
-    ))
+    ), scope: "github-copilot")
     await APIRegistry.shared.register(ProviderVariants.githubCopilotResponses(
         sessionToken: nil,
         integrationID: "vscode-chat",
         baseURL: baseURL
-    ))
+    ), scope: "github-copilot")
 
     // Default to `gpt-5.5` — generally available on all Copilot tiers, no
     // policy-enable dependency. Users can /model to Claude/GPT-5/etc after
@@ -530,7 +736,7 @@ private func registerAnthropicAPIKey(
     modelOverride: String? = nil
 ) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://api.anthropic.com"
-    await APIRegistry.shared.register(AnthropicProvider(defaultAPIKey: creds.access))
+    await APIRegistry.shared.register(AnthropicProvider(defaultAPIKey: creds.access), scope: "anthropic")
 
     let modelId = modelOverride ?? "claude-opus-4-8"
     let catalog = ModelsCatalog.model(provider: "anthropic", id: modelId)
@@ -559,7 +765,7 @@ private func registerOpenAIAPIKey(
     modelOverride: String? = nil
 ) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://api.openai.com"
-    await APIRegistry.shared.register(OpenAIResponsesProvider(defaultAPIKey: creds.access))
+    await APIRegistry.shared.register(OpenAIResponsesProvider(defaultAPIKey: creds.access), scope: "openai")
 
     let modelId = modelOverride ?? "gpt-5.5"
     let catalog = ModelsCatalog.model(provider: "openai", id: modelId)
@@ -588,7 +794,7 @@ private func registerGoogleAPIKey(
     modelOverride: String? = nil
 ) async -> ResolvedAuth {
     let baseURL = stringExtra(creds, "baseUrl") ?? "https://generativelanguage.googleapis.com"
-    await APIRegistry.shared.register(GoogleGeminiProvider(defaultAPIKey: creds.access))
+    await APIRegistry.shared.register(GoogleGeminiProvider(defaultAPIKey: creds.access), scope: "google")
 
     let modelId = modelOverride ?? "gemini-3.1-pro-preview"
     let catalog = ModelsCatalog.model(provider: "google", id: modelId)
@@ -626,7 +832,7 @@ private func registerOpenAICompatible(
     guard let modelId = modelOverride ?? storedModel, !modelId.isEmpty else {
         throw AuthResolveError.unsupportedProvider("openai-compatible (missing defaultModel)")
     }
-    await APIRegistry.shared.register(OpenAICompletionsProvider(defaultAPIKey: creds.access))
+    await APIRegistry.shared.register(OpenAICompletionsProvider(defaultAPIKey: creds.access), scope: "openai-compatible")
 
     let model = Model(
         id: modelId,

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -56,12 +56,17 @@ enum AuthResolveError: Error, LocalizedError {
 }
 
 /// Resolve credentials:
-///   1. `OAuthStore` has exactly one provider (kwwk login is exclusive) →
-///      route based on that provider id.
-///   2. Throw `noCredentials`.
+///   1. If `OAuthStore` holds any logins, register ALL of them via
+///      `registerAllStored` (each scoped by `model.provider`) and build a
+///      unified cross-provider resolver; same-scope dual logins are
+///      de-duplicated by priority. The highest-priority (or `provider/model`
+///      override's) provider is the active model.
+///   2. Otherwise fall back to environment API keys (lowest priority).
+///   3. Throw `noCredentials`.
 ///
-/// Registers the chosen provider on `APIRegistry.shared` as a side effect so
-/// the returned model can be used immediately.
+/// Registers every resolved provider on `APIRegistry.shared` as a side effect
+/// so the returned model — and any `/model` switch to another logged-in
+/// provider — can be used immediately.
 ///
 /// `modelOverride` (optional) replaces the provider's hardcoded default model
 /// id — catalog metadata is still resolved from `ModelsCatalog`, falling back
@@ -97,7 +102,7 @@ func resolveAgentAuth(
         // `/login` can add a stored provider mid-session.
         let slot = ProviderSlot(
             storeId: "env:\(env.model.provider)",
-            catalogProvider: catalogProvider(forCatalogKey: env.model.provider),
+            catalogProvider: catalogProviderKey(forAgentProvider: env.model.provider),
             displayName: providerDisplayName(forStoreId: "env:\(env.model.provider)"),
             template: env.model
         )
@@ -115,12 +120,6 @@ func resolveAgentAuth(
     }
 
     throw AuthResolveError.noCredentials
-}
-
-/// For env-auth the model's `provider` is already the catalog key (e.g.
-/// `openai`, `google`, `anthropic`), except the Codex variant. Normalize it.
-private func catalogProvider(forCatalogKey key: String) -> String {
-    key == "chatgpt-codex" ? "openai-codex" : key
 }
 
 /// Register **every** stored provider on `APIRegistry.shared` (each scoped by
@@ -257,8 +256,14 @@ func registerStoredProviderLive(
     guard let resolved = try? await registerStored(
         storeId: storeId, store: store, modelOverride: nil, context1m: context1m
     ) else { return nil }
+    // Keep the scope's provider instance and its resolver consistent: an
+    // OAuth provider installs a resolver; a static api-key provider has none
+    // and must clear any stale resolver left under this scope, else the next
+    // request would send a token through the wrong provider instance.
     if let r = resolved.authResolver {
         await authResolvers.set(scope: resolved.model.provider, r)
+    } else {
+        await authResolvers.remove(scope: resolved.model.provider)
     }
     return ProviderSlot(
         storeId: storeId,
@@ -659,9 +664,11 @@ private func registerGitHubCopilot(
 
     // Register one provider per wire format. Copilot's catalog mixes all
     // three: Claude models use anthropic-messages, GPT-4.x and Gemini use
-    // openai-completions, GPT-5 family uses openai-responses. With
-    // single-provider login (`setExclusive`) these don't collide with the
-    // direct-API providers; they replace them for this session.
+    // openai-completions, GPT-5 family uses openai-responses. All register
+    // under scope "github-copilot", so they live in the provider-scoped map
+    // and COEXIST with (rather than replace) the direct-API anthropic/openai
+    // providers — dispatch prefers the scoped instance only for models whose
+    // `provider == "github-copilot"`, falling back to the flat map otherwise.
     await APIRegistry.shared.register(ProviderVariants.githubCopilot(
         sessionToken: nil,
         integrationID: "vscode-chat",

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -9,8 +9,18 @@ import KWWKAgent
 func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
     registry.register(SlashCommand(
         name: "model",
-        description: "Pick a model for this session",
+        description: "Pick a model for this session (across all logged-in providers)",
         handler: handleModelCommand
+    ))
+    registry.register(SlashCommand(
+        name: "login",
+        description: "Log in to another provider (kept alongside existing logins)",
+        handler: handleLoginCommand
+    ))
+    registry.register(SlashCommand(
+        name: "logout",
+        description: "Show logged-in providers / remove one",
+        handler: handleLogoutCommand
     ))
     registry.register(SlashCommand(
         name: "compact",
@@ -91,39 +101,74 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
     ))
 }
 
-/// `/model` — opens a modal with every model the currently-authenticated
-/// provider supports. Selection updates `agent.state.model` for the next
-/// LLM request; the swap is session-scoped (restart = back to default).
-///
-/// Cross-provider switching (Codex → Anthropic or vice versa) needs a
-/// second provider registered on APIRegistry at startup, which is out of
-/// scope for V1.
+/// `/model` — opens a modal listing every model across **all** providers
+/// logged in this session (grouped by provider), and switches to the picked
+/// one. The pick is routed through the target provider's session template
+/// (`adoptFields`) so its wire api / provider scope / baseUrl / headers are
+/// correct, then stored on `agent.state.model` for the next request. The swap
+/// is session-scoped (restart = back to the launch default).
 @MainActor
 private func handleModelCommand(_ ctx: SlashContext, _ args: String) async {
     let current = ctx.agent.state.model
-    let agentProvider = current.provider
-    let catalogKey = catalogProviderKey(forAgentProvider: agentProvider)
+    let slots = ctx.sessionProviders.slots
 
-    let available = ModelsCatalog.models(for: catalogKey)
-        .sorted { $0.id < $1.id }
+    // Build a flat, provider-grouped list of routed models. Each entry carries
+    // a model already stamped with its provider's routing (via `adoptFields`),
+    // so selection is a straight assignment.
+    var models: [Model] = []
+    var groups: [String] = []
+    var currentIndex: Int?
 
-    if available.isEmpty {
-        ctx.notify(Style.error("  /model: no catalog entries for provider '\(agentProvider)'"))
+    let slotList: [ProviderSlot] = slots.isEmpty
+        // No session slots (e.g. a test/headless path): fall back to the
+        // active provider's own catalog so `/model` still works.
+        ? [ProviderSlot(
+            storeId: current.provider,
+            catalogProvider: catalogProviderKey(forAgentProvider: current.provider),
+            displayName: current.provider,
+            template: current)]
+        : slots
+
+    for slot in slotList {
+        let catalog = ModelsCatalog.models(for: slot.catalogProvider)
+            .sorted { $0.id < $1.id }
+        // Providers whose active model isn't catalogued (custom openai-compatible
+        // endpoints) still get their template as a selectable row.
+        let base = catalog.isEmpty ? [slot.template] : catalog
+        for m in base {
+            let routed = adoptFields(from: slot.template, into: m)
+            if routed.provider == current.provider && routed.id == current.id {
+                currentIndex = models.count
+            }
+            models.append(routed)
+            groups.append(slot.displayName)
+        }
+    }
+
+    if models.isEmpty {
+        ctx.notify(Style.error("  /model: no models available for the logged-in providers"))
         return
     }
 
+    let multi = slotList.count > 1
+    let title = multi ? "Select a model  (\(slotList.count) providers)" : "Select a model"
     let modal = ModelSelectorModal(
-        title: "Select a model  (provider: \(agentProvider))",
-        models: available,
+        title: title,
+        models: models,
         currentModelId: current.id,
+        groupLabels: multi ? groups : nil,
+        currentIndex: currentIndex,
         onSelect: { [agent = ctx.agent, notifyBlock = ctx.notifyBlock, modal = ctx.modal] picked in
-            let rebuilt = adoptFields(from: current, into: picked)
-            agent.state.model = rebuilt
+            let previous = agent.state.model
+            agent.state.model = picked
             modal.close()
-            if picked.id == current.id {
+            let switchedProvider = picked.provider != previous.provider
+            if picked.id == previous.id && !switchedProvider {
                 notifyBlock([Style.dimmed("  /model: already on \(picked.id)")])
+            } else if switchedProvider {
+                notifyBlock([Style.dimmed("  /model: switched to \(picked.id) · \(providerDisplayName(forCatalogScope: picked.provider))")])
             } else {
-                notifyBlock([Style.dimmed("  /model: switched \(current.id) → \(picked.id)")])
+                notifyBlock([Style.dimmed("  /model: switched \(previous.id) → \(picked.id)")])
             }
         },
         onCancel: { [modal = ctx.modal, notifyBlock = ctx.notifyBlock] in
@@ -132,6 +177,119 @@ private func handleModelCommand(_ ctx: SlashContext, _ args: String) async {
         }
     )
     ctx.modal.open(modal)
+}
+
+/// Best-effort human label for a live `model.provider` scope, for the
+/// `/model` switch confirmation. Falls back to the raw scope.
+@MainActor
+func providerDisplayName(forCatalogScope scope: String) -> String {
+    switch scope {
+    case "chatgpt-codex": return "ChatGPT Codex"
+    case "anthropic": return "Anthropic"
+    case "openai": return "OpenAI"
+    case "google": return "Google"
+    case "github-copilot": return "GitHub Copilot"
+    case "openai-compatible": return "OpenAI-compatible"
+    default: return scope
+    }
+}
+
+// MARK: - /login  ·  /logout
+
+/// Captures the result of the suspended login sub-flow (the `withSuspendedTUI`
+/// body returns Void, so we thread the outcome through a box).
+@MainActor
+private final class LoginResultBox {
+    var storeId: String?
+    var error: String?
+}
+
+/// `/login` — suspends the coding TUI, runs the full `kwwk login` flow
+/// (provider selector → browser OAuth / API-key form), and — crucially —
+/// **keeps** any existing logins. The freshly-authenticated provider is
+/// registered live and becomes available to `/model` without a restart.
+@MainActor
+private func handleLoginCommand(_ ctx: SlashContext, _ args: String) async {
+    guard let authResolvers = ctx.authResolvers else {
+        ctx.notify(Style.error("  /login: not available in this session"))
+        return
+    }
+    let box = LoginResultBox()
+    await ctx.withSuspendedTUI {
+        do {
+            box.storeId = try await runLoginInternal()
+        } catch {
+            box.error = error.localizedDescription
+        }
+    }
+    if let err = box.error {
+        // `.cancelled` (Esc) lands here too — a gentle note, not an error.
+        ctx.notify(Style.dimmed("  /login: \(err)"))
+        return
+    }
+    guard let storeId = box.storeId else {
+        ctx.notify(Style.dimmed("  /login: no provider logged in"))
+        return
+    }
+    guard let slot = await registerStoredProviderLive(
+        storeId: storeId, authResolvers: authResolvers
+    ) else {
+        ctx.notify(Style.error("  /login: '\(storeId)' logged in but couldn't be activated"))
+        return
+    }
+    ctx.sessionProviders.upsert(slot)
+    ctx.notify(Style.dimmed("  /login: \(slot.displayName) ready — /model to switch to it"))
+}
+
+/// `/logout` — with no argument lists the logged-in providers; with a provider
+/// id removes that login (from disk + this session's routing). Falls back to
+/// another logged-in provider if the active one is removed.
+@MainActor
+private func handleLogoutCommand(_ ctx: SlashContext, _ args: String) async {
+    let target = args.trimmingCharacters(in: .whitespacesAndNewlines)
+    let store = OAuthStore(url: OAuthStore.defaultURL())
+    let all = await store.all()
+    if all.isEmpty {
+        ctx.notify(Style.dimmed("  /logout: no stored logins (running on env keys or none)"))
+        return
+    }
+    let ids = storedProviderOrder(all)
+
+    if target.isEmpty {
+        var lines = [Style.dimmed("  logged-in providers:")]
+        for id in ids {
+            let isActive = ctx.agent.state.model.provider == modelProviderScope(forStoreId: id)
+            let tag = isActive ? Style.dimmed("  · active") : ""
+            lines.append("    " + id + "  " + Style.dimmed(providerDisplayName(forStoreId: id)) + tag)
+        }
+        lines.append(Style.dimmed("  /logout <provider> to remove one"))
+        ctx.notifyBlock(lines)
+        return
+    }
+
+    guard ids.contains(target) else {
+        ctx.notify(Style.error("  /logout: '\(target)' is not logged in — run /logout to list"))
+        return
+    }
+
+    try? await store.remove(target)
+    let scope = modelProviderScope(forStoreId: target)
+    await APIRegistry.shared.unregisterScope(scope)
+    if let ar = ctx.authResolvers { await ar.remove(scope: scope) }
+    ctx.sessionProviders.remove(storeId: target)
+
+    // If the removed provider was the one in use, switch to a survivor so the
+    // next request doesn't hit a now-unregistered provider.
+    if ctx.agent.state.model.provider == scope {
+        if let next = ctx.sessionProviders.slots.first {
+            ctx.agent.state.model = next.template
+            ctx.notify(Style.dimmed("  /logout: removed \(target); now on \(next.template.id) · \(next.displayName)"))
+        } else {
+            ctx.notify(Style.error("  /logout: removed \(target) — no providers left; /login to add one"))
+        }
+    } else {
+        ctx.notify(Style.dimmed("  /logout: removed \(target)"))
+    }
 }
 
 /// Map an in-session agent `Model.provider` to the key used in

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -236,9 +236,14 @@ private func handleLoginCommand(_ ctx: SlashContext, _ args: String) async {
     // `anthropic`). Don't let a second same-scope login clobber the active
     // provider's registration/resolver this session. The credentials are still
     // saved on disk; priority order decides on the next launch.
+    // Compare against each incumbent slot's ACTUAL registered scope
+    // (template.provider), not one re-derived from its storeId: an
+    // env-authenticated incumbent has storeId "env:<provider>" for which
+    // modelProviderScope has no case, but its template.provider is the real
+    // wire scope — so deriving from storeId would miss the collision.
     let newScope = modelProviderScope(forStoreId: storeId)
     if let existing = ctx.sessionProviders.slots.first(where: {
-        $0.storeId != storeId && modelProviderScope(forStoreId: $0.storeId) == newScope
+        $0.storeId != storeId && $0.template.provider == newScope
     }) {
         ctx.notify(Style.dimmed(
             "  /login: saved \(storeId), but it shares a provider slot with the active \(existing.storeId) — /logout \(existing.storeId) first to use it"

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -231,6 +231,20 @@ private func handleLoginCommand(_ ctx: SlashContext, _ args: String) async {
         ctx.notify(Style.dimmed("  /login: no provider logged in"))
         return
     }
+    // Same-scope dedup, mirroring launch-time registerAllStored: two store ids
+    // can share one wire scope (Anthropic OAuth + Anthropic API key both →
+    // `anthropic`). Don't let a second same-scope login clobber the active
+    // provider's registration/resolver this session. The credentials are still
+    // saved on disk; priority order decides on the next launch.
+    let newScope = modelProviderScope(forStoreId: storeId)
+    if let existing = ctx.sessionProviders.slots.first(where: {
+        $0.storeId != storeId && modelProviderScope(forStoreId: $0.storeId) == newScope
+    }) {
+        ctx.notify(Style.dimmed(
+            "  /login: saved \(storeId), but it shares a provider slot with the active \(existing.storeId) — /logout \(existing.storeId) first to use it"
+        ))
+        return
+    }
     guard let slot = await registerStoredProviderLive(
         storeId: storeId, authResolvers: authResolvers
     ) else {
@@ -272,14 +286,28 @@ private func handleLogoutCommand(_ ctx: SlashContext, _ args: String) async {
         return
     }
 
-    try? await store.remove(target)
     let scope = modelProviderScope(forStoreId: target)
+    // Only the store id that actually OWNS this session's slot for the scope
+    // may tear down the scope's live registration. A shadowed same-scope login
+    // (e.g. logging out `anthropic-api-key` while `anthropic` OAuth owns the
+    // `anthropic` scope) was never registered — removing it from disk is
+    // enough; touching the scope would wrongly unregister the active provider.
+    let ownsSlot = ctx.sessionProviders.slot(forStoreId: target) != nil
+    try? await store.remove(target)
+
+    guard ownsSlot else {
+        ctx.notify(Style.dimmed("  /logout: removed \(target) (was shadowed by a same-vendor login)"))
+        return
+    }
+
     await APIRegistry.shared.unregisterScope(scope)
     if let ar = ctx.authResolvers { await ar.remove(scope: scope) }
     ctx.sessionProviders.remove(storeId: target)
 
     // If the removed provider was the one in use, switch to a survivor so the
-    // next request doesn't hit a now-unregistered provider.
+    // next request doesn't hit a now-unregistered provider. (A same-vendor
+    // login still on disk isn't re-homed this session — it's available on the
+    // next launch, where priority order re-registers it.)
     if ctx.agent.state.model.provider == scope {
         if let next = ctx.sessionProviders.slots.first {
             ctx.agent.state.model = next.template

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -14,6 +14,8 @@ func runCodingTUIInternal(
     tools: CodingTools,
     builtinSubagents: BuiltinSubagentSelection = .all,
     authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    providerSlots: [ProviderSlot] = [],
+    authResolvers: SessionAuthResolvers? = nil,
     autoCompactThreshold: Double? = 0.75,
     thinkingLevel: ThinkingLevel = .medium,
     resume: SessionResume = .none
@@ -506,6 +508,9 @@ func runCodingTUIInternal(
         guard !frame.slashMenuActive else { return nil }
         return slashCompletion(for: input, commands: slashCommandInfos)?.suffix
     }
+    // Providers logged in this session — read by `/model` to list + route
+    // across accounts, mutated by `/login` / `/logout`.
+    let sessionProviders = SessionProviders(providerSlots)
     let slashContext = SlashContext(
         agent: agent,
         modal: modal,
@@ -542,6 +547,19 @@ func runCodingTUIInternal(
         },
         setSessionTitle: { title in
             await recorderBox.recorder.recordTitle(title)
+        },
+        sessionProviders: sessionProviders,
+        authResolvers: authResolvers,
+        withSuspendedTUI: { body in
+            // Release the terminal so a full-screen sub-flow (the `/login`
+            // OAuth handoff, which runs its own TUIRunner) owns it cleanly,
+            // then repaint the coding frame when it returns.
+            runner.suspend()
+            await body()
+            try? runner.resume()
+            recomputeTranscript()
+            updateFrameStatus()
+            runner.tui.requestRender()
         }
     )
 

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -220,7 +220,11 @@ func runCodingTUIInternal(
         Task { @MainActor in
             frame.setViewport(height: h)
             renderer.displayWidth = w
-            if !modal.isOpen {
+            if modal.isOpen {
+                // Re-window the open modal to the new height so a long list
+                // re-fits this frame rather than lagging until the next key.
+                modal.reflow()
+            } else {
                 recomputeTranscript()
             }
             updateFrameStatus()

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -210,7 +210,10 @@ func runCodingTUIInternal(
             recomputeTranscript()
             updateFrameStatus()
         },
-        requestRender: { runner.tui.requestRender() }
+        requestRender: { runner.tui.requestRender() },
+        // Rows available for the modal above the prompt box. Reserve ~4 for
+        // the prompt box + a margin; queried per redraw so it tracks resizes.
+        availableRows: { max(4, runner.terminal.height - 4) }
     )
 
     _ = runner.terminal.onResize { w, h in

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -48,6 +48,8 @@ public enum KWWK {
             tools: tools,
             builtinSubagents: builtinSubagents,
             authResolver: resolved.authResolver,
+            providerSlots: resolved.providerSlots,
+            authResolvers: resolved.authResolvers,
             autoCompactThreshold: autoCompactThreshold,
             thinkingLevel: thinkingLevel,
             resume: resume

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -306,7 +306,7 @@ private func runOAuthFlow(providerId: String) async throws {
         throw LoginError.oauthFailed(error.localizedDescription)
     }
 
-    try await persistExclusive(credentials, providerId: providerId)
+    try await persistCredentials(credentials, providerId: providerId)
 
     // GitHub Copilot post-login: opt the account in on every Copilot model
     // we know about. Claude/Grok/Gemini require this one-shot enable before
@@ -395,14 +395,14 @@ private func runAPIKeyFlow(
         expires: .max,
         extras: extras
     )
-    try await persistExclusive(credentials, providerId: storeId)
+    try await persistCredentials(credentials, providerId: storeId)
 }
 
 /// Save `credentials` under `providerId`, **keeping** any other providers
 /// already in the store (additive multi-login). Logging into the same
 /// provider again overwrites just that entry (re-auth / token refresh).
 /// Prints a confirmation line and lists the other providers still logged in.
-private func persistExclusive(
+private func persistCredentials(
     _ credentials: OAuthCredentials,
     providerId: String
 ) async throws {

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -159,15 +159,21 @@ enum LoginError: Error, LocalizedError {
 ///   1. Arrow-key selector over the known providers (OAuth + API-key).
 ///   2. Enter → tear down the TUI and run the chosen entry's flow:
 ///      OAuth = browser PKCE / device flow; API-key = small TUI form.
-///   3. Persist the resulting credentials exclusively — any previously
-///      logged-in provider is dropped so `AuthResolver` can't hit ambiguity.
+///   3. Persist the resulting credentials additively — other providers stay
+///      logged in so the user can keep several accounts and switch between
+///      them with `/model` / `/login`. Re-logging the same provider just
+///      refreshes its entry.
 ///
 /// The TUI is intentionally torn down before the OAuth flow begins so that
 /// the browser handoff + stderr progress logs don't fight the raw-mode
 /// terminal.
-func runLoginInternal() async throws {
+/// Returns the OAuth-store id the credentials were saved under (e.g.
+/// `anthropic`, `openai-codex`, `anthropic-api-key`), so an in-session
+/// `/login` caller can activate exactly that provider.
+@discardableResult
+func runLoginInternal() async throws -> String {
     let choice = try await selectProviderTUI()
-    try await runLoginFlow(entry: choice)
+    return try await runLoginFlow(entry: choice)
 }
 
 // MARK: - Selector TUI
@@ -264,10 +270,11 @@ private func renderSelectorMenu(into menu: TextComponent, state: SelectorState) 
 
 // MARK: - Flow dispatch
 
-private func runLoginFlow(entry: LoginEntry) async throws {
+private func runLoginFlow(entry: LoginEntry) async throws -> String {
     switch entry.flow {
     case .oauth:
         try await runOAuthFlow(providerId: entry.id)
+        return entry.id
     case .apiKey(let storeId, let fields, let extrasKeys):
         try await runAPIKeyFlow(
             providerId: entry.id,
@@ -275,6 +282,7 @@ private func runLoginFlow(entry: LoginEntry) async throws {
             fields: fields,
             extrasKeys: extrasKeys
         )
+        return storeId
     }
 }
 
@@ -390,20 +398,22 @@ private func runAPIKeyFlow(
     try await persistExclusive(credentials, providerId: storeId)
 }
 
-/// Save `credentials` under `providerId` as the only entry in the store,
-/// print a confirmation line and list any replaced entries.
+/// Save `credentials` under `providerId`, **keeping** any other providers
+/// already in the store (additive multi-login). Logging into the same
+/// provider again overwrites just that entry (re-auth / token refresh).
+/// Prints a confirmation line and lists the other providers still logged in.
 private func persistExclusive(
     _ credentials: OAuthCredentials,
     providerId: String
 ) async throws {
     let store = OAuthStore(url: OAuthStore.defaultURL())
-    let previous = await store.all().keys.filter { $0 != providerId }.sorted()
-    try await store.setExclusive(credentials, for: providerId)
+    let others = await store.all().keys.filter { $0 != providerId }.sorted()
+    try await store.set(credentials, for: providerId)
     let path = await store.url.path
     print("")
     print(Style.prompt("✓ saved \(providerId) credentials"))
     print(Style.dimmed("  → \(path)"))
-    if !previous.isEmpty {
-        print(Style.dimmed("  (replaced previous credentials: \(previous.joined(separator: ", ")))"))
+    if !others.isEmpty {
+        print(Style.dimmed("  (also logged in: \(others.joined(separator: ", ")) — switch with /model or /login)"))
     }
 }

--- a/Sources/KWWKCli/Modal.swift
+++ b/Sources/KWWKCli/Modal.swift
@@ -11,7 +11,10 @@ protocol Modal: AnyObject {
     func confirm()
     func cancel()
     /// Lines to render in place of the transcript while the modal is open.
-    func render() -> [String]
+    /// `maxRows` is the height budget (terminal rows available above the
+    /// prompt box); modals with long lists must window their content to fit
+    /// and keep the selection visible rather than overflow the viewport.
+    func render(maxRows: Int) -> [String]
 }
 
 /// Owns the "one modal at a time" invariant. The coding TUI's arrow /
@@ -28,15 +31,20 @@ final class ModalHost {
     /// so the user goes back to exactly what was on screen before the modal.
     private let restoreTranscript: () -> Void
     private let requestRender: () -> Void
+    /// Height budget (terminal rows available for the modal above the prompt
+    /// box), queried fresh on every redraw so windowing tracks resizes.
+    private let availableRows: () -> Int
 
     init(
         renderModalLines: @escaping ([String]?) -> Void,
         restoreTranscript: @escaping () -> Void,
-        requestRender: @escaping () -> Void
+        requestRender: @escaping () -> Void,
+        availableRows: @escaping () -> Int = { 24 }
     ) {
         self.renderModalLines = renderModalLines
         self.restoreTranscript = restoreTranscript
         self.requestRender = requestRender
+        self.availableRows = availableRows
     }
 
     func open(_ modal: Modal) {
@@ -63,7 +71,7 @@ final class ModalHost {
 
     private func redraw() {
         guard let active else { return }
-        renderModalLines(active.render())
+        renderModalLines(active.render(maxRows: max(4, availableRows())))
         requestRender()
     }
 }

--- a/Sources/KWWKCli/Modal.swift
+++ b/Sources/KWWKCli/Modal.swift
@@ -64,6 +64,11 @@ final class ModalHost {
     // Key routing. These are no-ops when no modal is open, so callers can
     // wire them unconditionally and let the host decide.
 
+    /// Re-render the open modal at the current height budget. Called on a
+    /// terminal resize so a windowed list re-fits immediately instead of
+    /// lagging a frame behind until the next keypress.
+    func reflow() { guard isOpen else { return }; redraw() }
+
     func routeUp() { guard isOpen else { return }; active?.up(); redraw() }
     func routeDown() { guard isOpen else { return }; active?.down(); redraw() }
     func routeConfirm() { guard isOpen else { return }; active?.confirm() }

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -18,6 +18,10 @@ final class ModelSelectorModal: Modal {
     /// alone is ambiguous; this pins the initially-selected row.
     private let currentIndex: Int?
     private var selectedIndex: Int
+    /// Top display-line of the visible window. Persistent so the list scrolls
+    /// only when the selection crosses an edge (rather than re-centering on
+    /// every keypress).
+    private var scroll = 0
     private let onSelect: @MainActor (Model) -> Void
     private let onCancel: @MainActor () -> Void
 
@@ -65,34 +69,68 @@ final class ModelSelectorModal: Modal {
         onCancel()
     }
 
-    func render() -> [String] {
+    func render(maxRows: Int) -> [String] {
         var out: [String] = []
         out.append("")
         out.append(Style.header("  \(title)"))
-        out.append("")
-        if models.isEmpty {
+        guard !models.isEmpty else {
+            out.append("")
             out.append(Style.dimmed("  (no models available for this provider)"))
-        } else {
-            var lastGroup: String?
-            for (i, model) in models.enumerated() {
-                if let group = groupLabels?[i], group != lastGroup {
-                    if lastGroup != nil { out.append("") }
-                    out.append(Style.dimmed("  ── \(group) ──"))
-                    lastGroup = group
-                }
-                let prefix = i == selectedIndex ? Style.prompt("  ❯ ") : "    "
-                // The active row is pinned by index (ids repeat across
-                // providers); tag only that exact row as current.
-                let isCurrent = currentIndex != nil ? (i == currentIndex) : (model.id == currentModelId)
-                let currentTag = isCurrent ? Style.dimmed("  · current") : ""
-                let body = i == selectedIndex
-                    ? Style.prompt(model.id) + "  " + Style.dimmed(model.name)
-                    : model.id + "  " + Style.dimmed(model.name)
-                out.append(prefix + body + currentTag)
-            }
+            out.append("")
+            out.append(Style.dimmed("  ↑/↓: move   Enter: confirm   Esc: cancel"))
+            return out
         }
+
+        // Expand to display lines (group headers interleaved with rows),
+        // tracking where the selected row lands so the window keeps it in view.
+        var lines: [(text: String, isHeader: Bool, group: String?)] = []
+        var selectedLine = 0
+        var lastGroup: String?
+        for (i, model) in models.enumerated() {
+            if let group = groupLabels?[i], group != lastGroup {
+                lines.append((Style.dimmed("  ── \(group) ──"), true, group))
+                lastGroup = group
+            }
+            let selected = i == selectedIndex
+            if selected { selectedLine = lines.count }
+            let prefix = selected ? Style.prompt("  ❯ ") : "    "
+            // Ids repeat across providers, so tag only the exact active row.
+            let isCurrent = currentIndex != nil ? (i == currentIndex) : (model.id == currentModelId)
+            let currentTag = isCurrent ? Style.dimmed("  · current") : ""
+            let body = selected
+                ? Style.prompt(model.id) + "  " + Style.dimmed(model.name)
+                : model.id + "  " + Style.dimmed(model.name)
+            lines.append((prefix + body + currentTag, false, groupLabels?[i]))
+        }
+
+        // Body height budget = total minus chrome (blank + title + blank +
+        // blank + footer = 5). Window the list so the prompt box is never
+        // pushed off-screen and the selection stays reachable.
+        let bodyBudget = max(3, maxRows - 5)
+        let windowed = lines.count > bodyBudget
+        // Reserve one line for the synthetic context header we may prepend when
+        // the window opens mid-group, so the scroll window (and therefore the
+        // selected row) is never squeezed out by it.
+        let windowRows = windowed ? max(1, bodyBudget - 1) : bodyBudget
+
+        // Scroll only at the edges.
+        if selectedLine < scroll { scroll = selectedLine }
+        else if selectedLine >= scroll + windowRows { scroll = selectedLine - windowRows + 1 }
+        scroll = max(0, min(scroll, max(0, lines.count - windowRows)))
+
+        var visible = Array(lines[scroll ..< min(lines.count, scroll + windowRows)])
+        // If the window opens mid-group (its header scrolled off), prepend the
+        // active group header for context. The reserved row above keeps this
+        // within budget without dropping the selected row.
+        if windowed, let first = visible.first, !first.isHeader, let group = first.group {
+            visible.insert((Style.dimmed("  ── \(group) ──"), true, group), at: 0)
+        }
+
         out.append("")
-        out.append(Style.dimmed("  ↑/↓: move   Enter: confirm   Esc: cancel"))
+        for line in visible { out.append(line.text) }
+        out.append("")
+        let move = "↑/↓: move   Enter: confirm   Esc: cancel"
+        out.append(Style.dimmed(windowed ? "  \(selectedIndex + 1)/\(models.count)   \(move)" : "  \(move)"))
         return out
     }
 }

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -8,7 +8,15 @@ import KWWKAI
 final class ModelSelectorModal: Modal {
     private let title: String
     private let models: [Model]
+    /// Optional per-model group label (e.g. provider display name). When
+    /// present and it changes between adjacent rows, a dim header is rendered
+    /// above the row so the same model id under different providers is
+    /// distinguishable. Must be the same length as `models` when non-nil.
+    private let groupLabels: [String]?
     private let currentModelId: String?
+    /// When the same model id appears under several providers, `currentModelId`
+    /// alone is ambiguous; this pins the initially-selected row.
+    private let currentIndex: Int?
     private var selectedIndex: Int
     private let onSelect: @MainActor (Model) -> Void
     private let onCancel: @MainActor () -> Void
@@ -17,14 +25,21 @@ final class ModelSelectorModal: Modal {
         title: String,
         models: [Model],
         currentModelId: String?,
+        groupLabels: [String]? = nil,
+        currentIndex: Int? = nil,
         onSelect: @MainActor @escaping (Model) -> Void,
         onCancel: @MainActor @escaping () -> Void
     ) {
         self.title = title
         self.models = models
+        self.groupLabels = (groupLabels?.count == models.count) ? groupLabels : nil
         self.currentModelId = currentModelId
-        // Start on the current model if it's in the list; otherwise top.
-        self.selectedIndex = models.firstIndex(where: { $0.id == currentModelId }) ?? 0
+        self.currentIndex = currentIndex
+        // Start on the current row: an explicit index wins, else the first
+        // model matching currentModelId, else the top.
+        self.selectedIndex = currentIndex
+            ?? models.firstIndex(where: { $0.id == currentModelId })
+            ?? 0
         self.onSelect = onSelect
         self.onCancel = onCancel
     }
@@ -58,9 +73,18 @@ final class ModelSelectorModal: Modal {
         if models.isEmpty {
             out.append(Style.dimmed("  (no models available for this provider)"))
         } else {
+            var lastGroup: String?
             for (i, model) in models.enumerated() {
+                if let group = groupLabels?[i], group != lastGroup {
+                    if lastGroup != nil { out.append("") }
+                    out.append(Style.dimmed("  ── \(group) ──"))
+                    lastGroup = group
+                }
                 let prefix = i == selectedIndex ? Style.prompt("  ❯ ") : "    "
-                let currentTag = model.id == currentModelId ? Style.dimmed("  · current") : ""
+                // The active row is pinned by index (ids repeat across
+                // providers); tag only that exact row as current.
+                let isCurrent = currentIndex != nil ? (i == currentIndex) : (model.id == currentModelId)
+                let currentTag = isCurrent ? Style.dimmed("  · current") : ""
                 let body = i == selectedIndex
                     ? Style.prompt(model.id) + "  " + Style.dimmed(model.name)
                     : model.id + "  " + Style.dimmed(model.name)

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -70,13 +70,17 @@ final class ModelSelectorModal: Modal {
     }
 
     func render(maxRows: Int) -> [String] {
+        // Cosmetic blank spacers (above the list and above the footer) are
+        // dropped on short terminals so the render stays within `maxRows` —
+        // title + body + footer is the irreducible minimum.
+        let roomy = maxRows >= 9
         var out: [String] = []
-        out.append("")
+        if roomy { out.append("") }
         out.append(Style.header("  \(title)"))
         guard !models.isEmpty else {
-            out.append("")
+            if roomy { out.append("") }
             out.append(Style.dimmed("  (no models available for this provider)"))
-            out.append("")
+            if roomy { out.append("") }
             out.append(Style.dimmed("  ↑/↓: move   Enter: confirm   Esc: cancel"))
             return out
         }
@@ -103,10 +107,12 @@ final class ModelSelectorModal: Modal {
             lines.append((prefix + body + currentTag, false, groupLabels?[i]))
         }
 
-        // Body height budget = total minus chrome (blank + title + blank +
-        // blank + footer = 5). Window the list so the prompt box is never
-        // pushed off-screen and the selection stays reachable.
-        let bodyBudget = max(3, maxRows - 5)
+        // Body height budget = total minus chrome. Chrome is title + footer
+        // (2), plus the two blank spacers when roomy (4). Window the list so
+        // the prompt box is never pushed off-screen and the selection stays
+        // reachable — and the whole render stays within `maxRows`.
+        let chrome = roomy ? 4 : 2
+        let bodyBudget = max(1, maxRows - chrome)
         let windowed = lines.count > bodyBudget
         // Reserve one line for the synthetic context header we may prepend when
         // the window opens mid-group, so the scroll window (and therefore the
@@ -126,9 +132,9 @@ final class ModelSelectorModal: Modal {
             visible.insert((Style.dimmed("  ── \(group) ──"), true, group), at: 0)
         }
 
-        out.append("")
+        if roomy { out.append("") }
         for line in visible { out.append(line.text) }
-        out.append("")
+        if roomy { out.append("") }
         let move = "↑/↓: move   Enter: confirm   Esc: cancel"
         out.append(Style.dimmed(windowed ? "  \(selectedIndex + 1)/\(models.count)   \(move)" : "  \(move)"))
         return out

--- a/Sources/KWWKCli/SessionProviders.swift
+++ b/Sources/KWWKCli/SessionProviders.swift
@@ -1,0 +1,102 @@
+import Foundation
+import KWWKAI
+
+/// One logged-in provider's session-scoped routing template. `/model` uses
+/// `template` to stamp correct wire routing (api / provider scope / baseUrl /
+/// headers) onto any catalog model the user switches to, and lists that
+/// provider's catalog under `catalogProvider` / `displayName`.
+struct ProviderSlot: Sendable {
+    /// The OAuth-store key this provider was logged in under
+    /// (`anthropic`, `openai-codex`, `github-copilot`, `anthropic-api-key`, …),
+    /// or a synthetic `env:<provider>` marker for environment-key auth.
+    let storeId: String
+    /// The `ModelsCatalog.byProvider` key whose models this slot lists.
+    let catalogProvider: String
+    /// Human label shown as the group header in the `/model` picker.
+    let displayName: String
+    /// The default model built at registration time — carries the resolved
+    /// wire `api`, provider scope, session `baseUrl`, and headers that every
+    /// model under this provider must route through.
+    let template: Model
+}
+
+/// Mutable, session-scoped set of logged-in providers. Shared by `/model`
+/// (reads, to list + route across providers), `/login` (appends a freshly
+/// authenticated provider), and `/logout` (removes one). Reference type so a
+/// single instance is observed by every slash handler.
+@MainActor
+final class SessionProviders {
+    private(set) var slots: [ProviderSlot]
+
+    init(_ slots: [ProviderSlot] = []) {
+        self.slots = slots
+    }
+
+    /// Add or replace the slot for a provider (re-login overwrites its
+    /// template), keeping priority order stable by de-duplicating on storeId.
+    func upsert(_ slot: ProviderSlot) {
+        slots.removeAll { $0.storeId == slot.storeId }
+        slots.append(slot)
+    }
+
+    func remove(storeId: String) {
+        slots.removeAll { $0.storeId == storeId }
+    }
+
+    func slot(forStoreId storeId: String) -> ProviderSlot? {
+        slots.first { $0.storeId == storeId }
+    }
+}
+
+/// Thread-safe, mutable map of per-provider auth resolvers keyed by
+/// `model.provider` scope. The agent holds one **stable** closure
+/// (`delegatingResolver()`) that reads through here, so `/login` can install a
+/// newly-authenticated provider's resolver mid-session and its tokens resolve
+/// on the next request — no agent rebuild. Static api-key providers have no
+/// entry; `resolve` returns nil and the provider falls back to its baked key.
+actor SessionAuthResolvers {
+    private var map: [String: @Sendable (Model, String?) async -> ResolvedProviderAuth?]
+
+    init(_ initial: [String: @Sendable (Model, String?) async -> ResolvedProviderAuth?] = [:]) {
+        self.map = initial
+    }
+
+    func set(scope: String, _ resolver: @escaping @Sendable (Model, String?) async -> ResolvedProviderAuth?) {
+        map[scope] = resolver
+    }
+
+    func remove(scope: String) {
+        map.removeValue(forKey: scope)
+    }
+
+    func resolve(_ model: Model, _ sessionId: String?) async -> ResolvedProviderAuth? {
+        guard let r = map[model.provider] else { return nil }
+        return await r(model, sessionId)
+    }
+
+    /// One stable delegating closure to hand the agent. It closes over this
+    /// actor, so later `set` / `remove` calls are visible without swapping the
+    /// agent's `authResolver`.
+    nonisolated func delegatingResolver() -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
+        { model, sid in await self.resolve(model, sid) }
+    }
+}
+
+/// Human-readable label for a stored provider id, shown in the `/model`
+/// group header and `/login` / `/logout` listings.
+func providerDisplayName(forStoreId storeId: String) -> String {
+    switch storeId {
+    case "anthropic": return "Anthropic (Claude Pro/Max)"
+    case "openai-codex": return "ChatGPT Codex"
+    case "github-copilot": return "GitHub Copilot"
+    case "anthropic-api-key": return "Anthropic (API key)"
+    case "openai-api-key": return "OpenAI (API key)"
+    case "google-api-key": return "Google AI Studio"
+    case "openai-compatible": return "OpenAI-compatible"
+    default:
+        if storeId.hasPrefix("env:") {
+            return String(storeId.dropFirst(4)) + " (env)"
+        }
+        return storeId
+    }
+}

--- a/Sources/KWWKCli/SessionResumeModal.swift
+++ b/Sources/KWWKCli/SessionResumeModal.swift
@@ -42,16 +42,19 @@ final class SessionResumeModal: Modal {
     func cancel() { onCancel() }
 
     func render(maxRows: Int) -> [String] {
+        // Drop the cosmetic blank spacers on short terminals so the render
+        // stays within `maxRows` (title + body + footer is the minimum).
+        let roomy = maxRows >= 9
         var out: [String] = []
-        out.append("")
+        if roomy { out.append("") }
         out.append(Theme.accentText("  Resume a session"))
-        out.append("")
+        if roomy { out.append("") }
         if sessions.isEmpty {
             out.append(Theme.faintText("  no saved sessions for this project yet"))
         } else {
             // Window the list so a long history stays on screen — sized to the
-            // terminal (chrome: blank + title + blank + blank + footer = 5).
-            let rows = max(3, maxRows - 5)
+            // terminal (chrome: title + footer, plus two blanks when roomy).
+            let rows = max(1, maxRows - (roomy ? 4 : 2))
             var start = 0
             if selectedIndex >= rows { start = selectedIndex - rows + 1 }
             start = min(start, max(0, sessions.count - rows))
@@ -71,7 +74,7 @@ final class SessionResumeModal: Modal {
                 out.append(marker + name + "  " + meta + current)
             }
         }
-        out.append("")
+        if roomy { out.append("") }
         out.append(Theme.faintText("  ↑/↓ move · ↵ resume · Esc cancel"))
         return out
     }

--- a/Sources/KWWKCli/SessionResumeModal.swift
+++ b/Sources/KWWKCli/SessionResumeModal.swift
@@ -41,7 +41,7 @@ final class SessionResumeModal: Modal {
 
     func cancel() { onCancel() }
 
-    func render() -> [String] {
+    func render(maxRows: Int) -> [String] {
         var out: [String] = []
         out.append("")
         out.append(Theme.accentText("  Resume a session"))
@@ -49,12 +49,13 @@ final class SessionResumeModal: Modal {
         if sessions.isEmpty {
             out.append(Theme.faintText("  no saved sessions for this project yet"))
         } else {
-            // Window the list so a long history stays on screen.
-            let maxRows = 10
+            // Window the list so a long history stays on screen — sized to the
+            // terminal (chrome: blank + title + blank + blank + footer = 5).
+            let rows = max(3, maxRows - 5)
             var start = 0
-            if selectedIndex >= maxRows { start = selectedIndex - maxRows + 1 }
-            start = min(start, max(0, sessions.count - maxRows))
-            for i in start..<min(sessions.count, start + maxRows) {
+            if selectedIndex >= rows { start = selectedIndex - rows + 1 }
+            start = min(start, max(0, sessions.count - rows))
+            for i in start..<min(sessions.count, start + rows) {
                 let info = sessions[i]
                 let selected = i == selectedIndex
                 let marker = selected ? Theme.accentText("  ❯ ", bold: false) : "    "

--- a/Sources/KWWKCli/SlashCommand.swift
+++ b/Sources/KWWKCli/SlashCommand.swift
@@ -70,6 +70,18 @@ final class SlashContext {
     /// Persist a user-set session title to the live session file. Backed by
     /// the SessionRecorder in the TUI; a no-op in headless/test contexts.
     let setSessionTitle: @MainActor (_ title: String) async -> Void
+    /// Providers logged in this session — read by `/model` to list + route
+    /// across accounts, mutated by `/login` / `/logout`. Empty in headless /
+    /// test contexts that don't wire it up.
+    let sessionProviders: SessionProviders
+    /// Mutable resolver map the agent delegates to; `/login` installs a
+    /// newly-authenticated provider's resolver here. Nil in headless/tests.
+    let authResolvers: SessionAuthResolvers?
+    /// Suspend the coding TUI (release raw stdin + terminal modes), run
+    /// `body` with the terminal in cooked state (for a full-screen sub-flow
+    /// like the `/login` OAuth handoff), then restore the TUI and repaint.
+    /// A no-op passthrough in headless / test contexts.
+    let withSuspendedTUI: @MainActor (_ body: @escaping @MainActor () async -> Void) async -> Void
 
     init(
         agent: Agent,
@@ -80,7 +92,10 @@ final class SlashContext {
         commitScrollback: @MainActor @escaping ((Int) -> [String]) -> Void,
         refreshTranscript: @MainActor @escaping () -> Void,
         recordCompaction: @MainActor @escaping (_ messagesCompacted: Int) async -> Void = { _ in },
-        setSessionTitle: @MainActor @escaping (_ title: String) async -> Void = { _ in }
+        setSessionTitle: @MainActor @escaping (_ title: String) async -> Void = { _ in },
+        sessionProviders: SessionProviders = SessionProviders(),
+        authResolvers: SessionAuthResolvers? = nil,
+        withSuspendedTUI: @MainActor @escaping (_ body: @escaping @MainActor () async -> Void) async -> Void = { body in await body() }
     ) {
         self.agent = agent
         self.modal = modal
@@ -91,6 +106,9 @@ final class SlashContext {
         self.refreshTranscript = refreshTranscript
         self.recordCompaction = recordCompaction
         self.setSessionTitle = setSessionTitle
+        self.sessionProviders = sessionProviders
+        self.authResolvers = authResolvers
+        self.withSuspendedTUI = withSuspendedTUI
     }
 
     /// Single-line convenience: one-off status messages (`/model switched

--- a/Sources/KWWKCli/TUI.swift
+++ b/Sources/KWWKCli/TUI.swift
@@ -168,6 +168,20 @@ final class TUI: @unchecked Sendable {
         fullRepaint()
     }
 
+    /// Drop retained live-zone geometry so the next render anchors fresh at the
+    /// current cursor instead of rewinding over rows that no longer exist.
+    /// Called by `TUIRunner.resume()` after a full-screen sub-flow (`/login`)
+    /// printed its own output where the live zone used to be — without this,
+    /// the first post-resume render would clear `lastFrameHeight` rows relative
+    /// to the new cursor and erase the sub-flow's output.
+    func resetFrameGeometryForResume() {
+        lock.withLock {
+            lastFrameHeight = 0
+            lastCursorUpBy = 0
+            lastRenderedLines = []
+        }
+    }
+
     private func handleResize() {
         let snapshotChildren: [Component] = lock.withLock { children }
         for child in snapshotChildren { child.invalidate() }

--- a/Sources/KWWKCli/TUI.swift
+++ b/Sources/KWWKCli/TUI.swift
@@ -344,6 +344,13 @@ final class TUI: @unchecked Sendable {
         let clearOnShrinkEnabled: Bool
         var committed: [String]
 
+        // Suppress all frame output while stopped/suspended (e.g. during a
+        // `/login` sub-flow that hands the terminal to another runner). A
+        // background spinner tick or agent event could otherwise fire a
+        // render straight into the sub-flow's screen. Pending commits stay
+        // buffered and flush on the first render after `start()` resumes.
+        guard lock.withLock({ isStarted }) else { return }
+
         lock.lock()
         snapshotChildren = children
         width = terminal.width

--- a/Sources/KWWKCli/TUIRunner.swift
+++ b/Sources/KWWKCli/TUIRunner.swift
@@ -142,9 +142,12 @@ final class TUIRunner: @unchecked Sendable {
 
     /// Re-acquire the terminal after `suspend()`: reinstall signal handling
     /// and raw stdin, re-enable bracketed paste + Kitty keyboard modes, and
-    /// repaint the frame from scratch.
+    /// repaint the frame with a fresh anchor. The geometry reset MUST happen
+    /// before `start()` (whose own render would otherwise rewind over the
+    /// sub-flow's output using the stale pre-suspend live-zone height).
     func resume() throws {
         try installSignalHandlers()
+        tui.resetFrameGeometryForResume()
         tui.start()
         terminal.write("\u{1B}[?2004h")
         terminal.write("\u{1B}[>1u")

--- a/Sources/KWWKCli/TUIRunner.swift
+++ b/Sources/KWWKCli/TUIRunner.swift
@@ -120,6 +120,38 @@ final class TUIRunner: @unchecked Sendable {
         cont?.resume()
     }
 
+    /// Hand the terminal back for a full-screen sub-flow that runs its own
+    /// runner (the `/login` OAuth handoff spins up a fresh `TUIRunner`). Drops
+    /// raw stdin (restoring cooked termios via `RawStdin.deinit`), leaves the
+    /// input modes, stops the frame, and cancels signal handling so only the
+    /// sub-flow's runner owns SIGINT/SIGTERM. Pair with `resume()`.
+    func suspend() {
+        terminal.write("\u{1B}[?2004l")
+        terminal.write("\u{1B}[<u")
+        tui.stop()
+        lock.withLock {
+            sigintSource?.cancel()
+            sigtermSource?.cancel()
+            sigintSource = nil
+            sigtermSource = nil
+            pendingEscapeFlush?.cancel()
+            pendingEscapeFlush = nil
+            stdin = nil     // triggers RawStdin deinit → restores termios
+        }
+    }
+
+    /// Re-acquire the terminal after `suspend()`: reinstall signal handling
+    /// and raw stdin, re-enable bracketed paste + Kitty keyboard modes, and
+    /// repaint the frame from scratch.
+    func resume() throws {
+        try installSignalHandlers()
+        tui.start()
+        terminal.write("\u{1B}[?2004h")
+        terminal.write("\u{1B}[>1u")
+        try installStdin()
+        tui.requestRender()
+    }
+
     // MARK: - Lifecycle helpers
 
     private func installSignalHandlers() throws {

--- a/Tests/KWWKAITests/APIRegistryScopeTests.swift
+++ b/Tests/KWWKAITests/APIRegistryScopeTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+
+/// Minimal `APIProvider` whose only job is to be identifiable by a tag so
+/// dispatch can be asserted.
+private final class TaggedProvider: APIProvider, @unchecked Sendable {
+    let api: String
+    let tag: String
+    init(api: String, tag: String) {
+        self.api = api
+        self.tag = tag
+    }
+    func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream {
+        AssistantMessageStream()
+    }
+}
+
+@Suite("APIRegistry provider-scoped dispatch")
+struct APIRegistryScopeTests {
+
+    @Test("provider-scoped registrations sharing one wire api don't collide")
+    func scopedCollision() async {
+        let registry = APIRegistry()
+        // Two providers both speaking `anthropic-messages` — Anthropic-OAuth
+        // and Copilot's Claude route — must coexist keyed by provider scope.
+        await registry.register(TaggedProvider(api: "anthropic-messages", tag: "anthropic-oauth"), scope: "anthropic")
+        await registry.register(TaggedProvider(api: "anthropic-messages", tag: "copilot"), scope: "github-copilot")
+
+        let a = await registry.provider(scope: "anthropic", api: "anthropic-messages") as? TaggedProvider
+        let c = await registry.provider(scope: "github-copilot", api: "anthropic-messages") as? TaggedProvider
+        #expect(a?.tag == "anthropic-oauth")
+        #expect(c?.tag == "copilot")
+    }
+
+    @Test("scoped lookup falls back to the flat api map")
+    func scopedFallsBackToFlat() async {
+        let registry = APIRegistry()
+        // Flat (env-key style) registration, no scope.
+        await registry.register(TaggedProvider(api: "openai-responses", tag: "flat"))
+        // An unknown scope still resolves the flat provider.
+        let p = await registry.provider(scope: "some-scope", api: "openai-responses") as? TaggedProvider
+        #expect(p?.tag == "flat")
+        // And a scoped entry wins over the flat one for its own scope.
+        await registry.register(TaggedProvider(api: "openai-responses", tag: "scoped"), scope: "github-copilot")
+        let scoped = await registry.provider(scope: "github-copilot", api: "openai-responses") as? TaggedProvider
+        #expect(scoped?.tag == "scoped")
+        let stillFlat = await registry.provider(scope: "openai", api: "openai-responses") as? TaggedProvider
+        #expect(stillFlat?.tag == "flat")
+    }
+
+    @Test("unregisterScope removes only that scope's entries")
+    func unregisterScope() async {
+        let registry = APIRegistry()
+        await registry.register(TaggedProvider(api: "anthropic-messages", tag: "anthropic"), scope: "anthropic")
+        await registry.register(TaggedProvider(api: "anthropic-messages", tag: "copilot"), scope: "github-copilot")
+        await registry.unregisterScope("github-copilot")
+        #expect(await registry.provider(scope: "github-copilot", api: "anthropic-messages") == nil)
+        let survivor = await registry.provider(scope: "anthropic", api: "anthropic-messages") as? TaggedProvider
+        #expect(survivor?.tag == "anthropic")
+    }
+
+    @Test("unregisterSource tears down both flat and scoped entries")
+    func unregisterSource() async {
+        let registry = APIRegistry()
+        await registry.register(TaggedProvider(api: "openai-completions", tag: "flat"), sourceId: "src")
+        await registry.register(TaggedProvider(api: "anthropic-messages", tag: "scoped"), scope: "anthropic", sourceId: "src")
+        await registry.unregisterSource("src")
+        #expect(await registry.provider(for: "openai-completions") == nil)
+        #expect(await registry.provider(scope: "anthropic", api: "anthropic-messages") == nil)
+    }
+}

--- a/Tests/KWWKCliTests/ModelSelectorModalTests.swift
+++ b/Tests/KWWKCliTests/ModelSelectorModalTests.swift
@@ -113,22 +113,26 @@ struct ModelSelectorModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        let maxRows = 12
         func strip(_ s: String) -> String {
             s.replacingOccurrences(of: "\u{1B}\\[[0-9;]*m", with: "", options: .regularExpression)
         }
-        // At every scroll position the render must fit the budget AND keep the
-        // selected row visible — including mid-list, where a context header may
-        // be prepended.
-        for step in 0..<50 {
-            let lines = modal.render(maxRows: maxRows).map(strip)
-            #expect(lines.count <= maxRows, "overflow at selection \(step)")
-            #expect(lines.contains(where: { $0.contains("❯ m\(step)  ") }),
-                    "selected row m\(step) must be within the window")
-            modal.down()
+        // At every scroll position, and across a range of terminal heights
+        // (including tiny ones), the render must fit the budget AND keep the
+        // selected row visible — including mid-list, where a context header
+        // may be prepended.
+        for maxRows in [4, 6, 9, 12, 40] {
+            // 50 downs on a 50-item list wraps back to selection 0, so each
+            // outer iteration starts from the top.
+            for step in 0..<50 {
+                let lines = modal.render(maxRows: maxRows).map(strip)
+                #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows), selection \(step)")
+                #expect(lines.contains(where: { $0.contains("❯ m\(step)  ") }),
+                        "selected row m\(step) must be within the window at maxRows \(maxRows)")
+                modal.down()
+            }
         }
         // Position indicator shows while windowed.
-        #expect(modal.render(maxRows: maxRows).contains(where: { $0.contains("/50") }))
+        #expect(modal.render(maxRows: 12).contains(where: { $0.contains("/50") }))
     }
 
     @MainActor

--- a/Tests/KWWKCliTests/ModelSelectorModalTests.swift
+++ b/Tests/KWWKCliTests/ModelSelectorModalTests.swift
@@ -95,11 +95,40 @@ struct ModelSelectorModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        let lines = modal.render()
+        let lines = modal.render(maxRows: 40)
         // Current (`b`) should get the pre-selection + "· current" tag.
         let bLine = lines.first(where: { $0.contains("b") && !$0.contains("Pick one") })
         #expect(bLine?.contains("current") == true)
         #expect(bLine?.contains("❯") == true)
+    }
+
+    @MainActor
+    @Test("long list windows to maxRows and keeps the selection visible")
+    func windowsToHeight() {
+        let models = (0..<50).map { model("m\($0)") }
+        let modal = ModelSelectorModal(
+            title: "Pick one",
+            models: models,
+            currentModelId: nil,
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        let maxRows = 12
+        func strip(_ s: String) -> String {
+            s.replacingOccurrences(of: "\u{1B}\\[[0-9;]*m", with: "", options: .regularExpression)
+        }
+        // At every scroll position the render must fit the budget AND keep the
+        // selected row visible — including mid-list, where a context header may
+        // be prepended.
+        for step in 0..<50 {
+            let lines = modal.render(maxRows: maxRows).map(strip)
+            #expect(lines.count <= maxRows, "overflow at selection \(step)")
+            #expect(lines.contains(where: { $0.contains("❯ m\(step)  ") }),
+                    "selected row m\(step) must be within the window")
+            modal.down()
+        }
+        // Position indicator shows while windowed.
+        #expect(modal.render(maxRows: maxRows).contains(where: { $0.contains("/50") }))
     }
 
     @MainActor
@@ -117,7 +146,7 @@ struct ModelSelectorModalTests {
         // Safe to call navigation/confirm on an empty list.
         modal.up(); modal.down(); modal.confirm()
         #expect(picked.value == nil)
-        let lines = modal.render()
+        let lines = modal.render(maxRows: 40)
         #expect(lines.contains(where: { $0.contains("no models") }))
     }
 }

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+@testable import KWWKCli
+
+@Suite("multi-provider auth")
+struct MultiProviderAuthTests {
+
+    // MARK: - Store is additive
+
+    @Test("OAuthStore.set keeps other providers (multi-login)")
+    func storeIsAdditive() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-multilogin-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("oauth.json")
+        let store = OAuthStore(url: url)
+
+        try await store.set(OAuthCredentials(access: "a", refresh: "ra", expires: .max), for: "anthropic")
+        try await store.set(OAuthCredentials(access: "c", refresh: "rc", expires: .max), for: "openai-codex")
+        let all = await store.all()
+        #expect(all.keys.sorted() == ["anthropic", "openai-codex"])
+
+        // Re-persist through a fresh store instance to confirm it round-trips.
+        let reopened = OAuthStore(url: url)
+        #expect(await reopened.get("anthropic")?.access == "a")
+        #expect(await reopened.get("openai-codex")?.access == "c")
+    }
+
+    // MARK: - Priority / scope / catalog helpers
+
+    @Test("storedProviderOrder ranks OAuth subscriptions before api keys")
+    func providerOrder() {
+        let all: [String: OAuthCredentials] = [
+            "google-api-key": .init(access: "g", refresh: "", expires: .max),
+            "anthropic": .init(access: "a", refresh: "r", expires: .max),
+            "openai-codex": .init(access: "c", refresh: "r", expires: .max),
+        ]
+        #expect(storedProviderOrder(all) == ["openai-codex", "anthropic", "google-api-key"])
+    }
+
+    @Test("modelProviderScope collapses same-vendor logins; catalogProvider maps to the catalog key")
+    func scopeAndCatalog() {
+        // Anthropic OAuth and API key share the anthropic-messages wire → same
+        // scope, so registerAllStored keeps only the higher-priority one.
+        #expect(modelProviderScope(forStoreId: "anthropic") == "anthropic")
+        #expect(modelProviderScope(forStoreId: "anthropic-api-key") == "anthropic")
+        // Codex registers under the chatgpt.com variant scope, not the catalog key.
+        #expect(modelProviderScope(forStoreId: "openai-codex") == "chatgpt-codex")
+        #expect(catalogProvider(forStoreId: "openai-codex") == "openai-codex")
+        #expect(catalogProvider(forStoreId: "openai-api-key") == "openai")
+        #expect(catalogProvider(forStoreId: "github-copilot") == "github-copilot")
+    }
+
+    // MARK: - Unified resolver dispatch
+
+    @Test("SessionAuthResolvers dispatches by model.provider and supports mid-session add/remove")
+    func resolverDispatch() async {
+        let resolvers = SessionAuthResolvers()
+        await resolvers.set(scope: "anthropic") { _, _ in
+            ResolvedProviderAuth(token: "anthropic-token", scheme: .bearer)
+        }
+        await resolvers.set(scope: "chatgpt-codex") { _, _ in
+            ResolvedProviderAuth(token: "codex-token", scheme: .bearer)
+        }
+
+        let anthropicModel = Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
+        let codexModel = Model(id: "gpt", api: "chatgpt-codex", provider: "chatgpt-codex")
+        let staticModel = Model(id: "k", api: "openai-responses", provider: "openai")
+
+        #expect(await resolvers.resolve(anthropicModel, nil)?.token == "anthropic-token")
+        #expect(await resolvers.resolve(codexModel, nil)?.token == "codex-token")
+        // A static (api-key) provider has no resolver → nil → baked key used.
+        #expect(await resolvers.resolve(staticModel, nil) == nil)
+
+        // The stable delegating closure sees a provider added later (`/login`).
+        let delegate = resolvers.delegatingResolver()
+        #expect(await delegate(staticModel, nil) == nil)
+        await resolvers.set(scope: "openai") { _, _ in
+            ResolvedProviderAuth(token: "openai-token", scheme: .bearer)
+        }
+        #expect(await delegate(staticModel, nil)?.token == "openai-token")
+
+        // Removal (`/logout`) drops it again.
+        await resolvers.remove(scope: "openai")
+        #expect(await delegate(staticModel, nil) == nil)
+    }
+
+    // MARK: - SessionProviders bookkeeping
+
+    @MainActor
+    @Test("SessionProviders upsert de-dupes by storeId; remove drops it")
+    func sessionProviders() {
+        let sp = SessionProviders()
+        let a = ProviderSlot(
+            storeId: "anthropic", catalogProvider: "anthropic",
+            displayName: "Anthropic", template: Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
+        )
+        sp.upsert(a)
+        sp.upsert(a)  // re-login overwrites, not duplicates
+        #expect(sp.slots.count == 1)
+
+        let codex = ProviderSlot(
+            storeId: "openai-codex", catalogProvider: "openai-codex",
+            displayName: "ChatGPT Codex", template: Model(id: "gpt", api: "chatgpt-codex", provider: "chatgpt-codex")
+        )
+        sp.upsert(codex)
+        #expect(sp.slots.count == 2)
+        #expect(sp.slot(forStoreId: "openai-codex")?.template.provider == "chatgpt-codex")
+
+        sp.remove(storeId: "anthropic")
+        #expect(sp.slots.map { $0.storeId } == ["openai-codex"])
+    }
+
+    // MARK: - /model cross-provider routing
+
+    @Test("adoptFields routes a cross-provider pick through the target template")
+    func adoptFieldsCrossProvider() {
+        // Switching to a Codex model: the catalog lists it under `openai-codex`
+        // with the `openai-responses` wire, but it must route through the
+        // registered `chatgpt-codex` variant scope + endpoint, and keep the
+        // Codex `maxTokens == 0` sentinel.
+        let codexTemplate = Model(
+            id: "gpt-5.5", api: "chatgpt-codex", provider: "chatgpt-codex",
+            baseUrl: "https://chatgpt.com", maxTokens: 0
+        )
+        let picked = Model(
+            id: "gpt-5.5-codex", api: "openai-responses", provider: "openai-codex",
+            baseUrl: "https://api.openai.com", maxTokens: 128_000
+        )
+        let routed = adoptFields(from: codexTemplate, into: picked)
+        #expect(routed.id == "gpt-5.5-codex")
+        #expect(routed.provider == "chatgpt-codex")
+        #expect(routed.api == "chatgpt-codex")
+        #expect(routed.baseUrl == "https://chatgpt.com")
+        #expect(routed.maxTokens == 0)
+
+        // Same-provider switch (Copilot enterprise) keeps the session baseUrl.
+        let copilotTemplate = Model(
+            id: "gpt-5.5", api: "openai-responses", provider: "github-copilot",
+            baseUrl: "https://api.business.githubcopilot.com"
+        )
+        let copilotPick = Model(
+            id: "claude-opus-4-8", api: "anthropic-messages", provider: "github-copilot",
+            baseUrl: "https://api.individual.githubcopilot.com"
+        )
+        let copilotRouted = adoptFields(from: copilotTemplate, into: copilotPick)
+        #expect(copilotRouted.provider == "github-copilot")
+        #expect(copilotRouted.api == "anthropic-messages")
+        #expect(copilotRouted.baseUrl == "https://api.business.githubcopilot.com")
+    }
+}


### PR DESCRIPTION
Support **multiple simultaneous provider logins** and **cross-provider switching** via in-session `/login` and `/model`.

## What changed
- **Additive credential store** — `kwwk login` now keeps every provider login in `~/.kwwk/oauth.json` (was exclusive/overwrite). Re-logging a provider just refreshes its entry.
- **Provider-scoped dispatch** — `APIRegistry` gained a `(providerScope, api)` layer alongside the flat `api` map; `stream()` prefers a scoped match, falls back to flat. This lets same-wire providers coexist (Anthropic-OAuth and Copilot's Claude both ride `anthropic-messages` with different tokens/headers). Single-login/env behavior is unchanged.
- **Register-all + unified resolver** — at launch, every stored provider is registered (each scoped by `model.provider`); the agent holds **one stable closure** delegating to a mutable `SessionAuthResolvers` actor, so a provider added mid-session resolves without an agent rebuild. Same-vendor dual logins (Anthropic OAuth + API key → `anthropic`) are de-duplicated by priority.
- **`/model` across providers** — lists models from all logged-in providers, grouped by provider (ids repeat across providers), and routes the pick through the target provider's session template (`adoptFields`) so wire api / scope / baseUrl / headers are correct.
- **In-session `/login` + `/logout`** — `/login` suspends the coding TUI (`withSuspendedTUI` → `TUIRunner.suspend/resume`), runs the full provider selector + OAuth/API-key flow, keeps existing logins, and registers the new provider live. `/logout` lists / removes, falling back to a survivor if the active provider is removed. `TUI.render()` is gated on `isStarted` so a background tick can't paint into the sub-flow.

## Review
Two adversarial-review workflows were run (5 review dimensions → per-finding verification → tmux functional test). The first found 5 real bugs (all in the same-scope multi-login paths a single-provider smoke can't reach) plus dead-code remnants; all were fixed and re-verified:
- `/logout` of a shadowed same-scope login no longer tears down the active provider (gated on slot ownership).
- In-session `/login` of a second same-scope provider no longer clobbers routing (mirrors launch-time dedup); also handles an env-authenticated incumbent by comparing the slot's actual registered scope.
- `registerStoredProviderLive` clears a stale resolver when the new provider is static (no OAuth token routed through an api-key instance).
- `resume()` resets retained frame geometry before repaint so multi-line `/login` output isn't rewound/erased.
- Removed dead `setExclusive`, renamed `persistExclusive`→`persistCredentials`, consolidated the duplicate catalog-key mapper, corrected stale single-login docs/comments.

## Testing
- `swift build` clean; **743 tests / 124 suites pass** (new suites: `APIRegistry provider-scoped dispatch`, `multi-provider auth`).
- tmux smoke: clean start; `/login` suspend→Esc-resume repaints cleanly and reinstalls raw input; `/model` shows no spurious grouping; `/logout` non-destructive; stderr empty; no orphan processes.

## Not yet covered
Real **two-provider** end-to-end routing (e.g. Anthropic OAuth + Codex, or same-vendor dual login) needs a second real account to exercise live requests — the logic was verified line-by-line by the review but not run against live endpoints with two credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3G8ebXSNko7iTA6vPP3ru
