### PR TITLE
Concurrency hardening, WebSocket keepalive, and smarter retry classification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,6 +71,42 @@
       "name": "Release kw-tui-snapshot",
       "program": "${workspaceFolder:kw}/.build/release/kw-tui-snapshot",
       "preLaunchTask": "swift: Build Release kw-tui-snapshot"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:kw}",
+      "name": "Debug kwwk",
+      "program": "${workspaceFolder:kw}/.build/debug/kwwk",
+      "preLaunchTask": "swift: Build Debug kwwk"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:kw}",
+      "name": "Release kwwk",
+      "program": "${workspaceFolder:kw}/.build/release/kwwk",
+      "preLaunchTask": "swift: Build Release kwwk"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:kw}",
+      "name": "Debug kwwk-generate-models",
+      "program": "${workspaceFolder:kw}/.build/debug/kwwk-generate-models",
+      "preLaunchTask": "swift: Build Debug kwwk-generate-models"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:kw}",
+      "name": "Release kwwk-generate-models",
+      "program": "${workspaceFolder:kw}/.build/release/kwwk-generate-models",
+      "preLaunchTask": "swift: Build Release kwwk-generate-models"
     }
   ]
 }

--- a/Docs/swift-library-concurrency-review.md
+++ b/Docs/swift-library-concurrency-review.md
@@ -1,0 +1,151 @@
+# Swift Library Concurrency Review (kwwk API)
+
+Date: 2026-07-03
+
+Scope reviewed:
+
+- `Sources/KWWKAI` (model/provider API, streaming HTTP, OAuth callback)
+- `Sources/KWWKAgent` (agent public API, tools, background/subagent execution)
+- `Sources/KWWKCli` at boundary level (MainActor/UI confinement vs library targets)
+- Test suites under `Tests/KWWKAITests`, `Tests/KWWKAgentTests`, `Tests/KWWKCliTests`
+
+Verification commands run:
+
+- `swift test --filter KWWKAITests` — passed, 280 tests / 37 suites
+- `swift test` — passed, 825 tests / 137 suites
+
+## Executive summary
+
+`KWWKAI` is largely aligned with Swift library best practices: public provider APIs are async/stream-oriented, not `@MainActor`, providers run work off the caller via `Task.detached`, and shared provider registry state is actor-isolated. During review, two `KWWKAI` hardening fixes were applied:
+
+1. `OAuthCallbackServer.waitForCallback()` now starts the NIO listener through an async future bridge instead of the blocking `.wait()` path.
+2. `URLSessionHTTPClient`'s streaming delegate no longer resumes continuations or finishes `AsyncThrowingStream` continuations while holding `NSLock`.
+
+`KWWKAgent` is mostly usable from non-main contexts and contains good concurrency primitives (`AgentState` locks, `BackgroundTaskManager` actor, `FileMutationQueue` actor, detached background/subagent runners). However, several library-quality risks remain, mostly around `@unchecked Sendable` reference state and synchronous process/file I/O inside async APIs. These are not necessarily current test failures, but they are the highest-priority areas before claiming the full API is free of deadlock/blocking risk.
+
+`KWWKCli` intentionally contains `@MainActor` UI code. I did not find `@MainActor` annotations leaking into `KWWKAI` or `KWWKAgent` public APIs; grep found none in those library targets except comments. A CLI-boundary subreview found that the public `KWWKCli.KWWK` entry points are not themselves `@MainActor`, but several internal headless/setup/helper paths do unnecessary main-actor or main-queue synchronous work (details below).
+
+## Findings and fixes
+
+### Fixed: OAuth callback async API used a blocking NIO wait
+
+Evidence before fix: `OAuthCallbackServer.waitForCallback()` called synchronous `start()`, and `start()` used NIO `.wait()`.
+
+Current evidence:
+
+- `Sources/KWWKAI/OAuthCallbackServer.swift:51-63` documents `start()` as synchronous compatibility API and still uses `.wait()` only there.
+- `Sources/KWWKAI/OAuthCallbackServer.swift:66-70` adds `startAsync()` using `try await ...bind(...).get()`.
+- `Sources/KWWKAI/OAuthCallbackServer.swift:91-93` has `waitForCallback()` call `try await startAsync()`.
+
+Assessment: async OAuth login flow no longer blocks the caller executor/main actor during socket bind. The synchronous `start()` remains a documented compatibility API and should not be used from UI/main-actor code.
+
+### Fixed: HTTP streaming delegate resumed continuations under lock
+
+Evidence/current state:
+
+- `Sources/KWWKAI/HTTPClient.swift:96-114` now extracts pending header state under `NSLock`, then resumes the continuation after the lock is released.
+- `Sources/KWWKAI/HTTPClient.swift:117-135` now finishes pending body stream completion after the lock is released.
+- `Sources/KWWKAI/HTTPClient.swift:161-203` now records completion actions under lock, then resumes/finishes outside the lock.
+- `Sources/KWWKAI/HTTPClient.swift:206-223` now resumes header continuations outside the lock.
+
+Assessment: reduces reentrancy/deadlock risk from continuation resumption callbacks executing synchronously while internal state lock is held.
+
+## Remaining risks / recommended follow-up
+
+### 1. `Agent` is `@unchecked Sendable` but exposes unsynchronized mutable public config
+
+Evidence:
+
+- `Sources/KWWKAgent/Agent.swift:133` declares `public final class Agent: @unchecked Sendable`.
+- `Sources/KWWKAgent/Agent.swift:137-140` lock-protects listeners/cancellation/idle waiters only.
+- `Sources/KWWKAgent/Agent.swift:142-156` exposes mutable public vars such as `sessionId`, `thinkingBudgets`, `maxTurns`, `toolExecution`, hooks, `autoCompact`, and `authResolver`.
+- `Sources/KWWKAgent/Agent.swift:425-448` reads these vars into `AgentLoopConfig` without synchronization.
+
+Risk: data races if callers mutate agent configuration from one task while prompt/continue/subagent execution reads it from another. `@unchecked Sendable` suppresses compiler help.
+
+Recommendation: make runtime configuration immutable after init, or move public mutable options behind a lock/actor and expose thread-safe setters/snapshots. If mutation is only supported while idle, enforce it and document it.
+
+### 2. Awaited subscribers can deadlock if they call back into same-agent idle/wait APIs inline
+
+Evidence:
+
+- `Sources/KWWKAgent/Agent.swift:559-562` awaits every listener during synthetic event emission.
+- `Sources/KWWKAgent/Agent.swift:595-599` awaits every listener during failure event emission.
+- `Sources/KWWKAgent/Agent.swift:466-472` marks the agent active until run lifecycle exits; `waitForIdle()` waits for this active handle to clear.
+
+Risk: a listener that does `await agent.waitForIdle()` inline can wait for a run that is itself waiting for the listener to return.
+
+Recommendation: document listener reentrancy rules and/or detect listener-context calls to `waitForIdle()`. Consider non-blocking listener fan-out if ordered backpressure is not required.
+
+### 3. `FileMutationQueue` can deadlock on nested same-path mutations
+
+Evidence:
+
+- `Sources/KWWKAgent/FileMutationQueue.swift:19-24` chains a new mutation task after previous same-key task.
+- `Sources/KWWKAgent/FileMutationQueue.swift:25-33` awaits the body and then awaits the task.
+
+Risk: `queue.run(path) { try await queue.run(path) { ... } }` creates an inner task waiting on the outer task, while the outer body waits on the inner task.
+
+Recommendation: track task-local current mutation key and throw a clear reentrant mutation error (or explicitly support reentrancy).
+
+### 4. Legacy bash execution can deadlock on large stdout/stderr pipe output
+
+Evidence:
+
+- `Sources/KWWKAgent/BashTool.swift:88-91` attaches stdout/stderr pipes.
+- `Sources/KWWKAgent/BashTool.swift:116-120` waits for process exit.
+- `Sources/KWWKAgent/BashTool.swift:124-145` reads stdout/stderr only after process exit.
+
+Risk: child process can block when pipe buffers fill; parent waits for exit; neither progresses.
+
+Recommendation: drain stdout/stderr concurrently while the process runs, or route legacy foreground execution through the file-backed runner used by background-capable paths.
+
+### 5. Some async APIs still do synchronous process/file work on the caller executor or actor
+
+Evidence:
+
+- `Sources/KWWKAgent/BashTool.swift:103` calls `Process.run()` before first suspension.
+- `Sources/KWWKAgent/BashTool.swift:124-145` performs synchronous reads after await.
+- `Sources/KWWKAgent/BashTool.swift:535-540` reads an entire output file with `Data(contentsOf:)` before capping to 1 MB.
+- `Sources/KWWKAgent/BackgroundTaskManager.swift:224-227` reads output tail inside actor isolation.
+- `Sources/KWWKAgent/BackgroundTaskManager.swift:383-385` reads tail while enqueueing notifications.
+- `Sources/KWWKAgent/BackgroundTaskManager.swift:552-562` snapshots include synchronous tail reads.
+
+Risk: not a direct global main-thread block unless called from `@MainActor`, but these APIs can block the caller executor or serialize unrelated actor work behind filesystem I/O.
+
+Recommendation: offload process startup/file reads to non-main execution and cap tail reads without loading whole files. Move expensive tail reading outside hot actor paths where possible.
+
+### 6. `KWWKCli` headless path and setup helpers do avoidable main-actor blocking
+
+Evidence from CLI subreview:
+
+- `Sources/KWWKCli/Headless.swift:21-24` marks `runHeadlessInternal` as `@MainActor`, and `Sources/KWWKCli/KWWK.swift:95-118` awaits it from the public headless entry point.
+- `Sources/KWWKCli/SessionPicker.swift:44-56` performs blocking stdin read for interactive resume selection from the main-actor setup path.
+- `Sources/KWWKCli/WelcomeScreen.swift:168-184` runs `git`, waits synchronously, then drains stdout during TUI setup.
+- `Sources/KWWKCli/Attachments.swift:215-281` and `Sources/KWWKCli/Attachments.swift:314-418` resolve attachments with synchronous `FileManager` / `Data(contentsOf:)` work from main-actor call sites in `CodingTUI`.
+- `Sources/KWWKCli/CustomSlashCommands.swift:241-260` and `Sources/KWWKCli/CustomSlashCommands.swift:276-291` synchronously discover/read custom command files during main-actor TUI setup.
+- `Sources/KWWKCli/TUIRunner.swift` mixes main dispatch queue confinement with `@MainActor` UI state, which weakens Swift 6 isolation guarantees.
+
+Risk: this is mostly CLI/UI responsiveness rather than core `KWWKAI` model API risk, but as `KWWKCli` is exported as a library product it can surprise embedders: headless usage hops to the main actor, TUI startup can freeze on slow stdin/process/filesystem work, and mixing `.main` queue callbacks with `MainActor` tasks creates subtle ordering/isolation issues.
+
+Recommendation: remove `@MainActor` from headless internals, move blocking stdin/process/filesystem work to detached/nonisolated helpers, keep only actual UI state mutation on `@MainActor`, and choose one UI confinement model (`MainActor` preferred) instead of mixing direct main-queue mutation with actor-isolated UI code.
+
+## Positive patterns confirmed
+
+- `KWWKAI` and `KWWKAgent` public APIs are not `@MainActor`-isolated (`grep @MainActor` returned none in `Sources/KWWKAI`; only a comment in `Sources/KWWKAgent`).
+- Provider registry is an actor: `Sources/KWWKAI/APIRegistry.swift`.
+- Providers return streams immediately and run network drivers in detached tasks, e.g. `AnthropicProvider.stream`.
+- `URLSessionHTTPClient` uses isolated ephemeral URL sessions by default.
+- `AgentState` uses locked snapshots for mutable UI/agent state.
+- `BackgroundTaskManager` and `FileMutationQueue` are actors.
+- Background bash/subagent work uses detached tasks plus explicit cancellation handles.
+
+## Suggested test additions
+
+1. KWWKAgent TSan/stress tests for concurrent mutation of `Agent` public config while prompting/subagent snapshotting.
+2. Regression test for listener reentrancy (`listener -> waitForIdle`) with timeout and expected documented behavior.
+3. Regression test for nested same-path `FileMutationQueue.run` with timeout or explicit thrown error.
+4. Large-output legacy bash test (`yes | head -c 10485760`) to catch pipe-buffer deadlock.
+5. MainActor responsiveness test invoking bash/tool APIs from `@MainActor` while a ticking main-actor task continues.
+6. `KWWKCli` boundary tests: `runHeadless` should not require/hop to `MainActor`; attachment/custom-command discovery should not block a ticking main-actor task.
+7. Background manager responsiveness test while large output tails are read and `killAll`/`closeSession` are issued.

--- a/Sources/KWWKAI/HTTPClient.swift
+++ b/Sources/KWWKAI/HTTPClient.swift
@@ -95,16 +95,20 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchec
 
     func awaitResponse() async throws -> HTTPURLResponse {
         try await withCheckedThrowingContinuation { cont in
-            lock.withLock {
+            let pending: Result<HTTPURLResponse, Error>? = lock.withLock {
                 if let pending = pendingHeaders {
                     pendingHeaders = nil
                     headerResolved = true
-                    switch pending {
-                    case .success(let http): cont.resume(returning: http)
-                    case .failure(let err):  cont.resume(throwing: err)
-                    }
+                    return pending
                 } else {
                     headerContinuation = cont
+                    return nil
+                }
+            }
+            if let pending {
+                switch pending {
+                case .success(let http): cont.resume(returning: http)
+                case .failure(let err):  cont.resume(throwing: err)
                 }
             }
         }
@@ -112,16 +116,20 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchec
 
     func makeByteStream(onCancel: @escaping @Sendable () -> Void) -> AsyncThrowingStream<UInt8, Error> {
         AsyncThrowingStream<UInt8, Error> { continuation in
-            lock.withLock {
+            let pending: Error?? = lock.withLock {
                 bodyContinuation = continuation
                 // Replay a completion that landed before the consumer started
                 // draining — typical when the server closed the connection
                 // between `didReceive response:` and the caller hooking in.
                 if let pending = pendingCompletion {
                     pendingCompletion = nil
-                    if let err = pending { continuation.finish(throwing: err) }
-                    else { continuation.finish() }
+                    return .some(pending)
                 }
+                return nil
+            }
+            if let pending {
+                if let err = pending { continuation.finish(throwing: err) }
+                else { continuation.finish() }
             }
             continuation.onTermination = { _ in onCancel() }
         }
@@ -151,42 +159,66 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchec
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        lock.withLock {
+        enum HeaderAction { case none, resume(CheckedContinuation<HTTPURLResponse, Error>, Error) }
+        enum BodyAction { case none, finish(AsyncThrowingStream<UInt8, Error>.Continuation, Error?) }
+
+        let actions: (HeaderAction, BodyAction) = lock.withLock {
+            var headerAction: HeaderAction = .none
+            var bodyAction: BodyAction = .none
+
             // If `didReceive response:` never fired (DNS/connect failure),
             // surface the error on the header continuation instead.
             if !headerResolved {
                 if let cont = headerContinuation {
                     headerContinuation = nil
                     headerResolved = true
-                    cont.resume(throwing: error ?? HTTPClientError.invalidResponse)
+                    headerAction = .resume(cont, error ?? HTTPClientError.invalidResponse)
                 } else {
                     pendingHeaders = .failure(error ?? HTTPClientError.invalidResponse)
                     headerResolved = true
                 }
             }
             if let body = bodyContinuation {
-                if let err = error { body.finish(throwing: err) }
-                else { body.finish() }
                 bodyContinuation = nil
+                bodyAction = .finish(body, error)
             } else {
                 pendingCompletion = .some(error)
             }
+            return (headerAction, bodyAction)
+        }
+
+        switch actions.0 {
+        case .none:
+            break
+        case .resume(let cont, let error):
+            cont.resume(throwing: error)
+        }
+        switch actions.1 {
+        case .none:
+            break
+        case .finish(let body, let error):
+            if let error { body.finish(throwing: error) }
+            else { body.finish() }
         }
         session.finishTasksAndInvalidate()
     }
 
     private func deliverHeader(_ result: Result<HTTPURLResponse, Error>) {
-        lock.withLock {
-            guard !headerResolved else { return }
+        let continuation: CheckedContinuation<HTTPURLResponse, Error>? = lock.withLock {
+            guard !headerResolved else { return nil }
             headerResolved = true
             if let cont = headerContinuation {
                 headerContinuation = nil
-                switch result {
-                case .success(let http): cont.resume(returning: http)
-                case .failure(let err):  cont.resume(throwing: err)
-                }
+                return cont
             } else {
                 pendingHeaders = result
+                return nil
+            }
+        }
+        if let continuation {
+            switch result {
+            case .success(let http): continuation.resume(returning: http)
+            case .failure(let err):  continuation.resume(throwing: err)
             }
         }
     }

--- a/Sources/KWWKAI/OAuthCallbackServer.swift
+++ b/Sources/KWWKAI/OAuthCallbackServer.swift
@@ -49,12 +49,29 @@ public final class OAuthCallbackServer: @unchecked Sendable {
     }
 
     /// Start listening. Idempotent.
+    ///
+    /// This synchronous compatibility entry point may block the calling thread
+    /// while NIO binds the socket. Async library flows should prefer
+    /// `waitForCallback()`, which starts via NIO's async future bridge and does
+    /// not block the caller's executor.
     public func start() throws {
         lock.lock()
         if channel != nil { lock.unlock(); return }
         lock.unlock()
 
-        let bootstrap = ServerBootstrap(group: group)
+        let ch = try makeBootstrap().bind(host: "127.0.0.1", port: Int(port)).wait()
+        lock.withLock { channel = ch }
+    }
+
+    private func startAsync() async throws {
+        if lock.withLock({ channel != nil }) { return }
+
+        let ch = try await makeBootstrap().bind(host: "127.0.0.1", port: Int(port)).get()
+        lock.withLock { channel = ch }
+    }
+
+    private func makeBootstrap() -> ServerBootstrap {
+        ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 4)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { [weak self] child in
@@ -64,9 +81,6 @@ public final class OAuthCallbackServer: @unchecked Sendable {
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-
-        let ch = try bootstrap.bind(host: "127.0.0.1", port: Int(port)).wait()
-        lock.withLock { channel = ch }
     }
 
     /// Resolve with whichever completes first: a callback request (query
@@ -75,7 +89,7 @@ public final class OAuthCallbackServer: @unchecked Sendable {
     /// is what lets a login UI abort a browser handoff the user never
     /// completes.
     public func waitForCallback() async throws -> [String: String] {
-        try start()
+        try await startAsync()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { cont in
                 lock.lock()

--- a/Sources/KWWKAI/WebSocketClient.swift
+++ b/Sources/KWWKAI/WebSocketClient.swift
@@ -18,11 +18,33 @@ public protocol WebSocketClient: Sendable {
     func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection
 }
 
+/// Surfaced when the keepalive heartbeat declares a connection dead. The
+/// description deliberately contains "connection" so `isRetryableError`
+/// classifies it as transient and the agent loop replays the turn.
+public struct WebSocketKeepaliveError: Error, CustomStringConvertible, Sendable {
+    public let reason: String
+    public var description: String { "WebSocket connection keepalive failed: \(reason)" }
+}
+
 public struct URLSessionWebSocketClient: WebSocketClient {
     public let session: URLSession
+    /// Seconds between keepalive pings. `0` disables the heartbeat.
+    public var pingIntervalSeconds: TimeInterval
+    /// Fail-closed liveness deadline: if no inbound traffic (data frame or
+    /// pong) arrives within this window the connection is declared dead and
+    /// torn down, instead of waiting for a read to hit ENOTCONN mid-turn.
+    /// Pongs alone aren't trusted as the liveness signal because they are
+    /// not reliably surfaced on every platform.
+    public var idleTimeoutSeconds: TimeInterval
 
-    public init(session: URLSession? = nil) {
+    public init(
+        session: URLSession? = nil,
+        pingIntervalSeconds: TimeInterval = 10,
+        idleTimeoutSeconds: TimeInterval = 60
+    ) {
         self.session = session ?? Self.makeIsolatedSession()
+        self.pingIntervalSeconds = pingIntervalSeconds
+        self.idleTimeoutSeconds = idleTimeoutSeconds
     }
 
     public func connect(url: URL, headers: [String: String]) async throws -> any WebSocketConnection {
@@ -30,7 +52,11 @@ public struct URLSessionWebSocketClient: WebSocketClient {
         for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
         let task = session.webSocketTask(with: request)
         task.resume()
-        return URLSessionWebSocketConnection(task: task)
+        return URLSessionWebSocketConnection(
+            task: task,
+            pingIntervalSeconds: pingIntervalSeconds,
+            idleTimeoutSeconds: idleTimeoutSeconds
+        )
     }
 }
 
@@ -48,33 +74,112 @@ private extension URLSessionWebSocketClient {
 
 private final class URLSessionWebSocketConnection: WebSocketConnection, @unchecked Sendable {
     private let task: URLSessionWebSocketTask
+    private let lock = NSLock()
+    private var lastInbound: DispatchTime = .now()
+    private var keepaliveFailure: WebSocketKeepaliveError?
+    private var heartbeat: Task<Void, Never>?
 
-    init(task: URLSessionWebSocketTask) {
+    init(task: URLSessionWebSocketTask, pingIntervalSeconds: TimeInterval, idleTimeoutSeconds: TimeInterval) {
         self.task = task
+        guard pingIntervalSeconds > 0 else { return }
+        heartbeat = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(pingIntervalSeconds * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                guard self.heartbeatTick(idleTimeoutSeconds: idleTimeoutSeconds) else { return }
+            }
+        }
+    }
+
+    deinit {
+        heartbeat?.cancel()
     }
 
     func send(_ message: WebSocketMessage) async throws {
-        switch message {
-        case .text(let text):
-            try await task.send(.string(text))
-        case .data(let data):
-            try await task.send(.data(data))
+        do {
+            switch message {
+            case .text(let text):
+                try await task.send(.string(text))
+            case .data(let data):
+                try await task.send(.data(data))
+            }
+        } catch {
+            throw recordedKeepaliveFailure() ?? error
         }
     }
 
     func receive() async throws -> WebSocketMessage? {
-        let message = try await task.receive()
-        switch message {
-        case .string(let text):
-            return .text(text)
-        case .data(let data):
-            return .data(data)
-        @unknown default:
-            return nil
+        do {
+            let message = try await task.receive()
+            noteInbound()
+            switch message {
+            case .string(let text):
+                return .text(text)
+            case .data(let data):
+                return .data(data)
+            @unknown default:
+                return nil
+            }
+        } catch {
+            throw recordedKeepaliveFailure() ?? error
         }
     }
 
     func close() {
+        heartbeat?.cancel()
         task.cancel(with: .normalClosure, reason: nil)
+    }
+
+    /// One heartbeat cycle: declare the connection dead if the inbound
+    /// deadline has passed, otherwise ping. Returns false once the
+    /// connection has failed and the heartbeat should stop.
+    private func heartbeatTick(idleTimeoutSeconds: TimeInterval) -> Bool {
+        lock.lock()
+        let failed = keepaliveFailure != nil
+        let last = lastInbound
+        lock.unlock()
+        if failed { return false }
+
+        let idleNs = DispatchTime.now().uptimeNanoseconds - last.uptimeNanoseconds
+        if idleTimeoutSeconds > 0, idleNs > UInt64(idleTimeoutSeconds * 1_000_000_000) {
+            fail(reason: "no inbound traffic for \(Int(idleTimeoutSeconds))s")
+            return false
+        }
+
+        task.sendPing { [weak self] error in
+            guard let self else { return }
+            if error == nil {
+                self.noteInbound()
+            }
+            // A ping error is not failed immediately: some platforms report
+            // spurious pong errors while data frames still flow. The
+            // inbound-traffic deadline above catches a genuinely dead socket.
+        }
+        return true
+    }
+
+    private func fail(reason: String) {
+        lock.lock()
+        let alreadyFailed = keepaliveFailure != nil
+        if !alreadyFailed {
+            keepaliveFailure = WebSocketKeepaliveError(reason: reason)
+        }
+        lock.unlock()
+        guard !alreadyFailed else { return }
+        // Cancelling the task makes any pending receive()/send() throw;
+        // the wrappers above replace that error with the keepalive failure.
+        task.cancel(with: .abnormalClosure, reason: nil)
+    }
+
+    private func noteInbound() {
+        lock.lock()
+        lastInbound = .now()
+        lock.unlock()
+    }
+
+    private func recordedKeepaliveFailure() -> WebSocketKeepaliveError? {
+        lock.lock()
+        defer { lock.unlock() }
+        return keepaliveFailure
     }
 }

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -415,21 +415,45 @@ public enum AgentLoop {
 
     private static let maxRetries = 5
 
-    private static func isRetryableError(_ message: String) -> Bool {
+    /// Whether a stream error looks transient enough to replay the turn.
+    /// Ordered like omp's classifier: timeouts always win, then retryable
+    /// HTTP statuses, then a validation short-circuit (a permanent 4xx-style
+    /// failure must not retry even if it also mentions "connection"), then
+    /// transport/overload patterns.
+    static func isRetryableError(_ message: String) -> Bool {
         let lower = message.lowercased()
-        return lower.contains("timeout")
-            || lower.contains("network")
-            || lower.contains("connection")
-            || lower.contains("429")
-            || lower.contains("rate limit")
-            || lower.contains("too many requests")
-            || lower.contains("502")
-            || lower.contains("503")
-            || lower.contains("504")
-            || lower.contains("internal server error")
-            || lower.contains("service unavailable")
-            || lower.contains("bad gateway")
-            || lower.contains("gateway timeout")
+
+        if lower.contains("timeout") || lower.contains("timed out") {
+            return true
+        }
+
+        for status in ["408", "429", "502", "503", "504", "529"] where lower.contains(status) {
+            return true
+        }
+
+        for fatal in [
+            "invalid", "validation", "bad request", "unsupported", "schema",
+            "missing required", "not found", "unauthorized", "forbidden",
+        ] where lower.contains(fatal) {
+            return false
+        }
+
+        // "connect" covers connection/connected/disconnect — including
+        // POSIX ENOTCONN's "Socket is not connected", which URLSession
+        // surfaces as an NSPOSIXErrorDomain error. "closed before" covers
+        // a WebSocket the server dropped mid-response.
+        for transient in [
+            "network", "connect", "nsposixerrordomain",
+            "econnreset", "enotconn", "epipe", "broken pipe", "reset by peer",
+            "socket closed", "socket error", "closed before", "closed unexpectedly",
+            "rate limit", "too many requests", "overloaded",
+            "internal error", "server error", "service unavailable", "bad gateway",
+            "temporarily", "stream stall", "fetch failed",
+        ] where lower.contains(transient) {
+            return true
+        }
+
+        return false
     }
 
     private static func streamAssistantResponse(

--- a/Tests/KWWKAgentTests/AgentRetryTests.swift
+++ b/Tests/KWWKAgentTests/AgentRetryTests.swift
@@ -148,6 +148,52 @@ struct AgentRetryTests {
     }
 }
 
+@Suite("Retry error classification")
+struct RetryClassificationTests {
+    @Test("POSIX socket deaths are retryable")
+    func posixSocketErrors() {
+        // The exact shape of the user-reported subagent failure.
+        #expect(AgentLoop.isRetryableError(
+            "WebSocket stream failed: Error Domain=NSPOSIXErrorDomain Code=57 \"Socket is not connected\""
+        ))
+        #expect(AgentLoop.isRetryableError(
+            "Error Domain=NSPOSIXErrorDomain Code=54 \"Connection reset by peer\""
+        ))
+        #expect(AgentLoop.isRetryableError("The network connection was lost."))
+        #expect(AgentLoop.isRetryableError("WebSocket stream closed before response.completed"))
+        #expect(AgentLoop.isRetryableError(
+            "WebSocket connection keepalive failed: no inbound traffic for 60s"
+        ))
+    }
+
+    @Test("timeouts and retryable statuses are retryable")
+    func transientStatuses() {
+        #expect(AgentLoop.isRetryableError("The request timed out."))
+        #expect(AgentLoop.isRetryableError("HTTP 429: rate limit exceeded"))
+        #expect(AgentLoop.isRetryableError("HTTP 503: service unavailable"))
+        #expect(AgentLoop.isRetryableError("HTTP 529: overloaded"))
+    }
+
+    @Test("validation and auth failures are not retryable")
+    func permanentFailures() {
+        #expect(!AgentLoop.isRetryableError("HTTP 400: invalid request body"))
+        #expect(!AgentLoop.isRetryableError("HTTP 401: unauthorized"))
+        #expect(!AgentLoop.isRetryableError("model not found"))
+        // Validation short-circuit wins even when the message also
+        // mentions a transport-ish word.
+        #expect(!AgentLoop.isRetryableError("invalid connection parameters"))
+        // ...but a timeout wins over everything.
+        #expect(AgentLoop.isRetryableError("invalid state: request timed out"))
+    }
+
+    @Test("in-flight session conflict is not retryable")
+    func busySessionNotRetryable() {
+        #expect(!AgentLoop.isRetryableError(
+            "OpenAI Responses WebSocket session already has an in-flight response for this sessionId. Use a distinct sessionId for parallel runs."
+        ))
+    }
+}
+
 actor RetryEventRecorder {
     struct Entry: Sendable {
         var attempt: Int


### PR DESCRIPTION
## Summary

Fixes the user-visible failure where a subagent turn dies with `NSPOSIXErrorDomain Code=57 "Socket is not connected"` instead of retrying, plus concurrency hardening from a library-level review (see `Docs/swift-library-concurrency-review.md`).

### WebSocket keepalive (`KWWKAI/WebSocketClient.swift`)
- Heartbeat pings every 10s with a fail-closed 60s inbound-traffic deadline: a dead socket is detected and surfaced as `WebSocketKeepaliveError` (retryable) instead of a raw ENOTCONN mid-turn.
- Pongs alone aren't trusted as liveness — any inbound frame or successful ping resets the deadline.

### Retry classification (`KWWKAgent/AgentLoop.swift`)
- `isRetryableError` reworked with explicit precedence: timeouts → retryable HTTP statuses (incl. 408/529) → validation/auth short-circuit → transport patterns.
- Now covers POSIX socket deaths (ENOTCONN, ECONNRESET, EPIPE), `NSPOSIXErrorDomain`, "closed before", "overloaded".
- Validation failures that also mention "connection" (e.g. `invalid connection parameters`) stay non-retryable; in-flight session conflicts stay non-retryable.

### Concurrency hardening (`KWWKAI`)
- `HTTPClient` streaming delegate no longer resumes continuations or finishes `AsyncThrowingStream` continuations while holding `NSLock`.
- `OAuthCallbackServer.waitForCallback()` binds the NIO listener via the async future bridge instead of blocking `.wait()`; sync `start()` remains as a documented compatibility entry point.

### Misc
- New `RetryClassificationTests` suite covering the exact reported failure shape.
- VS Code launch configs for `kwwk` and `kwwk-generate-models`.
- Concurrency review write-up in `Docs/`.

## Test plan
- `swift test` — 829 tests / 138 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLfDyRybDPr856taWgJL59