### PR TITLE
Holistic review fixes: correctness, DX, UX, performance, and side-effect hardening

### DIFF
--- a/Docs/holistic-review-2026-07-06.md
+++ b/Docs/holistic-review-2026-07-06.md
@@ -1,0 +1,952 @@
+# kwwk 全面 Review 报告
+
+> 2026-07-06 · 7 维度并行审查 + 每条发现独立对抗验证 · 74 个 agent 通过、4 条发现被验证推翻、3 条验证 agent 崩溃后由人工复核确认
+
+
+参照项目：`~/Draw/pi-mono`（pi 的 TypeScript 实现）。审查范围：`Sources/KWWKAI`、`Sources/KWWKAgent`、`Sources/KWWKCli`、`Sources/kwwk`。
+
+
+## 各维度总体评价
+
+### SDK DX — KWWKAI
+
+KWWKAI's public API is broadly well-designed for a 34k-line port: types are Sendable/Codable value types mirroring pi-ai's shapes, providers take explicit keys and pluggable HTTPClients with zero hidden ProcessInfo/env reads (EnvAPIKeys and registerBuiltinsFromEnvironment take explicit snapshots), and the scoped APIRegistry with sourceId teardown is genuinely nicer than pi-mono's flat module-global map. The significant gaps cluster in two places: cancellation semantics (stream iteration ignores Swift task cancellation and CancellationHandle is polled rather than eagerly aborting in-flight requests, so cancelling a stalled stream hangs) and silent-failure paths (empty-dict env defaults, corrupt OAuth store overwrites, try?-swallowed OAuth refresh errors, empty ModelsCatalog on resource failure, and complete() returning errors as ordinary-looking messages).
+
+### SDK DX — KWWKAgent
+
+The KWWKAgent public API is unusually disciplined about avoiding init-time surprises — bashEnvironment is a required explicit parameter, skills/context files/user directories are opt-in, SessionStore() is inert without a directory, and the append-only session log plus ResolvedResume/SessionRecorder design is coherent — but several sharp edges undercut the "no surprising side effects" goal: SessionRecorder.ensureCreated silently truncates resumed session files, a subagent definition containing .tmux can preconditionFailure-crash the host process at model tool-call time, makeCodingAgent installs an auto-continue background bridge (spontaneous billable LLM runs) while discarding the only detach handle, and Agent's public mutable config vars are unsynchronized despite the @unchecked Sendable annotation. A second tier of issues is about the obvious call being wrong or half-working: the README's steer(UserMessage) example does not compile, mutating agent.sessionId does not actually re-scope tools or background attachments, and invalid resume ids silently degrade to random fresh sessions.
+
+### 正确性 — KWWKAI
+
+Sources/KWWKAI is a careful, well-commented port of pi's provider layer and most of the streaming/state machinery is sound, but the review found three high-impact correctness gaps: an OAuth token-refresh race through actor reentrancy that can invalidate rotated refresh tokens under concurrent requests, Bedrock's failure to capture Claude thinking signatures (breaking thinking replay that pi explicitly handles), and cancellation that is only polled per-SSE-event on every HTTP provider path so a cancel during a silent stream gap neither aborts the request nor stops server-side token burn. A second tier of issues makes failures look like successes (Anthropic 'refusal' and premature EOF mapped to .stop, OpenAI Responses 'response.incomplete' unhandled and misclassified as a WebSocket transport failure) plus smaller robustness gaps in the OAuth callback server, byte-stream buffering, and error-body reporting.
+
+### 正确性 — KWWKAgent
+
+Sources/KWWKAgent is a generally faithful, carefully-commented port of pi's agent core — the loop, compactor, session store/recorder/resume, pending queues, and subagent runner all check out on the paths I traced, including tricky spots like compaction/persistedCount interplay and steering-queue drain semantics. The real defects cluster in process plumbing and advertised-but-unimplemented surface: two read-after-waitUntilExit pipe deadlocks (default bash path and tmux), missing process-group handling on the foreground bash paths, atomic-rename writes that defeat FileMutationQueue's inode keying and clobber symlinks, untruncated bash output, dead grep glob/context and read autoResizeImages options, plus two smaller protocol bugs (duplicate turnStart, stall-suppressed completion notifications).
+
+### TUI 用户体验
+
+The kwwk TUI is unusually carefully built for its size — escape-sequence disambiguation with a timed flush, IME-aware hardware-cursor placement via a zero-width APC marker, height-budgeted modals that survive tiny terminals, a thoughtful suspend/resume dance for the OAuth handoff, and multiplexer-aware resize repaints all show real polish, and the login/model/logout flows have consistent, well-worded feedback. The gaps that remain are concentrated and concrete: manual /compact runs entirely outside the busy/streaming machinery (no feedback, un-cancellable, and a real transcript-clobbering race with a concurrently submitted prompt), large pastes stall the main queue quadratically, modern emoji/ZWJ widths misalign the prompt box and IME cursor, signal-driven exits leak background processes by bypassing shutdown, and single-tap Ctrl-C plus the bare --resume prompt diverge from the pi/omp interaction conventions the project explicitly targets.
+
+### 性能
+
+The architecture makes fundamentally sound performance choices — append-only JSONL session persistence, a retained live zone with settled lines committed to native scrollback, cached input rendering, and activity-gated spinner ticks — so there are no whole-transcript-per-token or rewrite-file-per-message disasters. The real hot-path costs are concentrated in the transport layer (byte-granular AsyncThrowingStream delivery and a fresh URLSession/TLS handshake per API call), unpruned filesystem tools (grep/find walk .git and node_modules with per-file regex compilation, versus pi's ripgrep/fd with .gitignore), and several quadratic per-delta accumulation patterns (tool-call JSON re-parsed per SSE delta in all providers, O(n) snapshot re-derivation per delta in the transcript renderer), plus an unconditional full live-zone rewrite on every agent event with the stored previous frame never consulted for diffing.
+
+### 副作用/全局状态
+
+This codebase is unusually disciplined about side effects for an agent SDK: persistence is opt-in (OAuthStore()/SessionStore() are in-memory by default), bashEnvironment has no default so the host env is never silently exposed, EnvAPIKeys takes env snapshots as parameters instead of reading ProcessInfo, URLSession is ephemeral with cookies/cache disabled, tmux runs on a per-PID socket, background task logs are 0700/0600, and goal-mode internals are redacted before hitting disk. The real hazards found are concentrated in four places: atomic writes in Edit/Write that silently destroy symlinks (contradicting FileMutationQueue's inode-based design and pi's in-place writes), APIRegistry's scope-to-flat fallback that can send one vendor's API key to another vendor's host, tmux panes inheriting the full host environment despite the bash tool's explicit isolation contract, and permission gaps around ~/.kwwk (oauth.json's chmod-after-write race, world-readable session transcripts).
+
+
+## 发现清单（共 69 条：high 10 / medium 33 / low 26）
+
+
+---
+
+## HIGH（10 条）
+
+### H1. Cancellation on all HTTP/SSE provider paths is only polled per-event; a cancel during a silent stream gap does nothing and never aborts the request
+
+`Sources/KWWKAI/AnthropicProvider.swift:191` · 正确性 — KWWKAI
+
+
+**证据：** `drive()` checks `if state.signal?.isCancelled == true` only at the top of `for try await sse in events` — i.e. only when the server delivers the next SSE event. No `onCancel` registration cancels the in-flight HTTP task. The same poll-only pattern exists in OpenAICompletionsProvider.swift:160, BedrockProvider.swift:187, GoogleGeminiProvider.swift:138, and the OpenAIResponses HTTP path (OpenAIResponsesProvider.swift:482). By contrast, the Responses WebSocket path does it correctly: `cancellationRegistration = options?.cancellation?.onCancel { _ in connection.close() }` (OpenAIResponsesProvider.swift:281), and pi passes an AbortSignal into every fetch/SDK call (amazon-bedrock.ts:204 `client.send(command, { abortSignal })`).
+
+
+**影响：** A user pressing Esc/cancel while the model is in a long silent stretch (extended thinking with no summary deltas, slow first token, provider hiccup) sees nothing happen until the next event arrives; if the stream has genuinely stalled, cancel hangs indefinitely (until URLSession's request timeout). Meanwhile the server-side request keeps generating and billing tokens the user asked to stop.
+
+
+**建议：** Register `options?.cancellation?.onCancel { ... }` in each provider's `run` right after obtaining the byte stream, and have it cancel the underlying transport (e.g. keep the `AsyncThrowingStream` termination handle, or expose a cancel token from `HTTPClient.stream`). Remove or keep the per-event poll as a fallback.
+
+### H2. BedrockProvider never captures the reasoningContent.signature delta, so Claude thinking signatures are lost and replay degrades
+
+`Sources/KWWKAI/BedrockProvider.swift:257` · 正确性 — KWWKAI
+
+
+**证据：** The `contentBlockDelta` handler only reads `delta["reasoningContent"].text` (lines 257-269); there is no code path that reads `reasoningContent.signature`, and `BedrockStreamState` has no `appendSignature`. The reference implementation explicitly accumulates it (pi amazon-bedrock.ts:417-419: `thinkingBlock.thinkingSignature = (thinkingSignature || "") + delta.reasoningContent.signature`). On replay, `encodeMessages` (lines 484-499) requires a non-blank `th.thinkingSignature` to emit a `reasoningContent` block for Claude models; because the signature was never captured, every same-model thinking block falls into the `parts.append(["text": thinking])` degradation branch (line 499). pi's own comment (amazon-bedrock.ts:675) notes: "persisted message lacks a signature, Bedrock rejects the replayed [block]".
+
+
+**影响：** Any multi-turn conversation on Bedrock Claude with extended thinking enabled loses all reasoning blocks on the very next request: the thinking is re-sent as plain assistant text. In tool-use loops with thinking enabled, Anthropic-on-Bedrock expects signed thinking blocks to precede tool_use on replay; converting them to text can trigger request rejections or silently strip the model's chain-of-thought, degrading agent behavior versus pi.
+
+
+**建议：** In the `contentBlockDelta` case, also match `reasoningContent.signature` (a string delta) and accumulate it onto the thinking block's `thinkingSignature` (mirroring the existing `appendSignature` pattern in AnthropicStreamState); also handle `reasoningContent.redactedContent` if parity with pi's redaction handling is desired.
+
+### H3. A brand-new URLSession is created and invalidated per streaming request, so no TCP/TLS connection is ever reused across API calls
+
+`Sources/KWWKAI/HTTPClient.swift:67` · 性能
+
+
+**证据：** streamViaDelegate does `let driver = URLSession(configuration: base.configuration, delegate: delegate, delegateQueue: nil)` for every call, and StreamingDelegate.didCompleteWithError calls `session.finishTasksAndInvalidate()` (line 203). URLSession connection pools are per-session, so each request performs a fresh DNS lookup + TCP connect + TLS handshake. The injected `session` in URLSessionHTTPClient is only used as a configuration donor, never for requests.
+
+
+**影响：** An agent turn is a sequence of API calls (assistant turn -> tool results -> next turn, plus retries and compaction summaries), all to the same provider host. Each call pays a full handshake (~100-300ms to api.anthropic.com plus TLS CPU) that HTTP keep-alive would amortize to near zero. Over a long session this adds seconds of dead time and directly worsens perceived latency between tool call and next token.
+
+
+**建议：** Keep one long-lived URLSession and use per-task delegates: `session.dataTask(with: request)` + `task.delegate = StreamingDelegate()` (supported on macOS 12+/iOS 15+), or on Linux keep a single session-level delegate that demultiplexes callbacks by `dataTask.taskIdentifier` into per-request continuations.
+
+### H4. OAuthManager token refresh races via actor reentrancy, causing concurrent refreshes with the same refresh token
+
+`Sources/KWWKAI/OAuth.swift:205` · (补录)
+
+
+**证据：** In `OAuthManager.apiKey(for:)`: `if credentials.isExpired { credentials = try await provider.refresh(credentials, using: client); try await store.set(...) }`. `OAuthManager` is an actor, but Swift actors are reentrant: while the first call is suspended in `await provider.refresh(...)` (a network round-trip), a second `apiKey(for:)` call enters the actor, reads the still-stale credentials from the store, sees `isExpired == true`, and launches a second refresh with the same refresh token. There is no in-flight-refresh deduplication (no pending-task cache, no flag). The `resolver()` closure (line 214) is handed to every stream request, so concurrent requests (parallel subagents, retry overlap) hit this path simultaneously.
+
+
+**影响：** Anthropic's OAuth token endpoint rotates refresh tokens: two concurrent refreshes with the same refresh token means one of them uses an already-consumed token, and whichever `store.set` lands last can persist credentials whose refresh token was just invalidated. The user gets intermittently logged out of Claude Pro/Max mid-session and must re-run login. GitHub Copilot is also hit with duplicate session-token exchanges (wasteful but benign).
+
+
+**建议：** Deduplicate in-flight refreshes: keep a `[String: Task<OAuthCredentials, Error>]` inside the actor keyed by providerId; if a refresh task already exists for the provider, `await` its value instead of starting a new one, and re-read the store after resuming before deciding to refresh.
+
+### H5. Default (no-manager) bash path deadlocks on output larger than the pipe buffer because pipes are read only after waitUntilExit
+
+`Sources/KWWKAgent/BashTool.swift:117` · 正确性 — KWWKAgent
+
+
+**证据：** LocalBashOperations.execute wires `process.standardOutput = stdoutPipe; process.standardError = stderrPipe`, then blocks: `await withCheckedContinuation { ... DispatchQueue.global().async { process.waitUntilExit(); cont.resume() } }` and only afterwards calls `readAll(stdoutPipe.fileHandleForReading)` (lines 117-125). Nothing drains the pipes while the child runs.
+
+
+**影响：** A pipe holds ~64KB. Any command whose stdout+stderr exceeds that (e.g. `git log`, `npm install`, a failing test suite) blocks in write(2); the parent blocks in waitUntilExit — a permanent deadlock until the soft-timeout task SIGTERMs the child, after which the (truncated-at-64KB-buffered) run is reported as "Command timed out". This is the default path for every SDK consumer who does not attach a BackgroundTaskManager (BashToolOptions.manager defaults to nil), so ordinary commands mysteriously "time out" at exactly 64KB of output.
+
+
+**建议：** Start readabilityHandler-based draining (or readToEnd on background threads) for both pipes before/while waiting, and only then waitUntilExit — mirroring how pi streams child output. Alternatively route the legacy path through the same fd-dup-to-file mechanism used by BashRunnerImpl.
+
+### H6. CodingTools.tmux without a tmuxManager crashes the whole process via preconditionFailure — reachable at model tool-call time through subagent definitions
+
+`Sources/KWWKAgent/CodingAgentBuilder.swift:267` · SDK DX — KWWKAgent
+
+
+**证据：** buildCodingToolList: `guard let tmuxManager else { preconditionFailure("CodingTools.tmux requires an explicit TmuxSessionManager") }`. makeCodingAgent never validates `config.subagents[*].tools`; SubagentInvocationRunner.runChild (SubagentTool.swift:850-861) calls buildCodingToolList with `selectedTools = definition.tools ?? parent.tools` and the tmuxManager forwarded from config (possibly nil) — so the trap fires lazily when the model invokes the `agent` tool, not at build time. Failure policy is also inconsistent: `.taskStatus`/`.waitTask` without a manager are silently dropped (lines 259-264), and `.tmux` with a manager but no tmux binary is silently dropped (`createTmuxTool` returns nil, TmuxTool.swift:23), while a nil manager traps.
+
+
+**影响：** A host app that registers a SubagentDefinition with `tools: [.read, .tmux]` but no tmuxManager builds and prompts fine, then hard-crashes mid-conversation the first time the model delegates to that subagent — taking down the embedding application. Same class of misconfiguration produces three different behaviors (silent drop, silent drop, process abort).
+
+
+**建议：** Validate subagent tool sets in makeCodingAgent and either throw a typed error or degrade like the other tools do (omit tmux and surface a diagnostic). Reserve preconditionFailure for programmer invariants that cannot be data-driven by config.
+
+### H7. Edit and Write tools' atomic writes silently destroy symlinks (and detach hard links) instead of writing through them
+
+`Sources/KWWKAgent/EditTool.swift:24` · 副作用/全局状态
+
+
+**证据：** LocalEditOperations.writeFile and LocalWriteOperations.writeFile (WriteTool.swift:17) both do `try content.write(to: URL(fileURLWithPath: absolutePath), options: .atomic)`. I verified empirically on this machine (Darwin, Swift 6): writing with `.atomic` to a path that is a symlink replaces the symlink itself with a new regular file — afterwards `FileManager.attributesOfItem` reports `NSFileTypeRegular` and the link target still contains the original content. EditTool reads through the link (`Data(contentsOf:)` follows symlinks), so an edit "succeeds" while the real target file is never modified and the link is severed. This also detaches hard-link siblings (rename swaps the inode). It directly contradicts FileMutationQueue.swift:7-9, which keys its queue by inode explicitly "so symlink siblings [stay] on the same queue" — the queue assumes symlink-transparent writes that these operations do not perform. The pi reference behaves correctly: packages/coding-agent/src/core/tools/write.ts:33 and edit.ts:81 use `fsWriteFile(path, content)`, which opens and truncates in place, following symlinks and preserving the inode.
+
+
+**影响：** A user whose project or dotfiles use symlinks (e.g. `~/.zshrc` -> dotfiles repo, `node_modules` links, Bazel/Nix trees) asks the agent to edit such a file. The tool reports success, but the actual target file is untouched and the symlink is silently converted to a divergent regular file. The user's dotfiles repo and live config now disagree with no error anywhere — classic silent data corruption from a coding agent.
+
+
+**建议：** In LocalEditOperations/LocalWriteOperations, resolve symlinks before writing (`URL.resolvingSymlinksInPath()`), or write in place via `FileHandle`/`open(path, O_WRONLY|O_TRUNC)` like pi's fs.writeFile. If atomic replacement is desired for crash safety, resolve the final target first and rename over that resolved path.
+
+### H8. grep walks the entire tree including .git and node_modules, reads every file fully into memory, and the advertised glob filter is never applied
+
+`Sources/KWWKAgent/GrepTool.swift:81` · 性能
+
+
+**证据：** collectFiles uses `fm.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey])` with no `.skipsHiddenFiles`, no `skipDescendants()`, and no ignore rules, then materializes the full file list before any matching. The scan loop (line 47) does `Data(contentsOf: fileURL)` + full UTF-8 decode + `components(separatedBy: "\n")` for every file — including .git pack files and binaries, whose bytes are fully read from disk before the decode fails. The tool schema declares `glob` and `context` parameters (lines 100, 104) and GrepParams carries them (CodingTools.swift:99,102), but the execute closure never extracts them and LocalGrepOperations never uses them, so every grep is an unfiltered whole-tree scan. The pi reference implementation shells out to ripgrep and documents "Respects .gitignore" (pi-mono/packages/coding-agent/src/core/tools/grep.ts:130).
+
+
+**影响：** In any real project (a node_modules tree of 100k+ files, a .git directory with multi-hundred-MB packfiles), a single model-issued grep reads gigabytes from disk and holds each file's full contents in memory, taking tens of seconds per call — and the model calls grep constantly. Because the file list is fully collected up front, even a `limit: 5` query still enumerates every path.
+
+
+**建议：** Prune during enumeration: skip `.git`, `node_modules`, and other VCS/dependency directories via `enumerator.skipDescendants()` (or honor .gitignore like pi's ripgrep path). Apply the declared `glob` parameter to filter candidate files. Stream files line-by-line (or at least skip files whose first bytes look binary) instead of `Data(contentsOf:)` on everything, and interleave matching with enumeration so `limit` can stop the walk early.
+
+### H9. SessionRecorder.ensureCreated() truncates an existing session file, destroying resumed history if called on the obvious path
+
+`Sources/KWWKAgent/SessionRecorder.swift:53` · SDK DX — KWWKAgent
+
+
+**证据：** ensureCreated() unconditionally calls store.create: `_ = try? await store.create(id: sessionId, cwd: cwd, ...)`. SessionStore.create (SessionStore.swift:311-325) is documented "Overwrites any existing file for the same id" and does `try data.write(to: try path(for: id), options: .atomic)` with only the header line — replacing the entire JSONL log. Every in-house caller must remember the guard the CLI uses (CodingTUI.swift:83 `if !resolvedResume.resumed { await initialRecorder.ensureCreated() }`); Headless.swift:85 repeats the same guard.
+
+
+**影响：** An SDK user resuming a session (`resolveResume(.id(x))` → `SessionRecorder(persistedCount: loaded.persistedCount)`) who then calls `ensureCreated()` — the name says "ensure", implying idempotence, and the doc says "Call once before the first run" — silently wipes the entire persisted transcript, leaving a header-only file. The recorder's non-zero persistedCount then also suppresses re-persisting the seeded messages, so the history is unrecoverable.
+
+
+**建议：** Make ensureCreated() create-if-missing (the fileExists check already used by SessionStore.append/setTitle), or have SessionStore.create throw/skip when the file exists and add a separate `recreate`. Alternatively fold the `resumed` guard into the recorder so callers cannot get it wrong.
+
+### H10. Manual /compact runs with no busy gate: a prompt submitted during the compact round-trip gets its turn clobbered when the compactor overwrites agent.state.messages
+
+`Sources/KWWKCli/BuiltinSlashCommands.swift:689` · TUI 用户体验
+
+
+**证据：** handleCompactCommand awaits performCompact → AgentContextCompactor.compactAgent, which does its LLM summarize via agent.streamForCompaction (Agent.swift:216) — a path that never calls state.setStreaming(true) (only runLifecycle at Agent.swift:473 does) and never emits .compactStart (only the auto path at Agent.swift:529 does). The Enter handler's busy gate is `let busy = agent.state.isStreaming || isAutoCompacting` (CodingTUI.swift:696), and isAutoCompacting is set only by the .compactStart event (CodingTUI.swift:486). So during a manual /compact the TUI reports idle: the user can submit a prompt, agent.prompt() starts streaming, and when the compact finishes compactAgent executes `agent.state.messages = replacement.messages` (AgentContextCompactor.swift:104), replacing the transcript out from under the in-flight turn. There is also zero progress feedback: the state line stays at the idle hint and the "summarizing N messages…" notify prints only AFTER the compact completed (BuiltinSlashCommands.swift:705), and Esc cannot cancel it (the Esc binding checks agent.state.isStreaming, which is false).
+
+
+**影响：** On a long transcript /compact takes tens of seconds with the UI looking completely idle. A user who types /compact and then continues prompting (the natural thing to do when nothing indicates work in progress) has their new turn's messages silently discarded or interleaved with the summary when the compactor's assignment lands — lost user input plus an inconsistent context sent to the model on the next request.
+
+
+**建议：** Before awaiting performCompact, set the same busy state the auto path uses (flip isAutoCompacting / frameMode = .compacting and requestRender so the spinner shows), and have the Enter handler treat that as busy so prompts queue via steer instead of starting a turn. Alternatively emit .compactStart/.compactEnd from compactAgent itself so both paths share one signal. Print the "summarizing…" notice before the await, not after.
+
+
+---
+
+## MEDIUM（33 条）
+
+### M1. APIRegistry's flat fallback can route a model to a provider holding a different vendor's API key and send that key to the model's foreign baseUrl
+
+`Sources/KWWKAI/APIRegistry.swift:73` · 副作用/全局状态 ·（对抗验证后降级）
+
+
+**证据：** `provider(scope:api:)` returns `scoped[scope]?[api] ?? providers[api]` — when a model's `provider` scope has no registration, dispatch silently falls back to whatever flat provider owns the wire `api`, with no check that the flat provider belongs to that vendor. Providers then build the request URL from the model, not from their own configuration: AnthropicProvider.swift:74-77 uses `model.baseUrl` and lines 103-105 attach `defaultAPIKey` via `x-api-key`. So a flat `AnthropicProvider(defaultAPIKey: <ANTHROPIC_API_KEY>)` (registered unscoped by registerBuiltins in RegisterBuiltins.swift:41-44 or by the CLI env path in AuthResolver.swift:490) will serve any model with `api: "anthropic-messages"` — including catalog models whose provider is "github-copilot" with `baseUrl: api.individual.githubcopilot.com` — POSTing the Anthropic key to that third-party host. The same pattern applies to OpenAICompletionsProvider + openrouter-catalog models (OpenAI key sent to openrouter.ai).
+
+
+**影响：** An SDK embedder (e.g. the OpenBridge app) registers builtins with an Anthropic API key, then calls the top-level `stream(model:)` with a catalog model from another provider that shares the wire protocol. Instead of `ProviderNotFoundError`, the request silently transmits the user's Anthropic secret key to a different company's endpoint. Secret exfiltration to an unintended host, with no error and no log.
+
+
+**建议：** Gate the flat fallback: only fall back when `model.provider` matches the vendor the flat provider was registered for (record a provider/vendor tag at registration), or when the model's baseUrl host matches the provider's defaultBaseURL. Otherwise throw ProviderNotFoundError so mis-scoped models fail loudly instead of leaking credentials.
+
+### M2. CancellationHandle.cancel() is only polled between SSE events, so cancelling a stalled stream never aborts the HTTP request and the stream never ends
+
+`Sources/KWWKAI/AnthropicProvider.swift:191` · SDK DX — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** The Anthropic drive loop checks `if state.signal?.isCancelled == true` only after `for try await sse in events` yields an event (line 190-196). Grep confirms the same polled pattern in BedrockProvider.swift:187, GoogleGeminiProvider.swift:138, OpenAICompletionsProvider.swift:160, and OpenAIResponsesProvider SSE path; only the Responses WebSocket path registers `options?.cancellation?.onCancel { connection.close() }` (OpenAIResponsesProvider.swift:281). CancellationHandle.onCancel exists precisely for eager abort but no SSE provider uses it to cancel the in-flight request.
+
+
+**影响：** The user hits Esc / the app calls handle.cancel(reason:) while the connection is stalled or the model is between events. Nothing happens: the socket stays open, `stream.result()` never resolves, and combined with the non-cancellable `next()` (previous finding) there is no way to reclaim the task. The advertised 'AbortSignal analog' silently does not abort.
+
+
+**建议：** In each provider's run(), register `options?.cancellation?.onCancel { ... }` that cancels the byte stream / URLSession task (the HTTPClient stream already cancels the task on termination via onTermination), then emit the .aborted error immediately rather than waiting for the next SSE event.
+
+### M3. AnthropicProvider maps 'refusal' / 'sensitive' / unknown stop reasons to .stop, reporting a refused response as a successful completion
+
+`Sources/KWWKAI/AnthropicProvider.swift:780` · 正确性 — KWWKAI
+
+
+**证据：** `mapStopReason` handles only end_turn/max_tokens/tool_use/stop_sequence and has `default: return .stop`. pi's anthropic.ts:1190-1208 maps `"refusal" → "error"` and `"sensitive" → "error"`, and throws on unknown values so new API stop reasons are surfaced rather than silently absorbed.
+
+
+**影响：** When Claude refuses or a safety filter fires, the stream ends with `.done(reason: .stop)` and an (often empty or partial) assistant message that looks like a normal turn. The agent loop proceeds as if the model completed successfully — no retry, no error surfaced to the user — and the bogus turn is persisted into the transcript for replay.
+
+
+**建议：** Map `refusal` and `sensitive` to `.error` (setting `errorMessage`), and treat unknown stop reasons conservatively (log verbose + map to `.error` or at least surface the raw value) instead of defaulting to `.stop`.
+
+### M4. Anthropic stream that closes without message_stop finalizes as a successful .done(.stop) instead of an error
+
+`Sources/KWWKAI/AnthropicProvider.swift:313` · 正确性 — KWWKAI
+
+
+**证据：** After the event loop, the comment says "Upstream closed without message_stop." and the code runs `let final = state.finalize(); out.push(.done(reason: final.stopReason, message: final))` — `state.stopReason` is initialized to `.stop` and is only changed by a `message_delta`, so a clean half-close mid-message yields `.done(.stop)`. The sibling OpenAICompletionsProvider explicitly guards this case (`validateAndFinish`: "Stream ended without finish_reason" → `.error`, lines 325-332), so the codebase already treats premature EOF as an error elsewhere.
+
+
+**影响：** If a proxy or the server cleanly closes the SSE connection mid-generation (no transport error thrown), the truncated assistant message is reported as a normal successful stop; the agent loop will not retry and persists an incomplete turn as if the model finished.
+
+
+**建议：** Track whether `message_stop` (or an `error` event) was seen; if the loop exits without one, finish with `.error` ("stream ended before message_stop") the same way OpenAICompletionsProvider validates a missing finish_reason.
+
+### M5. Provider stream state re-parses the full accumulated tool-call JSON with a fresh JSONDecoder on every delta, giving O(n^2) work while a tool call streams
+
+`Sources/KWWKAI/AnthropicProvider.swift:739` · 性能
+
+
+**证据：** Every delta event pushes `partial: state.snapshot()` (e.g. toolCallDelta at line 260, textDelta at 238). AnthropicStreamState.snapshot() (lines 730-758) rebuilds the message and, for each `.toolUse` block, runs `json.data(using: .utf8)` + `try? JSONDecoder().decode(JSONValue.self, ...)` on the entire accumulated (usually still-incomplete) argument buffer — a full UTF-8 conversion and a parse attempt per delta, per block, with a new JSONDecoder allocation each time. OpenAICompletionsProvider has the identical pattern (snapshot -> parseArguments, lines 1123-1186), as does OpenAIResponsesProvider.
+
+
+**影响：** Streaming a `write` tool call whose arguments embed a 50KB file arriving in ~500 deltas performs ~500 parse attempts over an average of 25KB each — roughly 12.5MB of cumulative JSON scanning for one tool call, on the token hot path. Multi-tool turns are worse: deltas for tool #2 re-parse tool #1's complete JSON too. This is pure waste since nearly all consumers ignore the partial's parsed arguments until toolCallEnd.
+
+
+**建议：** In snapshot(), represent in-progress tool calls with the raw JSON string (or an empty-object placeholder) and parse exactly once in finishBlock/finalize; alternatively cache the parsed value per block keyed by buffer length so unchanged blocks are never re-parsed. Reuse a single static JSONDecoder.
+
+### M6. AssistantMessageStream iteration is not cancellation-aware: a consumer task that gets cancelled while awaiting the next event hangs until the producer pushes or ends
+
+`Sources/KWWKAI/AssistantMessageStream.swift:91` · SDK DX — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** StreamState.nextEvent() suspends with `await withCheckedContinuation { ... eventWaiters.append(cont) ... }` (lines 90-107) and awaitResult() does the same (lines 109-120). Neither uses withTaskCancellationHandler, and the continuation is Never-failing, so Swift Task cancellation of the consuming task is invisible: the continuation stays queued until the producer's next push()/end().
+
+
+**影响：** A Swift developer naturally writes `let t = Task { for await ev in stream { ... } }; t.cancel()`. If the provider is stalled (network hang, no SSE events arriving), t.cancel() does nothing — the task never resumes, and any structured-concurrency group waiting on it deadlocks. This directly violates the ecosystem expectation that AsyncSequence iteration responds to task cancellation (URLSession.bytes, AsyncStream, AsyncChannel all do).
+
+
+**建议：** Wrap the suspension in withTaskCancellationHandler and, on cancellation, remove the waiter and resume it with nil (iteration) — or back StreamState with AsyncStream/AsyncThrowingStream continuations, which are cancellation-aware for free. Document whether ending iteration early also aborts the underlying request.
+
+### M7. EnvAPIKeys functions default env to [:] so calls like EnvAPIKeys.apiKey(for: "openai") silently always return nil
+
+`Sources/KWWKAI/EnvAPIKeys.swift:81` · SDK DX — KWWKAI
+
+
+**证据：** `public static func apiKey(for provider: String, env: [String: String] = [:]) -> String?` — same `env: [String: String] = [:]` default on foundEnvVars (line 74), hasBedrockAuth (line 91), configuredProviders (line 104), firstValue (line 112), azure (line 144), cloudflare (line 182). With the default, every function is a guaranteed no-op (empty dict has no keys).
+
+
+**影响：** The type is named EnvAPIKeys and pi's env-api-keys.ts reads process.env, so a consumer writing `EnvAPIKeys.apiKey(for: "anthropic")` compiles, runs, and always gets nil — they then debug a mysterious 'no provider configured' state. An always-wrong default is worse than no default: it converts a forgotten argument into silent misbehavior instead of a compile error.
+
+
+**建议：** Drop the default value (force callers to pass a snapshot, keeping the no-hidden-env-reads property), or default to ProcessInfo.processInfo.environment and document the read. Either is defensible; the empty-dict default is not.
+
+### M8. HTTPClient protocol bakes byte-at-a-time AsyncThrowingStream<UInt8> into the public extension point, with a comment that mis-states its copying and backpressure behavior
+
+`Sources/KWWKAI/HTTPClient.swift:153` · SDK DX — KWWKAI
+
+
+**证据：** The public protocol requires `AsyncThrowingStream<UInt8, Error>` (line 16). The delegate feeds it with `for byte in data { cont.yield(byte) }` (line 158) under the comment '`yield(contentsOf:)` on a Data ... yields without copying and keeps the stream back-pressured' — but the code doesn't call yield(contentsOf:), it yields one element per byte, and AsyncThrowingStream's default buffering policy is .unbounded, so urlSession(_:didReceive:) enqueues the entire chunk regardless of consumer speed: there is no backpressure at all.
+
+
+**影响：** Every custom HTTPClient a consumer writes (proxy, mock, retry wrapper) is forced into per-byte streaming — one continuation enqueue + one await-path element per byte, easily millions of operations for an image-bearing response, and HTTPClient.request() re-assembles Data one appended byte at a time (line 254). The misleading comment also tells implementers the contract provides backpressure when it does not.
+
+
+**建议：** Change the protocol to stream Data chunks (AsyncThrowingStream<Data, Error>) and adapt SSEParser to consume chunks; fix or delete the incorrect comment. This is a small pre-1.0 break that removes a permanent per-byte tax from the public contract.
+
+### M9. HTTP body streaming yields one AsyncThrowingStream element per byte, making SSE consumption cost ~1000x more than chunk-level delivery
+
+`Sources/KWWKAI/HTTPClient.swift:158` · 性能 ·（对抗验证后降级）
+
+
+**证据：** StreamingDelegate.urlSession(_:dataTask:didReceive:) does `for byte in data { cont.yield(byte) }` into an `AsyncThrowingStream<UInt8, Error>`. The comment claims "yields without copying and keeps the stream back-pressured", but each yield individually locks the stream's internal state and buffers one element (the default buffering policy is unbounded, so there is no back-pressure either). The consumer side (SSEParser.swift:96 `for try await byte in bytes { chunk.append(byte) ... }`) pays one async-iterator hop plus one Array append per byte, and the non-streaming helper `request()` (HTTPClient.swift:254) does `for try await byte in stream { buffer.append(byte) }`.
+
+
+**影响：** Every streamed LLM response is shuttled through the pipeline byte-by-byte: a 200KB response body becomes ~200,000 lock-protected yield calls plus ~200,000 awaits, instead of a few hundred Data-chunk events. This burns CPU on the hot token-streaming path of every single turn, and the same per-byte loop makes one-shot requests (OAuth, model catalogs) needlessly slow for large bodies.
+
+
+**建议：** Change the stream element type to Data (or [UInt8]) and yield the whole `didReceive data:` chunk once (`cont.yield(data)`). Update SSEParser/parseSSE to ingest chunks (it already has an `ingest(bytes: Data)` entry point) and split on newlines inside the chunk. Consider a bounded buffering policy if back-pressure is actually desired.
+
+### M10. OAuthStore silently discards an unreadable/corrupt store at init, and the next set() overwrites the file — destroying all stored logins with no error surfaced
+
+`Sources/KWWKAI/OAuth.swift:114` · SDK DX — KWWKAI
+
+
+**证据：** init: `if isPersistent, let data = try? Data(contentsOf: self.url), let decoded = try? JSONDecoder().decode(...) { self.credentials = decoded } else { self.credentials = [:] }` (lines 114-120). Any decode failure (one malformed entry, partial write, permissions) yields an empty in-memory store; persist() (line 148) then writes that empty/partial state back over ~/.kwwk/oauth.json atomically on the next set()/remove(). The code's own comment on OAuthCredentials.init(from:) (lines 28-31) acknowledges this exact failure mode but only fixes the missing-`extras` case.
+
+
+**影响：** A user with three OAuth logins hand-edits oauth.json and introduces a typo in one entry; the next kwwk run sees an empty store, prompts them to log in to one provider, and set() persists — wiping the refresh tokens for the other two providers with no warning. Refresh tokens are not recoverable.
+
+
+**建议：** Make the load failure loud: either a throwing `OAuthStore.load(url:)` factory, or record a `loadError` and refuse to persist() over a file that existed but failed to decode (e.g. rename it to oauth.json.corrupt first). Decode per-entry so one bad record doesn't drop the rest.
+
+### M11. OAuthManager.resolver() swallows every refresh error with try?, degrading expired-token failures into anonymous requests and confusing 401s
+
+`Sources/KWWKAI/OAuth.swift:218` · SDK DX — KWWKAI
+
+
+**证据：** `return { model, _ in ... return try? await manager.resolvedAuth(for: oauthId) }` (lines 214-220). A failed refresh (revoked token, network down, OAuthError.refreshFailed) becomes nil; in AnthropicProvider.run the nil resolvedAuth falls through to `options?.apiKey ?? defaultAPIKey` (AnthropicProvider.swift:104) which is typically nil in the OAuth setup, so the request goes out with no auth header at all.
+
+
+**影响：** A user whose Claude OAuth refresh token was revoked sees 'Anthropic returned status 401 — authentication_error' with zero indication that the actual failure was the OAuth refresh call, whose error text (OAuthError.refreshFailed with the token endpoint's body) was thrown away. Debugging requires reading library source.
+
+
+**建议：** Propagate the failure: make the resolver signature `async throws -> ResolvedProviderAuth?` (or log through StreamOptions.onVerbose / a callback) so the provider can emit the refresh error into the stream's .error event instead of sending an unauthenticated request.
+
+### M12. ~/.kwwk/oauth.json is momentarily world-readable on first creation and the 0600 lockdown is silently best-effort
+
+`Sources/KWWKAI/OAuth.swift:157` · 副作用/全局状态
+
+
+**证据：** `persist()` writes via `try data.write(to: url, options: .atomic)` and only afterwards runs `try? FileManager.default.setAttributes([.posixPermissions: 0o600], ...)`. I verified empirically that a fresh file created by `Data.write(.atomic)` under the default umask gets mode 0644. So on the very first `/login` (and any re-creation after deletion) the file containing OAuth access + refresh tokens and stored API keys is world-readable until the chmod lands; if `setAttributes` fails or the process dies in between, it stays 0644 forever because the failure is swallowed by `try?`. The pi reference sets the mode at write time: coding-agent/src/migrations.ts:69 `writeFileSync(authPath, ..., { mode: 0o600 })` and auth-storage.ts chmods unconditionally on every save. (The 0700 directory mitigates the default `~/.kwwk` case, but callers can pass any `url` — e.g. a store in a shared or pre-existing 0755 directory gets no protection.)
+
+
+**影响：** On a multi-user machine or when an embedder points OAuthStore at a directory that already exists with default permissions, refresh tokens (long-lived account credentials) are readable by other local users during the race window, or permanently if the silent chmod fails.
+
+
+**建议：** Create the file with 0600 before writing (e.g. `open(path, O_CREAT|O_EXCL, 0o600)` or FileManager.createFile(attributes:)), or write to a 0600 temp file and rename over the destination; make the permission set a hard error rather than `try?`.
+
+### M13. OpenAI Responses provider requests encrypted reasoning (`include: reasoning.encrypted_content`) but never captures or replays it
+
+`Sources/KWWKAI/OpenAIResponsesProvider.swift:770` · 正确性 — KWWKAI
+
+
+**证据：** `makeRequest` sets `root["include"] = .array([.string("reasoning.encrypted_content")])` with the comment "Required so encrypted reasoning round-trips across turns" (line 770), and defaults `store: false` (line 804). But the drive loop's `response.output_item.done` handler for reasoning items only emits `thinkingEnd` (lines 620-623) — it never reads `item["encrypted_content"]` — and `encodeInput` (lines 835-865) encodes assistant messages as only text parts and `function_call` items, dropping thinking blocks entirely. pi persists the full serialized reasoning item in `thinkingSignature` and replays it (`output.push(JSON.parse(block.thinkingSignature))`, openai-responses-shared.ts:173-174) and preserves fc_ item ids via the `callId|itemId` scheme.
+
+
+**影响：** With `store:false`, reasoning state for GPT-5/Codex models is silently discarded between turns: every request pays for the `include` option yet the model loses its prior chain-of-thought at each tool round-trip, degrading multi-step task quality versus pi. (Hard 400s from OpenAI's reasoning/function_call pairing validation are only avoided because kwwk also omits the fc_ item ids.)
+
+
+**建议：** Capture the full reasoning item (including `encrypted_content` and item `id`) from `response.output_item.done`, store it on the thinking block's `thinkingSignature` (serialized JSON, as pi does), and re-emit it in `encodeInput` for same-model assistant messages.
+
+### M14. OpenAI Responses `response.incomplete` terminal event is unhandled: truncation reports stopReason .stop over HTTP and a spurious transport failure over WebSocket
+
+`Sources/KWWKAI/OpenAIResponsesProvider.swift:648` · 正确性 — KWWKAI
+
+
+**证据：** The drive switch handles `response.completed`, `response.failed`, `response.error`, and `error` but not `response.incomplete` (OpenAI's terminal event when `max_output_tokens` is hit). The stream then ends without a terminal case: on HTTP (`finishOnStreamEnd: true`, lines 677-687) the message is finished with the default `state.stopReason = .stop`; on WebSocket the run lands in the `endedWithoutTerminalEvent` branch (lines 353-390), which calls `session.recordWebSocketFailure(...)` and — because `progress.hasReceivedEvent` is true — pushes the error "WebSocket stream closed before response.completed".
+
+
+**影响：** A merely length-truncated response is misreported: over HTTP the agent sees a clean `.stop` and treats truncated output as a complete answer; over WebSocket the user gets a hard stream error for a normal truncation, and three truncations trip `maxWebSocketFailures`, permanently disabling the WebSocket transport for that session.
+
+
+**建议：** Add a `case "response.incomplete":` that reads `response.status` / `incomplete_details`, sets `state.stopReason = .length`, and finishes via the same path as `response.completed` (including usage capture and `recordCompletedResponse`).
+
+### M15. README steering example does not compile: steer() takes Message, not UserMessage, and no ergonomic overloads exist
+
+`Sources/KWWKAgent/Agent.swift:225` · SDK DX — KWWKAgent
+
+
+**证据：** The only signature is `public func steer(_ message: Message)` (same for followUp, line 228). README.md:336 shows `agent.steer(UserMessage(text: "also add tests as you go"))`, which fails to type-check — callers must write `agent.steer(.user(UserMessage(text: ...)))`. pi-mono's Agent accepts `string | AgentMessage | AgentMessage[]` overloads for prompt and plain AgentMessage for steer (packages/agent/src/agent.ts:325-336).
+
+
+**影响：** The first thing a developer copies from the "Steering a running agent" README section is a compile error; the fix (`.user(...)` wrapping) is non-obvious because UserMessage is the natural type to construct. Every steer/followUp call site pays the wrapping boilerplate.
+
+
+**建议：** Add `steer(_ text: String)` and `steer(_ message: UserMessage)` conveniences (and the same for followUp), and fix the README snippet.
+
+### M16. Agent's public mutable configuration properties are unsynchronized on an @unchecked Sendable class
+
+`Sources/KWWKAgent/Agent.swift:142` · SDK DX — KWWKAgent
+
+
+**证据：** `public var sessionId`, `thinkingBudgets`, `maxRetryDelayMs`, `maxTurns`, `toolExecution`, `toolChoice`, `parallelToolCalls`, and all eight hook closures (lines 142-156) are plain stored properties with no lock, on `final class Agent: @unchecked Sendable`. They are read during runs — loopConfig() (line 412) reads them at run start, and builtInBetweenTurnsHook captures `autoCompact`. Contrast AgentState, which routes every field through `lock.withLock`, and the same class's own `listeners`/`activeCancellation` which are lock-protected.
+
+
+**影响：** The type signature advertises cross-thread use (Sendable, and steer() is documented "from any thread"), but setting e.g. `agent.maxTurns` or `agent.beforeToolCall` from a UI thread while a run executes on another thread is a Swift data race (undefined behavior; existential/closure fields can tear). Developers get no compiler diagnostic because of @unchecked.
+
+
+**建议：** Protect these vars with the existing NSLock (computed get/set like AgentState), or make them immutable after init and provide an explicit `updateOptions` API with documented run-boundary semantics.
+
+### M17. Foreground bash results bypass truncation: legacy path returns unbounded output, flip path returns up to 1MB verbatim
+
+`Sources/KWWKAgent/BashTool.swift:470` · 正确性 — KWWKAgent
+
+
+**证据：** runBashLegacy joins full stdout+stderr into the tool result with no cap (`let body = [result.stdout, result.stderr]...joined`), and ForegroundBashExecution.readOutput only caps at `data.prefix(1_000_000)` (line 539) before the whole string is returned as content AND duplicated into `details.stdout`. Nothing downstream applies Truncate to tool results (Truncate.truncateHead is used only by ReadTool).
+
+
+**影响：** One `cat large.log` or verbose test run injects up to 1MB (legacy: arbitrarily more) into the transcript — twice, since details duplicates content — blowing the context window, triggering immediate auto-compaction, and inflating cost. pi truncates bash output to a bounded head/tail for exactly this reason.
+
+
+**建议：** Run bash output through Truncate (e.g. tail-biased, ~50KB/2000 lines like the read tool) before building AgentToolResult, keep the full output in the on-disk file, and don't duplicate the full text into details.
+
+### M18. makeCodingAgent silently wires an auto-continue bridge that starts new LLM runs at arbitrary times, and discards the only detach handle
+
+`Sources/KWWKAgent/CodingAgentBuilder.swift:224` · SDK DX — KWWKAgent
+
+
+**证据：** `_ = await agent.attachBackgroundManager(bgManager, sessionId: sessionId)` — the returned unsubscribe closure (the only way to detach the bridge, Agent+Background.swift:118-123) is thrown away. BackgroundAgentBridge.onNotification (Agent+Background.swift:48-63) steers a user message and, when the agent is idle, fires `Task { try? await ref?.continue() }` — a brand-new model run.
+
+
+**影响：** For an SDK caller, `try await agent.prompt(...)` returning does not mean the agent is done: a background bash task (including one auto-flipped on the 120s foreground timeout) completing minutes later spontaneously triggers a new billable LLM turn on an agent the caller may no longer be observing. There is no public API to detach; the only recourse is `abortAndKillBackgroundTasks()`, which also kills the tasks. Conflicts with the stated goal of "no surprising side effects".
+
+
+**建议：** Return the detach handle from makeCodingAgent (e.g. a small `CodingAgent` result type bundling agent + detach), or make auto-continue-when-idle an explicit opt-in flag, and document the spontaneous-run behavior prominently.
+
+### M19. Session identity is duplicated across Agent.sessionId, tool closures, recorder, and background attachments with no coherent way to rotate it
+
+`Sources/KWWKAgent/CodingAgentBuilder.swift:250` · SDK DX — KWWKAgent
+
+
+**证据：** buildCodingToolList bakes `sessionId` into the bash/task_status/wait_task tool closures at construction time (lines 250-263); attachBackgroundManager captures it again (CodingAgentBuilder.swift:224); `Agent.sessionId` is a separate public mutable var consumed per-run by the loop (AgentLoop.swift:479,491) and by closeSession(). Setting `agent.sessionId` re-scopes only provider auth/streams — tools and the notification bridge keep the old id. The CLI's own `/new` and `/resume` (CodingTUI.swift performNewSession, SessionSlashCommands.swift:85-101) swap only the recorder's id and never touch agent.sessionId or the tools.
+
+
+**影响：** The obvious call — mutate the public `agent.sessionId` to move an agent to a new session — silently half-works: background tasks are still tagged and killed under the old id, subagent child ids still prefix the old id, and `closeSession()` closes the new id while provider resources from earlier turns were opened under the old one. Developers cannot implement /new-style session rotation correctly with the public surface.
+
+
+**建议：** Either make sessionId immutable and per-agent (document "one Agent = one session"), or thread it through a shared mutable box that tools and bridges read at call time, exposing a single `agent.rotateSession(to:)`.
+
+### M20. FileMutationQueue's inode-based keying is defeated by the tools' own atomic writes, breaking per-file serialization
+
+`Sources/KWWKAgent/FileMutationQueue.swift:47` · 正确性 — KWWKAgent
+
+
+**证据：** `queueKey(for:)` returns "inode:st_dev:st_ino" when the file exists. But LocalEditOperations/LocalWriteOperations write with `Data.write(to:options:.atomic)` (EditTool.swift line 24, WriteTool.swift line 17), which writes a temp file and rename(2)s it over the path — allocating a NEW inode on every mutation. So after edit A completes, a chained edit B is still running under key inode:X while a newly arriving edit C stats the file, gets inode:Y, finds no inflight entry, and runs concurrently with B.
+
+
+**影响：** With the loop's default `toolExecution: .parallel`, overlapping edit/write calls to the same file across turns can interleave read-modify-write: one edit's changes are silently lost or `applyEdits` corrupts/fails on stale content. Additionally, `.atomic` rename-over-path replaces a symlink with a regular file — editing a file through a symlink clobbers the link and never touches the real target, directly contradicting the queue's "keeps symlink siblings on the same queue" design comment.
+
+
+**建议：** Key the queue by canonical resolved path (realpath) instead of inode, and write via truncate-and-write on the resolved target (or FileHandle) rather than `.atomic` rename, so both serialization and symlinks survive.
+
+### M21. find/Glob recompiles the glob regex for every visited file and walks .git/node_modules unpruned
+
+`Sources/KWWKAgent/Glob.swift:7` · 性能
+
+
+**证据：** Glob.matches does `path.range(of: regex, options: .regularExpression)`, which compiles a fresh NSRegularExpression on each call, and it is invoked once per enumerated file inside Glob.expand's loop (line 55). patternToRegex is also re-run per file. Like GrepTool, `expand` uses `fm.enumerator` with no pruning of .git or node_modules (line 45). pi's find explicitly ignores `**/node_modules/**` and `**/.git/**` (pi-mono/.../find.ts:168).
+
+
+**影响：** A `find **/*.swift` in a repo with 200k files under node_modules/.git performs 200k regex compilations plus 200k directory-tree stats — multiple seconds of pure overhead per tool call for work that pruning plus a single pre-compiled NSRegularExpression would reduce by orders of magnitude.
+
+
+**建议：** Compile the pattern once (NSRegularExpression instance) before the enumeration loop and reuse it, and prune well-known ignore directories via `skipDescendants()` during enumeration (ideally honoring .gitignore).
+
+### M22. Grep tool advertises `glob` and `context` parameters that are silently ignored
+
+`Sources/KWWKAgent/GrepTool.swift:150` · 正确性 — KWWKAgent
+
+
+**证据：** The tool schema declares `"glob": ["type": "string"]` and `"context": ["type": "number"]` (lines 101, 104), and GrepParams has `glob`/`context` fields (CodingTools.swift lines 99-111), but the execute closure builds `GrepParams(pattern:path:ignoreCase:literal:limit:)` without ever reading obj["glob"] or obj["context"], and LocalGrepOperations never consults `params.glob`/`params.context` either.
+
+
+**影响：** When the model narrows a search with `glob: "*.swift"` it silently gets matches from every file type (node_modules, binaries-as-UTF8, build output), burning the 50-match limit on noise; requesting `context: 3` yields no context lines. The model receives no error, so it trusts wrong results — exactly the "surprising side effect" class the project wants to avoid.
+
+
+**建议：** Either implement glob filtering (filter collectFiles via Glob.matches) and context-line output in LocalGrepOperations, or remove the two parameters from the published schema until implemented.
+
+### M23. resolveResume(.id) with an invalid-format id silently substitutes a random fresh session id
+
+`Sources/KWWKAgent/SessionResume.swift:91` · SDK DX — KWWKAgent
+
+
+**证据：** `case .id(let id): guard SessionStore.isValidSessionId(id) else { return ResolvedResume(sessionId: freshId) }` — freshId is a random UUID. The very next branch honors caller intent for an unknown-but-valid id ("create a new session under that id so the caller's intent ... is honored", line 104-107), but a validation failure (e.g. `--session "my session"` with a space, or a leading dot) discards the requested id without any signal: `resumed` is false either way and no error is thrown.
+
+
+**影响：** A user or SDK caller asking for a specific named session gets a silently different, randomly-named session; subsequent runs with the same flag mint yet another id each time, scattering transcripts across UUID files with no explanation. The API is documented "Never throws", so the caller cannot distinguish "typo in id" from "fresh session as requested".
+
+
+**建议：** Surface invalid ids: either throw SessionStoreError.invalidId from a throwing variant, or add a `rejectedId`/reason field on ResolvedResume so callers can warn. Silent degradation should be reserved for unreadable files, not caller typos.
+
+### M24. SessionStore.load silently drops any undecodable entry, so schema drift or corruption loses messages with no diagnostics
+
+`Sources/KWWKAgent/SessionStore.swift:456` · SDK DX — KWWKAgent
+
+
+**证据：** `guard let data = ..., let entry = try? Self.decoder.decode(Entry.self, from: data) else { // Skip malformed/partial trailing lines ... continue }`. The rationale covers a crash-truncated trailing line, but the catch-all applies to every line: an entry written by a newer build (new Message block type, renamed key) fails decode and vanishes. The file-level `version` is only checked on the header (line 496), and entries carry no version. Contrast Skills, which reports every skipped file via SkillDiagnostic.
+
+
+**影响：** After an upgrade/downgrade or partial corruption mid-file, `--resume` reconstructs a context with messages silently missing from the middle of the conversation — potentially breaking user/assistant alternation that providers reject — and neither the developer nor the user gets any indication that data was skipped.
+
+
+**建议：** Return skipped-line diagnostics (count + line numbers) on LoadedSession, and restrict the lenient path to the final line of the file; a mid-file decode failure should at least be observable.
+
+### M25. Session listing fully JSON-decodes every message of every session file just to count messages, and --continue startup pays for all of it
+
+`Sources/KWWKAgent/SessionStore.swift:547` · 性能
+
+
+**证据：** info(at:) reads each session file entirely into a String and runs `Self.decoder.decode(Entry.self, ...)` on every line — decoding every message body (full transcripts, embedded base64 images) — only to increment `messageCount` and pick up the last meta values. list() does this for every .jsonl file in the directory, and latestForCwd (line 581) calls list(), so the `--resume`/`--continue` startup path and the session picker replay the user's entire on-disk history.
+
+
+**影响：** With 100 accumulated sessions averaging 2MB each, opening the CLI with --continue parses ~200MB of JSON (including image attachments) before the first prompt renders; the /resume picker does the same on each open. Cost grows without bound as sessions accumulate.
+
+
+**建议：** For listing, avoid full Entry decodes: count lines and decode only the header plus a lightweight probe of `"type":"meta"` lines (e.g. match the type field before decoding, or scan the file backwards for the last meta). Alternatively maintain a small sidecar index (id, cwd, updatedAt, count, title) updated on append.
+
+### M26. TmuxSessionManager.runProcessSync has the same read-after-wait pipe deadlock, and it hangs the whole actor on large capture-pane output
+
+`Sources/KWWKAgent/TmuxSessionManager.swift:273` · 正确性 — KWWKAgent
+
+
+**证据：** `process.waitUntilExit()` (line 273) runs before `stdoutPipe.fileHandleForReading.readDataToEndOfFile()` (line 274). `capture(_:lines:)` passes a model-controlled `lines` straight to `capture-pane -S -<lines>` (TmuxTool.swift lines 195-200 accept any Int with no cap), and runTmuxSync executes synchronously on the actor.
+
+
+**影响：** The model calling `tmux capture` with a large `lines` value (e.g. 10000 lines of a busy pane) makes tmux emit more than the ~64KB pipe buffer; tmux blocks writing, kwwk blocks in waitUntilExit, and because the call is synchronous actor-isolated work, every subsequent tmux tool call (and the cooperative-pool thread) is wedged forever — no timeout ever fires.
+
+
+**建议：** Drain stdout/stderr concurrently with the wait (readabilityHandler or background readToEnd started before waitUntilExit), and clamp/truncate the `lines` argument in TmuxTool.
+
+### M27. tmux tool panes inherit the full host process environment, bypassing the SDK's explicit bashEnvironment isolation guarantee
+
+`Sources/KWWKAgent/TmuxSessionManager.swift:259` · (补录)
+
+
+**证据：** `runProcessSync` builds a `Process()` and never sets `process.environment`, so the tmux server spawned by the first `new-session` inherits kwwk's complete environment, and every pane command inherits it from the server. This defeats the deliberate design elsewhere: CodingAgentConfig.bashEnvironment has no default and is documented "Exact environment passed to bash tool processes. Empty by default so SDK callers do not expose host process environment variables" (CodingAgentBuilder.swift:80-82), and BashTool.swift:83 sets `process.environment = environment` explicitly.
+
+
+**影响：** A host app (or the kwwk CLI itself, which runs with ANTHROPIC_API_KEY / OPENROUTER_API_KEY etc. exported) carefully passes a minimal bashEnvironment, but as soon as the model uses the tmux tool, every command it runs in a pane can read the host's secrets via `env`, and those secrets can then land in captured pane output inside the session transcript.
+
+
+**建议：** Accept an explicit environment in TmuxSessionManager (like BashToolOptions does), set it on the tmux server Process, and/or use `tmux new-session -e`/`set-environment` so pane processes see only the caller-approved variables.
+
+### M28. Scalar-summed width table misses modern emoji (U+1FA70–1FAFF), ZWJ sequences, and skin-tone composition, misaligning the prompt box and cursor
+
+`Sources/KWWKCli/ANSI.swift:107` · (补录)
+
+
+**证据：** columnWidth's wide table ends its emoji coverage at (0x1F900, 0x1F9FF); the entire Symbols & Pictographs Extended-A block U+1FA70–1FAFF (🫠 🩷 🪄 🫡 — very common emoji) falls through to `return 1` while terminals render them at width 2. InputComponent.charColumnWidth (InputComponent.swift:523) sums per-scalar widths, so a ZWJ family emoji 👨‍👩‍👧 counts 2+0+2+0+2=6 and a skin-toned 👍🏽 counts 4 (modifier U+1F3FD is in the 1F300–1F64F wide range), where terminals render both at 2. pi-tui instead segments graphemes and applies an RGI-emoji regex → width 2 per cluster (utils.ts:155-176).
+
+
+**影响：** Typing or pasting any of these emoji into the input box shifts the prompt box's right border (Box.pad/Box.row pad by the wrong visible width), soft-wraps at the wrong column, and parks the hardware cursor — the IME anchor — on the wrong cell, so CJK IME candidate windows and the visible caret drift from the actual insertion point. Same drift affects committed transcript lines that carry emoji.
+
+
+**建议：** Add the missing wide ranges (0x1FA70–0x1FAFF, 0x1F004, 0x1F0CF, 0x1F18E, 0x1F191–0x1F19A, 0x1F6D5–…) and, in InputComponent/visibleWidth, measure per grapheme cluster (Character) rather than per scalar: if the cluster contains ZWJ or an emoji base + modifier/VS16, treat it as width 2, mirroring pi-tui's graphemeWidth.
+
+### M29. A stale clipboard image silently wins over genuinely pasted text — the paste body is discarded whenever NSPasteboard holds an unseen image
+
+`Sources/KWWKCli/CodingTUI.swift:1419` · TUI 用户体验
+
+
+**证据：** handlePastedBody checks the pasteboard first: `if let image = ClipboardImageReader.readIfPresent() { … input.insert(token); return }` — the bracketed-paste body is unconditionally thrown away when an image is found ("the terminal's paste body is typically empty or garbage in this case, so we discard it"). But bracketed paste also fires for text that never came from NSPasteboard: tmux paste-buffer (prefix-]), iTerm paste history, and Finder drag-and-drop of a file path all send a meaningful body. ClipboardImageReader only dedupes by changeCount (Clipboard.swift:34), so the first such paste after any image copy takes this branch.
+
+
+**影响：** User screenshots something (image lands on the clipboard), then drags a file from Finder into the terminal or pastes a tmux buffer: kwwk discards the real pasted text and attaches the unrelated stale screenshot as `[image #N]`. The user's path/text is lost and a wrong image is silently queued for the model.
+
+
+**建议：** Only prefer the pasteboard image when the paste body is empty or degenerate (e.g. blank/whitespace or a few control bytes). When the body carries real text, route it through the normal path/text logic and leave the pasteboard untouched.
+
+### M30. Bracketed-paste accumulation is O(n²) with a per-byte Array allocation, freezing the whole TUI on large pastes
+
+`Sources/KWWKCli/StdinBuffer.swift:130` · TUI 用户体验
+
+
+**证据：** While a paste is in flight, every feed() re-runs takeOne → findBracketedPasteEnd, which rescans the entire buffer from index 0: `for i in 0...(buffer.count - end.count) { if Array(buffer[i..<(i + end.count)]) == end { … } }` — allocating a fresh 6-element Array per byte position on every chunk. A paste delivered in 4KB read chunks (RawStdin reads 4096 bytes, StdoutTerminal.swift:107) rescans ~n²/2 positions total. All of this runs on the main dispatch queue, the same queue that renders frames and handles keys. pi-tui's stdin-buffer instead keeps a pasteMode flag and does an incremental indexOf on the growing buffer (stdin-buffer.ts:315-325).
+
+
+**影响：** Pasting a large block (a long log, a big diff, a few hundred KB file) visibly hangs the TUI for seconds to minutes — no keystrokes, no spinner, no render — because the quadratic scan monopolizes the main queue. Pasting big text into the prompt is a core coding-agent workflow (the app even has a pasted-text attachment path designed for exactly this).
+
+
+**建议：** Track a resume offset (the buffer length already scanned minus 5) and continue the end-marker search from there on each feed; compare bytes in place (buffer[i] == end[0] && … or memcmp-style) instead of materializing an Array per position.
+
+### M31. TUI has no frame diffing or no-op suppression: every agent event, including every token delta, rewrites the entire live zone
+
+`Sources/KWWKCli/TUI.swift:108` · 性能
+
+
+**证据：** `requestRender()` calls `render()` synchronously with no coalescing, and CodingTUI's subscriber calls `runner.tui.requestRender()` after every event (CodingTUI.swift:530), including `.messageUpdate` deltas that usually change nothing visible (assistant text is committed at newline boundaries, not held in the live zone). render() always re-renders all children, ANSI-truncates every row, and emits rewind + `ESC[2K` + reprint for the full frame. `lastRenderedLines` is stored (line 434) but never read for comparison anywhere in the file — the previous frame is retained and then ignored.
+
+
+**影响：** At 50-100 stream events/sec with a ~15-row live zone (prompt box + tool slots), the terminal receives ~1-2KB of redundant escape output per token even when the frame is pixel-identical, costing CPU in both kwwk and the terminal emulator and risking visible flicker on slower terminals. During parallel tool execution with partial-result updates, the entire zone is repainted for each tool's update.
+
+
+**建议：** Compare the newly rendered lines against `lastRenderedLines` and skip the terminal write when identical and no commits are pending (or emit only changed rows). Additionally coalesce bursts by scheduling at most one render per run-loop tick / small interval rather than one per event.
+
+### M32. Every SIGWINCH triggers an unthrottled full-transcript replay of up to 20,000 lines, rebuilt as one giant string per resize step
+
+`Sources/KWWKCli/TUI.swift:211` · 性能
+
+
+**证据：** handleResize calls fullRepaint "synchronously on every SIGWINCH, no throttle" (comment, lines 208-211). fullRepaint copies `committedLines` (capped at 20,000 lines, line 32) and string-concatenates `"\u{1B}[2K" + line + "\r\n"` for every history line into a single output string before writing (lines 281-283). multiplexerRepaint is worse per step: it re-wraps the entire history through ANSI.wrap (line 346), which allocates `Array(s.unicodeScalars)` per line.
+
+
+**影响：** With a long session (near the 20k-line cap, ~1.5-2MB of text), an interactive corner-drag emitting ~30 SIGWINCHs/sec forces ~50MB/s of string building and terminal writes plus scrollback-clear escape codes — visible stutter and a pegged core during resize, and inside tmux an additional full re-wrap of history per step.
+
+
+**建议：** Debounce/coalesce resize repaints (e.g. repaint at most every ~50ms during a burst, with a trailing authoritative repaint), and cap the replayed history to what can plausibly matter (viewport + recent tail) during the drag, replaying full history only on the final settle.
+
+### M33. SIGTERM/SIGINT exit path calls Foundation.exit inside TUIRunner.run, skipping CodingTUI's shutdown — background tasks, tmux socket, and provider session leak
+
+`Sources/KWWKCli/TUIRunner.swift:99` · TUI 用户体验
+
+
+**证据：** run() ends with `let code = lock.withLock { pendingExitCode } ?? 0; if code != 0 { Foundation.exit(code) }`. The SIGINT/SIGTERM dispatch sources set code 130/143 (TUIRunner.swift:165,168), so any signal-driven exit terminates the process right there. The caller's cleanup in runCodingTUIInternal — `await shutdown()` which runs agent.abortAndKillBackgroundTasks(), agent.closeSession(), and tmuxManager?.teardown() (CodingTUI.swift:994-1013) — only runs after `try await runner.run()` returns normally, which the Foundation.exit call prevents. (Terminal modes themselves are restored: tearDown() runs first.)
+
+
+**影响：** Kill kwwk with `kill <pid>` (SIGTERM) or deliver SIGINT externally while background tasks are running: the process exits but its spawned background processes keep running and the isolated tmux server/socket is left behind — exactly the leak the shutdown closure documents itself as preventing. Users accumulate orphaned processes after every signal-driven exit.
+
+
+**建议：** Return the exit code from run() (or store it) and let the caller perform its shutdown before terminating, e.g. `let code = try await runner.run(); await shutdown(); Foundation.exit(code)` — keeping Foundation.exit out of the runner so the API has no hidden process-terminating side effect.
+
+
+---
+
+## LOW（26 条）
+
+### L1. Top-level stream()/complete() are hardwired to APIRegistry.shared with no registry parameter, unlike registerBuiltins which accepts one
+
+`Sources/KWWKAI/APIRegistry.swift:122` · SDK DX — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** `public func stream(model:context:options:) async throws` looks up `APIRegistry.shared.provider(scope:api:)` (line 123) with no way to supply another registry, while registerBuiltins takes `registry: APIRegistry = .shared` and its doc comment explicitly advertises 'tests can pass a private APIRegistry() to avoid mutating global state' (RegisterBuiltins.swift:28-29).
+
+
+**影响：** The advertised isolation escape hatch is half-built: a test or embedding app that registers into a private APIRegistry() cannot use the documented entry points stream()/complete() at all — it must reimplement the scoped-then-flat lookup and the ProviderNotFoundError throw by hand. Meanwhile any code in the process can mutate .shared and change what a library caller's stream() resolves to (hidden global mutable state). pi-mono has the same module-global registry, but it doesn't dangle an instance-registry API that the entry points then ignore.
+
+
+**建议：** Add `registry: APIRegistry = .shared` parameters to stream() and complete() (and closeProviderSession), or move them onto APIRegistry as instance methods with global free-function wrappers.
+
+### L2. complete() has a split error surface: missing provider throws, but every runtime failure is silently encoded in the returned message's stopReason
+
+`Sources/KWWKAI/APIRegistry.swift:130` · SDK DX — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** complete() throws ProviderNotFoundError (line 124) yet drains the stream and returns `await s.result()` unconditionally (lines 131-134). Per the APIProvider contract (lines 3-5: providers surface errors 'never via thrown errors'), an auth failure, 400, or network error comes back as a normal-looking AssistantMessage with stopReason == .error and the detail in errorMessage. Nothing forces the caller to inspect it, and ProviderNotFoundError isn't LocalizedError so it also prints as `api("anthropic-messages")`.
+
+
+**影响：** The obvious consumer code `let msg = try await complete(model: m, context: ctx); print(msg.content)` compiles, 'succeeds', and prints an empty content array on a 401 — the try suggests errors are handled when the dominant failure mode isn't thrown. Every consumer must know to check stopReason == .error/.aborted, which is only documented on a different type.
+
+
+**建议：** Keep the event-encoded errors for streaming (pi parity), but give complete() an honest contract: either throw a typed StreamFailedError(message:) when stopReason is .error, or add a `try message.get()`-style helper / `completeOrThrow` variant, and document the check prominently on complete().
+
+### L3. AnthropicProvider's doc comment lists OAuth bearer tokens, anthropic-beta headers, and retry as 'non-goals' even though the first two are implemented in this exact file
+
+`Sources/KWWKAI/AnthropicProvider.swift:9` · SDK DX — KWWKAI
+
+
+**证据：** Lines 9-15: 'Non-goals for this implementation: OAuth bearer tokens, anthropic-beta opt-in headers ... These are tracked in follow-up work'. The same type ships authHeaderBuilder for Bearer auth (line 30, used by ProviderVariants.anthropicOAuth), systemPromptPrefix for OAuth identity (line 35), and an appendBeta() helper stamping extended-cache-ttl / fine-grained-tool-streaming / interleaved-thinking betas (lines 113-139).
+
+
+**影响：** This is the header documentation a consumer reads first when choosing how to authenticate; it tells them OAuth is unsupported and sends them looking for a nonexistent alternative, when ProviderVariants.anthropicOAuth is the supported path three files away.
+
+
+**建议：** Rewrite the header to describe the actual capabilities and point to ProviderVariants.anthropicOAuth; keep only genuinely-missing items (e.g. retry-after handling if still absent) in the non-goals list.
+
+### L4. AssistantMessageStream is silently single-consumer and exposes producer push()/end() to consumers with no guard or documentation
+
+`Sources/KWWKAI/AssistantMessageStream.swift:34` · SDK DX — KWWKAI
+
+
+**证据：** makeAsyncIterator() hands every iterator the same StreamState (line 35), whose nextEvent() destructively pops a shared buffer — two concurrent `for await` loops each receive an arbitrary interleaved subset of events. Meanwhile push() and end() are public (lines 17-25): a consumer calling end() on a provider-owned stream makes all subsequent provider push()/end() calls silently no-ops (StreamState lines 56-59, 75-78). Neither constraint is documented. Additionally, if a caller only awaits result() without iterating, every event (each carrying a full `partial` AssistantMessage snapshot) accumulates in the unbounded buffer.
+
+
+**影响：** A developer who iterates in one task for UI deltas and iterates again elsewhere (or hands the stream to two observers) gets nondeterministically split events with no error. One accidental end() call on the returned stream truncates the run and freezes result() at a stale message, with the real provider outcome silently dropped.
+
+
+**建议：** Document single-consumer semantics on the type; consider trapping or asserting on a second makeAsyncIterator(). Separate the producer surface (an internal or provider-facing continuation type) from the consumer-facing stream, mirroring AsyncStream's makeStream(of:) split.
+
+### L5. Gemini and Bedrock discard the HTTP error body on 4xx/5xx, unlike the other providers
+
+`Sources/KWWKAI/GoogleGeminiProvider.swift:113` · 正确性 — KWWKAI
+
+
+**证据：** On `response.statusCode >= 400` GoogleGeminiProvider emits only "Gemini returned status \(response.statusCode)" without draining the body; BedrockProvider.swift:161-168 does the same ("Bedrock returned status N"). AnthropicProvider (lines 145-167) and both OpenAI providers deliberately read up to 4KB of the error body "so the user has signal whether it's the thinking field, max_tokens, or the proxy rejecting a shape."
+
+
+**影响：** Gemini's and Bedrock's error bodies carry the actionable message (invalid tool schema field, unsupported thinkingConfig, AccessDeniedException detail). Users debugging a 400 on these two providers only see the bare status code and must resort to packet captures, exactly the DX failure the Anthropic code comments call out.
+
+
+**建议：** Reuse the `errorBodyPreview(from:)` helper from OpenAICompletionsProvider (or the Anthropic drain pattern) in both providers' >=400 branches.
+
+### L6. HTTPClient byte stream claims back-pressure but is unbounded, and yields one continuation call per byte
+
+`Sources/KWWKAI/HTTPClient.swift:158` · 正确性 — KWWKAI
+
+
+**证据：** `didReceive data:` does `for byte in data { cont.yield(byte) }` under the comment "yields without copying and keeps the stream back-pressured." Both claims are wrong: `AsyncThrowingStream` is created with the default `.unbounded` buffering policy, so `yield` never suspends and every byte the server sends is buffered if the consumer lags; and yielding per-UInt8 performs a synchronized continuation operation per byte (then `parseSSE` re-iterates the same bytes one at a time), which is a large constant factor on every streamed token.
+
+
+**影响：** A slow or paused consumer (e.g. the 4096-byte error-preview loops that `break` early in AnthropicProvider.swift:152-155 while the server keeps sending) lets the buffer grow without bound — memory, not back-pressure, absorbs the stream. Per-byte yields also tax the hot streaming path in a project that lists performance as a goal.
+
+
+**建议：** Change the transport element type to `Data`/`[UInt8]` chunks (yield each `didReceive data:` once) and have `parseSSE`/`parseAWSEventStream` consume chunks; or at minimum set a bounded buffering policy and fix the comment.
+
+### L7. Inconsistent URL casing across the public surface: Model.baseUrl vs ResolvedProviderAuth.baseURL vs provider defaultBaseURL
+
+`Sources/KWWKAI/Model.swift:29` · SDK DX — KWWKAI
+
+
+**证据：** Model declares `public var baseUrl: String` (Model.swift:29) while ResolvedProviderAuth declares `public var baseURL: String?` (Context.swift:90) and every provider initializer takes `defaultBaseURL: URL` (e.g. AnthropicProvider.swift:21). The Model field is also a String while the provider fields are URL.
+
+
+**影响：** Consumers constructing models and auth side by side must remember two spellings of the same concept ('baseUrl' compiles on Model, errors on ResolvedProviderAuth, and vice versa), and autocomplete/grep across the codebase splits. Swift API Design Guidelines uniformly uppercase acronyms (URL). Since Model is Codable and baseUrl matches pi's JSON wire key, renaming the property with a CodingKeys mapping preserves compatibility.
+
+
+**建议：** Standardize on `baseURL` in Swift API (keep the `baseUrl` JSON coding key via CodingKeys), and consider typing it as URL? for parity with the provider constructors — a cheap pre-1.0 cleanup.
+
+### L8. ModelsCatalog silently returns an empty catalog when the bundled models.json is missing or unparseable
+
+`Sources/KWWKAI/ModelsCatalog.swift:37` · SDK DX — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** loadAll(): `guard let url = Bundle.module.url(forResource: "models", withExtension: "json"), let data = try? Data(contentsOf: url) else { return [:] }` and `guard let root = try? JSONSerialization... else { return [:] }` (lines 36-43). Individual model entries that fail decode are also silently skipped (line 50 `compactMap`-style continue). There is no diagnostic of any kind, and the static `byProvider` caches the empty result for the process lifetime.
+
+
+**影响：** A consumer embedding KWWKAI in a context where SwiftPM resource bundles are mishandled (static linking, custom packaging, renamed bundle) gets ModelsCatalog.all == [] and ModelsCatalog.model(provider:id:) == nil everywhere. The docs promise '900+ models'; the developer has no signal whether the id is wrong, the provider key is wrong, or the whole resource failed to load.
+
+
+**建议：** At minimum distinguish 'resource missing/corrupt' from 'empty' — e.g. expose `ModelsCatalog.loadError: Error?` or a `loadCatalog() throws` entry point, and count/report skipped entries. First access is a fine time to fail loudly in debug builds.
+
+### L9. OAuth callback server resolves success for any request hitting the path — even with no query parameters — killing the pending login
+
+`Sources/KWWKAI/OAuthCallbackServer.swift:238` · 正确性 — KWWKAI ·（对抗验证后降级）
+
+
+**证据：** `CallbackHandler.handle` resolves the flow for any GET whose path matches: it only special-cases an `error` query param; otherwise it runs `write(... status: .ok, html: server.successHTML); server.resolveSuccess(params)` even when `params` is empty (no `code`, no `state`). `resolveSuccess` sets `resolved = true` and calls `stop()`, closing the listener. The `code` check only happens later in `OAuthLogin.loginAnthropic` (line 79), which then throws "callback had no code" — and `waitForCallback()` can never be re-armed (`resolved` is sticky, line 97). Additionally, loginAnthropic's state check is `if let state, state != pkce.verifier` (OAuthLogin.swift:83), so a callback that simply omits `state` bypasses CSRF validation.
+
+
+**影响：** Any stray localhost request — a browser prefetch, another local app probing ports 53692/1455, a security scanner — that hits `/callback` before the real OAuth redirect permanently aborts the login: the server shuts down, the real redirect gets connection-refused, and the user sees "callback had no code" and must restart the flow. The optional-state check also weakens the PKCE/CSRF story.
+
+
+**建议：** In `CallbackHandler.handle`, only resolve when the expected parameter is present (`code` or `error`); reply 404/ignore otherwise and keep listening. Make the `state` parameter mandatory in both login flows (`guard params["state"] == expected`).
+
+### L10. OAuthLogin's default Callbacks make the SDK write to stderr, spawn the user's browser, and block reading stdin
+
+`Sources/KWWKAI/OAuthLogin.swift:31` · 副作用/全局状态
+
+
+**证据：** `Callbacks()` defaults are `defaultAuthURL` (writes to `FileHandle.standardError` and calls `Browser.open(url)`, which spawns `/usr/bin/open` / `xdg-open`), `defaultProgress` (stderr writes), and `defaultPrompt` (stderr write + blocking `readLine()` on stdin). `loginAnthropic(callbacks: Callbacks = Callbacks(), ...)` and the other login entry points use these defaults, so a library call with no arguments performs process-global stdio and launches an external application. The hooks are injectable, which is good, but the terminal-oriented behavior is the silent default in the SDK target (KWWKAI), not the CLI.
+
+
+**影响：** An embedder like a GUI app that calls `OAuthLogin.loginGitHubCopilot()` without customizing callbacks gets a surprise browser launch plus a `readLine()` that blocks a thread forever (GUI apps have no interactive stdin), and progress text interleaved into its stderr stream.
+
+
+**建议：** Make `Callbacks` parameters non-defaulted in the SDK (force the caller to choose), or move the stderr/readLine/browser defaults into the CLI target and give the library a `.silent`/throwing default so headless embedders fail fast instead of blocking.
+
+### L11. SSEParser.ingest(bytes:) silently drops a whole chunk when it splits a multi-byte UTF-8 character
+
+`Sources/KWWKAI/SSEParser.swift:23` · 正确性 — KWWKAI
+
+
+**证据：** `public func ingest(bytes: Data) { guard let s = String(data: bytes, encoding: .utf8) else { return } ... }` — if a network chunk boundary lands inside an emoji/CJK character, UTF-8 decoding of that chunk fails and the entire chunk (possibly kilobytes of events) is discarded with no error and no resynchronization. The only internal caller (`parseSSE`) happens to cut chunks at 0x0A so it is safe today, but this is a public API of the SSE parser and nothing documents the newline-alignment requirement.
+
+
+**影响：** Any future or external caller feeding raw URLSession chunks (the natural usage) will intermittently lose events exactly when responses contain non-ASCII text — corrupted transcripts that are near-impossible to reproduce.
+
+
+**建议：** Buffer raw bytes in the parser and only decode up to the last complete UTF-8 sequence boundary (retain the trailing partial bytes for the next ingest), or make the parser byte-oriented and decode per-line.
+
+### L12. Every run emits a duplicate turnStart event because runLoop is entered with firstTurn: false
+
+`Sources/KWWKAgent/AgentLoop.swift:138` · 正确性 — KWWKAgent
+
+
+**证据：** AgentLoop.run emits `.turnStart` (line 130) and then calls `runLoop(currentContext:firstTurn: false, ...)`; inside runLoop the first iteration hits `if !firstTurn { await emit(.turnStart) }` (line 253) and emits a second `.turnStart` before any turnEnd. runContinue has the same shape. The pi reference passes `firstTurn = true` into its inner loop precisely to skip this (pi-mono agent-loop.ts line 165).
+
+
+**影响：** SDK consumers that pair turnStart/turnEnd (turn counters, per-turn timers, transcript segmenters) see two turn_start events for one turn on every single run — an off-by-one that silently corrupts turn-based accounting. Nothing in-repo consumes turnStart today, which is why it went unnoticed.
+
+
+**建议：** Pass `firstTurn: true` from run()/runContinue() so the pre-emitted turnStart is consumed by the first iteration, matching pi's semantics.
+
+### L13. A stall notification permanently suppresses the task's completion notification, breaking the tool's promise that the model "will be notified on completion"
+
+`Sources/KWWKAgent/BackgroundTaskManager.swift:526` · 正确性 — KWWKAgent
+
+
+**证据：** stallTick enqueues a `stalled` notification and sets `tasks[taskId]?.notified = true` (line 526); complete() later runs `if !entry.notified { enqueueNotification(...) }` (line 366) and therefore skips the completion notification. The bash tool result explicitly tells the model: "You will receive a <task-notification> user message when it completes."
+
+
+**影响：** A background `apt-get install`-style task that prints a prompt-like line ("Do you want to continue? [Y/n]") triggers a stall notification; if the process then proceeds and finishes (default answer, timeout, buffered input), no completion notification is ever delivered. The agent, told to "not poll", waits indefinitely for a message that cannot arrive, and the user sees a hung session unless the model spontaneously calls wait_task.
+
+
+**建议：** Track stall and completion notification flags separately (suppress duplicate stalls, but always deliver the terminal completion/failure notification), or reset `notified` when output growth resumes after a stall.
+
+### L14. CodingTools.all is identical to .standard and, contrary to its name, excludes tmux
+
+`Sources/KWWKAgent/CodingTools.swift:38` · SDK DX — KWWKAgent
+
+
+**证据：** `.standard` (lines 33-35) and `.all` (lines 38-40) contain the exact same ten... nine flags; `.all` is commented "Everything except tmux" and a third name `.allIncludingTmux` (line 43) holds the actual full set. Also, `.standard`/`.all` include `.taskStatus` and `.waitTask`, which buildCodingToolList silently drops when no backgroundManager is supplied (CodingAgentBuilder.swift:259-264).
+
+
+**影响：** A developer choosing between `.standard` and `.all` reasonably assumes they differ; `.all` not meaning "all" and two of its members evaporating depending on an unrelated config field (backgroundManager) makes the option set's behavior non-obvious from the call site.
+
+
+**建议：** Drop `.all` (or make it a deprecated alias of `.standard`), rename `.allIncludingTmux` to `.all`, and document the backgroundManager dependency on the individual flags rather than only on the type doc.
+
+### L15. Glob patterns containing [ ] are passed unescaped into the regex, silently matching wrong files or nothing
+
+`Sources/KWWKAgent/Glob.swift:31` · 正确性 — KWWKAgent
+
+
+**证据：** patternToRegex escapes only `"().+|^$\\{}"`; `[` and `]` fall through to the literal-append branch. `matches` then does `path.range(of: regex, options: .regularExpression)` — an unbalanced `[` yields an invalid regex, for which range(of:) returns nil for every path.
+
+
+**影响：** `find` with a pattern like `page[1].tsx` (bracket characters are common in Next.js route filenames: `[id].tsx`, `[...slug].ts`) matches `pageid.tsx`-style names via an unintended character class, or — with an unclosed bracket — silently returns "No files match" for files that exist, sending the model down a wrong path with no error signal.
+
+
+**建议：** Escape `[` and `]` (and validate the final regex, falling back to literal comparison on failure) in patternToRegex.
+
+### L16. ReadToolOptions.autoResizeImages is a dead option: images are never resized and unbounded image bytes are base64-inlined
+
+`Sources/KWWKAgent/ReadTool.swift:89` · 正确性 — KWWKAgent
+
+
+**证据：** `autoResizeImages` is stored on ReadToolOptions (lines 5-16) but never read anywhere in the module (grep shows only the declaration/init). The image branch does `let buffer = try await ops.readFile(absolutePath); let base64 = buffer.base64EncodedString()` with no size check, unlike the text branch which enforces maxBytes.
+
+
+**影响：** An API caller who sets `autoResizeImages: true` (the default!) reasonably expects pi-style downscaling; instead a `read` of a 20MB screenshot injects ~27MB of base64 into the request, typically producing a provider 400/413 or an enormous bill. The option's existence actively misleads.
+
+
+**建议：** Either implement resizing/size-capping for the image path (reject or downscale above a byte threshold) or delete the option until it does something.
+
+### L17. read tool loads the entire file into memory and splits every line even when only an offset/limit window is requested
+
+`Sources/KWWKAgent/ReadTool.swift:102` · 性能
+
+
+**证据：** The text path does `try await ops.readFile(absolutePath)` (Data(contentsOf:) of the whole file, line 27), decodes all of it to a String, then `text.components(separatedBy: "\n")` materializes an array of every line — before offset/limit slicing and the maxLines/maxBytes truncation are applied.
+
+
+**影响：** Asking the model to read a window of a large artifact (a 1-2GB build log or JSONL dump) allocates the entire file in memory twice (Data + String) plus a per-line array, potentially causing multi-second stalls or memory pressure, when only ~2000 lines were ever going to be returned.
+
+
+**建议：** Stream the file: read incrementally (FileHandle chunks), count newlines to skip to `offset`, and stop after `limit`/maxBytes lines are collected. At minimum, stat the file and bail out with a helpful error above some size threshold.
+
+### L18. Session transcripts are persisted world-readable while the same content in background task logs is deliberately locked to 0600
+
+`Sources/KWWKAgent/SessionStore.swift:293` · 副作用/全局状态
+
+
+**证据：** `ensureDirectory()` calls `createDirectory(at:withIntermediateDirectories:)` with no attributes (default 0755) and `create(id:)`/`appendEntry` write `<id>.jsonl` with default 0644 permissions. Contrast BashTool.swift:615-628, where the same project deliberately creates the background-output directory with `[.posixPermissions: 0o700]` and each log file with `0o600`. The JSONL transcript contains the full conversation plus every tool result — including bash output, which is exactly the data the 0600 task logs protect (and, via the tmux env-inheritance issue above, potentially `env` dumps with API keys). Note ~/.kwwk itself is only created 0700 if the OAuth store made it first; SessionStore.ensureDirectory can be the creator when a user runs kwwk before ever logging in via OAuth (env-key auth), leaving ~/.kwwk itself 0755.
+
+
+**影响：** On shared machines, other local users can read complete agent transcripts — proprietary code, prompts, and any secrets echoed by tools — even though the project's own task-log handling shows the authors consider this class of data sensitive.
+
+
+**建议：** Create the sessions directory with 0700 and session files with 0600, mirroring BackgroundTaskManager.allocateForegroundOutputFile.
+
+### L19. Built-in subagent names have inconsistent casing and lookup is case-sensitive, unlike the selection parser
+
+`Sources/KWWKAgent/SubagentDefinition.swift:127` · SDK DX — KWWKAgent
+
+
+**证据：** Built-ins are named "general" (lowercase, line 98) but "Explore" (line 127) and "Plan" (line 152) capitalized. SubagentRegistry.definition and SubagentRunner.definition(named:) do exact dictionary/equality matches (SubagentTool.swift:385-387, 696-699), while BuiltinSubagentSelection.named() lowercases its input (SubagentDefinition.swift:59). The README itself directs `runner.run(type: "Plan", ...)`. Additionally SubagentRegistry keeps the last duplicate definition but the first name-order slot (SubagentTool.swift:374-380), silently overriding earlier definitions — the opposite of Skills.load, where the first duplicate wins (Skills.swift:298).
+
+
+**影响：** `runner.run(type: "plan")` throws "unknown type 'plan'. Available subagents: general, Explore, Plan" — a needless failure for both SDK callers and models emitting `subagent_type`. Duplicate subagent names silently shadow each other with a policy inconsistent with the neighboring Skills subsystem.
+
+
+**建议：** Normalize subagent names to lowercase (or make lookups case-insensitive), and make duplicate handling explicit and consistent (first-wins with a diagnostic, matching Skills).
+
+### L20. CLI startup performs OAuth token refresh/exchange network calls for every stored login, not just the session's active provider
+
+`Sources/KWWKCli/AuthResolver.swift:183` · 副作用/全局状态
+
+
+**证据：** `registerAllStored` loops over every store id and each register function eagerly primes credentials before any prompt is sent: `_ = try? await manager.apiKey(for: "openai-codex")` (line 514), `_ = try? await manager.apiKey(for: "anthropic")` (line 561), `_ = try? await manager.apiKey(for: "github-copilot")` (line 614). OAuthManager.apiKey refreshes whenever `isExpired`, and GitHub Copilot's "refresh" is a PAT→session-token exchange whose token is short-lived, so it round-trips github.com on essentially every launch even when the user only intends to use, say, Anthropic this session. The Copilot resolver itself would refresh on demand at first request (AuthResolver.swift:887-897), so the launch-time priming is not required for correctness of the other providers.
+
+
+**影响：** Every kwwk launch with multiple stored logins fires N sequential token-refresh requests before the TUI is usable — added startup latency, needless traffic to providers the session never touches, and refresh-token rotation churn on accounts the user did not intend to exercise (a failure/ratelimit on an unused provider's refresh happens invisibly at startup).
+
+
+**建议：** Register providers lazily and let each `oauthResolver` perform the refresh on first actual request (the code path already exists); only prime the active provider, and fetch Copilot's `extras["endpoint"]` from the stored credentials without forcing a token exchange.
+
+### L21. Single-tap Ctrl-C exits the whole app instantly — even mid-stream — where pi requires a double-press and uses the first press to clear the editor
+
+`Sources/KWWKCli/CodingTUI.swift:885` · TUI 用户体验 ·（对抗验证后降级）
+
+
+**证据：** `runner.bind(.ctrl("c")) { … await agent.abortAndKillBackgroundTasks(); runner.exit() }` — one keypress kills all background tasks and quits, regardless of streaming state or a draft in the input. pi-mono's interactive mode binds ctrl+c to "Clear editor" and only shuts down on a second press within 500ms (interactive-mode.ts:3227-3235, hint "ctrl+c twice to exit").
+
+
+**影响：** Ctrl-C is deeply wired muscle memory for "stop the current thing" — a user reflexively hitting it to interrupt a generation (instead of the less conventional Esc) instantly loses their draft, kills every background task, and exits the app. There is no confirmation and no grace window; recovery requires relaunching with --continue.
+
+
+**建议：** Adopt the pi/Claude Code convention: first Ctrl-C aborts the stream (if streaming) or clears the input, and only a second press within ~500ms exits; surface the "press again to exit" hint in the state line. Keep Ctrl-D-on-empty as the deliberate quit.
+
+### L22. Background-task status poll repaints the idle UI and queries the task actor 4 times per second even when nothing is running
+
+`Sources/KWWKCli/CodingTUI.swift:968` · 性能
+
+
+**证据：** frameStatusTask loops forever: every 250ms it awaits `bgManager.list(sessionId:)`, calls updateFrameStatus() (which rebuilds breadcrumb/meta strings and queries agent state and the goal store), and calls `runner.tui.requestRender()` unconditionally — with no check that anything changed and no gating on activity. This contradicts the adjacent spinnerTask comment (lines 982-983): "so an idle prompt isn't redrawn ~11x/s for no reason" — it is still redrawn 4x/s by this task, and (per the TUI finding above) each redraw rewrites the whole live zone.
+
+
+**影响：** A kwwk instance sitting idle at the prompt performs continuous actor hops, string formatting, and full live-zone terminal writes 4 times per second indefinitely — wasted CPU wakeups and battery drain on laptops, and constant redraw traffic for terminals that render on output.
+
+
+**建议：** Skip updateFrameStatus/requestRender when the computed status is unchanged (compare the previous running-count/status tuple), and back the poll off (or park the task entirely) while the agent is idle and no background tasks exist, resuming on task spawn.
+
+### L23. Kitty CSI-u decoding only maps letters and five named keys, so Ctrl+_ / Ctrl+/ undo (and other modified punctuation) dies on kitty-protocol terminals kwwk itself opts into
+
+`Sources/KWWKCli/Keys.swift:161` · TUI 用户体验
+
+
+**证据：** TUIRunner enables the kitty keyboard protocol (`ESC[>1u`, TUIRunner.swift:93), under which modified keys arrive as CSI-u. kittyKeyName maps only tab/enter/escape/space/backspace and a–z/A–Z; every other keycode returns nil, parse returns nil, and InputComponent.handleInput drops ESC-prefixed data (InputComponent.swift:609). Ctrl+_ (keycode 95) and Ctrl+/ (keycode 47) — the advertised undo chords (InputComponent.swift:631-634) — therefore parse to nothing on kitty/Ghostty/foot, while on legacy terminals they work via the raw 0x1F byte.
+
+
+**影响：** On exactly the modern terminals that honor kwwk's own protocol opt-in, undo via Ctrl+_ / Ctrl+/ silently does nothing (and other modified punctuation/digit chords are swallowed), an inconsistency users can't diagnose — the /hotkeys help still advertises the binding.
+
+
+**建议：** Extend kittyKeyName to cover the printable ASCII range (map the keycode to its character, deriving shift from the shifted-key field or uppercase range) so CSI-u punctuation and digits resolve; at minimum map 95 → "_" and 47 → "/" and route ctrl+"/" to undo.
+
+### L24. `kwwk --resume` drops to a bare numbered stdin prompt while `/resume` inside the TUI gets the polished arrow-key picker
+
+`Sources/KWWKCli/SessionPicker.swift:45` · TUI 用户体验
+
+
+**证据：** SessionPicker.choose prints a plain text menu to stderr and reads one line from cooked stdin (`FileHandle.standardInput.read(upToCount: 1024)`), requiring the user to type an index number; any non-number cancels and exits 0 ("No session selected", CodingTUI.swift:35-41). The in-session `/resume` command opens SessionResumeModal with arrow keys, titles, relative ages, windowing and `· current` tags. pi's --resume shows its full SessionSelectorComponent.
+
+
+**影响：** The very first interaction a returning user has with the app (resuming from the shell) is its least polished: no arrow keys, no highlighting, session ids truncated into a dense line, and a stray Enter cancels straight to exit. It also renders no titles styling consistent with the rest of the product, undercutting the stated goal of a polished first-run experience.
+
+
+**建议：** Boot a minimal TUIRunner with the existing SessionResumeModal (or a standalone raw-mode list using ModalListCore) for --resume, falling back to the numbered prompt only when stdin/stdout isn't a TTY.
+
+### L25. Normal render path erases and rewrites the entire live zone every frame with no diffing and no synchronized-output guard
+
+`Sources/KWWKCli/TUI.swift:487` · TUI 用户体验
+
+
+**证据：** renderInline unconditionally clears all oldHeight rows (`for i in 0..<oldHeight { out += "\u{1B}[2K" … }`) and repaints every live row on every requestRender — which fires per keystroke, per agent event, and at ~11Hz from the spinner tick while streaming. lastRenderedLines is stored (TUI.swift:434) but never compared, and unlike fullRepaint/multiplexerRepaint the inline path is not wrapped in DEC 2026 synchronized output. pi-tui diffs against previousLines and repaints only changed rows inside a ?2026h/?2026l bracket (tui.ts:1053-1145).
+
+
+**影响：** With a tall live zone (running tool blocks + queue list + prompt box) the terminal receives a full clear+rewrite many times per second during streaming. On terminals without atomic-write coalescing, over SSH, or under load, this shows as flicker/shimmer of the input box and status line — precisely the polish gap versus pi the project aims to close.
+
+
+**建议：** Wrap the inline frame in \u{1B}[?2026h … \u{1B}[?2026l (already done for the repaint paths), and short-circuit when rendered == lastRenderedLines (cursor-only moves can reposition without repainting). Full per-line diffing à la pi-tui is a further step but the two cheap changes remove most of the churn.
+
+### L26. TranscriptRenderer re-derives the full assistant text snapshot and does O(n) character-index math on every stream delta, O(n^2) over a long message
+
+`Sources/KWWKCli/TranscriptRenderer.swift:382` · 性能 ·（对抗验证后降级）
+
+
+**证据：** ingestAssistantText runs on every `.messageUpdate` (line 174). It calls assistantTextSnapshot(assistant), which concatenates all text blocks into a fresh String; then `snapshot.count` (O(chars) grapheme walk), `snapshot.index(snapshot.startIndex, offsetBy: assistantIngestedCharacters)` (another O(chars) walk), and a substring copy — all proportional to the total message length so far, per delta.
+
+
+**影响：** A 20KB assistant response arriving in ~1000 deltas performs on the order of 30M grapheme-cluster traversals plus 1000 full-string rebuilds on the MainActor render path. Long responses make token rendering measurably lag toward the end of the message, competing with input handling on the same actor.
+
+
+**建议：** Consume the delta payload the event already carries (AssistantMessageEvent.textDelta includes the delta string) instead of re-deriving the full snapshot, or track ingestion with a stored String.Index per block so no offsetBy walk is needed.

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ let anthropicAPIKey = "sk-ant-..."
 await registerBuiltins(anthropic: anthropicAPIKey)
 
 // 2. Build a coding agent scoped to a working directory.
-let agent = await makeCodingAgent(CodingAgentConfig(
+let agent = try await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet5,
     cwd: FileManager.default.currentDirectoryPath,
     tools: .readOnly,
     bashEnvironment: [:]
-))
+)).agent
 
 // 3. Drive it.
 try await agent.prompt("Summarize the Swift files under Sources/KWWKAgent.")
@@ -130,7 +130,7 @@ let reviewer = SubagentDefinition(
 
 let bg = BackgroundTaskManager()
 let shellEnvironment = ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
-let agent = await makeCodingAgent(CodingAgentConfig(
+let coding = try await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet5,
     cwd: FileManager.default.currentDirectoryPath,
     tools: .standard,
@@ -139,20 +139,24 @@ let agent = await makeCodingAgent(CodingAgentConfig(
     bashEnvironment: shellEnvironment
 ))
 
-try await agent.prompt("Use the reviewer subagent to review Sources/KWWKAgent.")
+try await coding.agent.prompt("Use the reviewer subagent to review Sources/KWWKAgent.")
+
+// With a backgroundManager, completed background tasks auto-continue the
+// agent (new LLM runs start on their own). Call `coding.detachBackground?()`
+// to unsubscribe when embedding.
 ```
 
 For the same built-ins that the CLI uses, SDK users can opt in without
 copying prompts:
 
 ```swift
-let agent = await makeCodingAgent(CodingAgentConfig(
+let agent = try await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet5,
     cwd: FileManager.default.currentDirectoryPath,
     tools: .standard,
     backgroundManager: BackgroundTaskManager(),
     bashEnvironment: shellEnvironment
-).withBuiltinSubagents([.general, .explore, .plan]))
+).withBuiltinSubagents([.general, .explore, .plan])).agent
 ```
 
 SDK users can also run a subagent directly:
@@ -333,7 +337,7 @@ Task {
 }
 
 // later, from any thread:
-agent.steer(UserMessage(text: "also add tests as you go"))
+agent.steer("also add tests as you go")
 ```
 
 ### Providers

--- a/Sources/KWWKAI/APIRegistry.swift
+++ b/Sources/KWWKAI/APIRegistry.swift
@@ -36,6 +36,12 @@ public actor APIRegistry {
     public static let shared = APIRegistry()
 
     private var providers: [String: APIProvider] = [:]
+    /// `api → the model.provider vendor a flat registration belongs to`, when
+    /// the caller declared it. Gates the flat fallback in
+    /// `provider(scope:api:)` so a scoped miss can never route to a provider
+    /// registered for a *different* vendor (which would send that vendor's
+    /// key to the model's foreign `baseURL`).
+    private var flatVendor: [String: String] = [:]
     /// `providerScope → api → provider`. Populated when `register` is given a
     /// `scope`. Looked up first by `stream`, keyed on `model.provider`.
     private var scoped: [String: [String: APIProvider]] = [:]
@@ -49,7 +55,18 @@ public actor APIRegistry {
     /// its `api` (legacy behavior). With `scope`, it also lands in the
     /// provider-scoped map under `(scope, api)` so it can coexist with other
     /// providers sharing the same wire `api`.
-    public func register(_ provider: APIProvider, scope: String? = nil, sourceId: String? = nil) {
+    ///
+    /// `providerVendor` tags a flat registration with the model `provider` it
+    /// serves. When set, the flat fallback in `provider(scope:api:)` only
+    /// matches models of that vendor — required so a single-login Anthropic
+    /// key isn't handed to, say, a GitHub-Copilot model that happens to share
+    /// the `anthropic-messages` wire. Ignored for scoped registrations.
+    public func register(
+        _ provider: APIProvider,
+        scope: String? = nil,
+        sourceId: String? = nil,
+        providerVendor: String? = nil
+    ) {
         if let scope, !scope.isEmpty {
             scoped[scope, default: [:]][provider.api] = provider
             if let sourceId {
@@ -57,6 +74,11 @@ public actor APIRegistry {
             }
         } else {
             providers[provider.api] = provider
+            if let providerVendor {
+                flatVendor[provider.api] = providerVendor
+            } else {
+                flatVendor.removeValue(forKey: provider.api)
+            }
             if let sourceId {
                 bySource[sourceId, default: []].insert("\u{1}\(provider.api)")
             }
@@ -68,13 +90,18 @@ public actor APIRegistry {
     }
 
     /// Resolve the provider for a model: prefer a provider-scoped match on
-    /// `(scope, api)`, then fall back to the flat `api` map.
+    /// `(scope, api)`, then fall back to the flat `api` map — but never fall
+    /// back to a flat provider tagged for a different vendor.
     public func provider(scope: String, api: String) -> APIProvider? {
-        scoped[scope]?[api] ?? providers[api]
+        if let scopedMatch = scoped[scope]?[api] { return scopedMatch }
+        guard let flat = providers[api] else { return nil }
+        if let vendor = flatVendor[api], vendor != scope { return nil }
+        return flat
     }
 
     public func unregister(api: String) {
         providers.removeValue(forKey: api)
+        flatVendor.removeValue(forKey: api)
         for key in bySource.keys {
             bySource[key]?.remove("\u{1}\(api)")
         }
@@ -95,6 +122,7 @@ public actor APIRegistry {
             let api = String(key[key.index(after: sep)...])
             if scope.isEmpty {
                 providers.removeValue(forKey: api)
+                flatVendor.removeValue(forKey: api)
             } else {
                 scoped[scope]?.removeValue(forKey: api)
                 if scoped[scope]?.isEmpty == true { scoped.removeValue(forKey: scope) }
@@ -117,21 +145,48 @@ public enum ProviderNotFoundError: Error, Equatable {
     case api(String)
 }
 
+/// Thrown by `complete()` when the drained stream finished in an error state,
+/// so a runtime failure surfaces as a thrown error rather than an ordinary
+/// message whose `stopReason` a caller might not inspect. `message` carries
+/// the finished assistant message (including `errorMessage`).
+public struct CompletionFailedError: Error, LocalizedError {
+    public let message: AssistantMessage
+    public init(message: AssistantMessage) { self.message = message }
+    public var errorDescription: String? {
+        message.errorMessage ?? "completion failed"
+    }
+}
+
 /// Top-level streaming entry point. Looks up the registered provider for the
 /// model's `api` and delegates to it. Throws if no provider is registered.
-public func stream(model: Model, context: Context, options: StreamOptions? = nil) async throws -> AssistantMessageStream {
-    guard let provider = await APIRegistry.shared.provider(scope: model.provider, api: model.api) else {
+public func stream(
+    model: Model,
+    context: Context,
+    options: StreamOptions? = nil,
+    registry: APIRegistry = .shared
+) async throws -> AssistantMessageStream {
+    guard let provider = await registry.provider(scope: model.provider, api: model.api) else {
         throw ProviderNotFoundError.api(model.api)
     }
     return provider.stream(model: model, context: context, options: options)
 }
 
 /// Convenience: run a stream to completion and return the final message.
-public func complete(model: Model, context: Context, options: StreamOptions? = nil) async throws -> AssistantMessage {
-    let s = try await stream(model: model, context: context, options: options)
+/// Throws `CompletionFailedError` if the stream finished in an error state.
+public func complete(
+    model: Model,
+    context: Context,
+    options: StreamOptions? = nil,
+    registry: APIRegistry = .shared
+) async throws -> AssistantMessage {
+    let s = try await stream(model: model, context: context, options: options, registry: registry)
     // Drain events so producers aren't blocked waiting for consumption.
     for await _ in s {}
-    return await s.result()
+    let message = await s.result()
+    if message.stopReason == .error {
+        throw CompletionFailedError(message: message)
+    }
+    return message
 }
 
 /// Close provider-owned resources associated with a session id across every

--- a/Sources/KWWKAI/AWSEventStream.swift
+++ b/Sources/KWWKAI/AWSEventStream.swift
@@ -19,14 +19,14 @@ public struct AWSEventMessage: Sendable {
 /// We only decode string-typed values (type 7) and short values for the rest —
 /// everything Bedrock Converse Stream actually emits.
 public func parseAWSEventStream(
-    bytes: AsyncThrowingStream<UInt8, Error>
+    bytes: AsyncThrowingStream<Data, Error>
 ) -> AsyncThrowingStream<AWSEventMessage, Error> {
     AsyncThrowingStream { continuation in
         let task = Task {
             var buffer = Data()
             do {
-                for try await byte in bytes {
-                    buffer.append(byte)
+                for try await chunk in bytes {
+                    buffer.append(chunk)
                     while buffer.count >= 12 {
                         let totalLen = Int(readU32BE(buffer, offset: 0))
                         if totalLen <= 0 || totalLen > 1 << 20 {

--- a/Sources/KWWKAI/AnthropicProvider.swift
+++ b/Sources/KWWKAI/AnthropicProvider.swift
@@ -4,15 +4,15 @@ import FoundationNetworking
 #endif
 
 /// Anthropic Messages streaming provider. Implements the `anthropic-messages`
-/// API against a pluggable `HTTPClient`.
+/// API against a pluggable `HTTPClient`. Supports API-key and OAuth bearer auth
+/// (via `authHeaderBuilder`), `anthropic-beta` opt-in headers, prompt-cache
+/// breakpoints, and extended/adaptive thinking.
 ///
 /// Non-goals for this implementation:
-///  - OAuth bearer tokens, anthropic-beta opt-in headers
-///  - Cache-control placement heuristics
-///  - Rate-limit retry with `retry-after` parsing
+///  - Rate-limit retry with `retry-after` parsing (handled by the agent loop)
 ///
-/// These are tracked in follow-up work; for now the provider is testable via a
-/// URLProtocol mock and produces the standard AssistantMessageEvent stream.
+/// The provider is testable via a stub `HTTPClient` and produces the standard
+/// AssistantMessageEvent stream.
 public final class AnthropicProvider: APIProvider, @unchecked Sendable {
     public typealias AuthHeaderBuilder = @Sendable (String) -> [String: String]
 
@@ -71,7 +71,7 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
         options: StreamOptions?
     ) async {
         let url: URL = {
-            var base = model.baseUrl.isEmpty ? defaultBaseURL.absoluteString : model.baseUrl
+            var base = model.baseURL.isEmpty ? defaultBaseURL.absoluteString : model.baseURL
             while base.hasSuffix("/") { base.removeLast() }
             return URL(string: "\(base)/v1/messages") ?? defaultBaseURL.appendingPathComponent("v1/messages")
         }()
@@ -173,11 +173,23 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
                 modelId: model.id
             )
             state.signal = options?.cancellation
-            try await drive(events: parseSSE(bytes: stream), out: out, state: state)
+            // Bridge external cancellation to the in-flight request: cancelling
+            // the drive task tears down the SSE/byte streams, which aborts the
+            // underlying URLSession task even during a silent stream gap.
+            let driveTask = Task { try await self.drive(events: parseSSE(bytes: stream), out: out, state: state) }
+            let cancelReg = options?.cancellation?.onCancel { _ in driveTask.cancel() }
+            defer { cancelReg?.cancel() }
+            try await driveTask.value
         } catch {
-            let msg = Self.makeError(model: model, api: api, text: "\(error)")
-            out.push(.error(reason: .error, error: msg))
-            out.end(msg)
+            if options?.cancellation?.isCancelled == true {
+                let aborted = Self.makeAborted(model: model, api: api)
+                out.push(.error(reason: .aborted, error: aborted))
+                out.end(aborted)
+            } else {
+                let msg = Self.makeError(model: model, api: api, text: "\(error)")
+                out.push(.error(reason: .error, error: msg))
+                out.end(msg)
+            }
         }
     }
 
@@ -282,7 +294,13 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
             case "message_delta":
                 if case .object(let delta) = obj["delta"] ?? .null,
                    case .string(let reason) = delta["stop_reason"] ?? .null {
-                    state.stopReason = mapStopReason(reason)
+                    let mapped = mapStopReason(reason)
+                    state.stopReason = mapped
+                    // A `refusal`/`sensitive`/unknown stop reason is not a clean
+                    // completion — record it so `message_stop` surfaces `.error`.
+                    if mapped == .error {
+                        state.errorMessage = "Anthropic stop reason: \(reason)"
+                    }
                 }
                 if case .object(let usage) = obj["usage"] ?? .null {
                     state.applyUsageDelta(usage)
@@ -290,7 +308,11 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
 
             case "message_stop":
                 let final = state.finalize()
-                out.push(.done(reason: final.stopReason, message: final))
+                if final.stopReason == .error {
+                    out.push(.error(reason: .error, error: final))
+                } else {
+                    out.push(.done(reason: final.stopReason, message: final))
+                }
                 out.end(final)
                 return
 
@@ -309,10 +331,19 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
             }
         }
 
-        // Upstream closed without message_stop.
-        let final = state.finalize()
-        out.push(.done(reason: final.stopReason, message: final))
-        out.end(final)
+        // Loop ended without message_stop.
+        if state.signal?.isCancelled == true {
+            let aborted = state.asAborted()
+            out.push(.error(reason: .aborted, error: aborted))
+            out.end(aborted)
+            return
+        }
+        // A clean half-close mid-message is a truncated turn, not a success —
+        // surface it as an error so the agent loop can retry, mirroring
+        // OpenAICompletionsProvider's missing-finish_reason handling.
+        let err = state.asError(text: "Anthropic stream ended before message_stop")
+        out.push(.error(reason: .error, error: err))
+        out.end(err)
     }
 
     // MARK: - Helpers
@@ -594,6 +625,19 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
             timestamp: Timestamp.now()
         )
     }
+
+    private static func makeAborted(model: Model, api: String) -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Request was aborted",
+            timestamp: Timestamp.now()
+        )
+    }
 }
 
 /// Mutable state the Anthropic stream driver mutates while consuming SSE.
@@ -715,19 +759,26 @@ final class AnthropicStreamState: @unchecked Sendable {
             case .text(let t): return .text(t.text)
             case .thinking(let th): return .thinking(th.thinking)
             case .toolUse(let id, let name, let json):
-                let parsed: JSONValue = {
-                    if let data = json.data(using: .utf8),
-                       let v = try? JSONDecoder().decode(JSONValue.self, from: data) { return v }
-                    return .object([:])
-                }()
-                let call = ToolCall(id: id, name: name, arguments: parsed)
+                let call = ToolCall(id: id, name: name, arguments: Self.parseToolJSON(json))
                 blocks[index] = .toolUse(id: id, name: name, json: json)
                 return .toolCall(call)
             }
         }
     }
 
-    func snapshot() -> AssistantMessage {
+    static func parseToolJSON(_ json: String) -> JSONValue {
+        if let data = json.data(using: .utf8),
+           let v = try? JSONDecoder().decode(JSONValue.self, from: data) { return v }
+        return .object([:])
+    }
+
+    /// Streaming snapshot. In-progress tool calls are represented with an empty
+    /// object rather than re-parsing the (usually incomplete) argument buffer on
+    /// every delta — that reparse is O(n) per delta, O(n^2) over a tool call.
+    /// The complete arguments are parsed once in `finishBlock`/`finalize`.
+    func snapshot() -> AssistantMessage { buildMessage(parseToolArgs: false) }
+
+    private func buildMessage(parseToolArgs: Bool) -> AssistantMessage {
         lock.withLock {
             var content: [AssistantBlock] = []
             for i in orderedIndices.sorted() {
@@ -736,12 +787,8 @@ final class AnthropicStreamState: @unchecked Sendable {
                 case .text(let t): content.append(.text(t))
                 case .thinking(let th): content.append(.thinking(th))
                 case .toolUse(let id, let name, let json):
-                    let parsed: JSONValue = {
-                        if let data = json.data(using: .utf8),
-                           let v = try? JSONDecoder().decode(JSONValue.self, from: data) { return v }
-                        return .object([:])
-                    }()
-                    content.append(.toolCall(ToolCall(id: id, name: name, arguments: parsed)))
+                    let args: JSONValue = parseToolArgs ? Self.parseToolJSON(json) : .object([:])
+                    content.append(.toolCall(ToolCall(id: id, name: name, arguments: args)))
                 }
             }
             return AssistantMessage(
@@ -759,7 +806,7 @@ final class AnthropicStreamState: @unchecked Sendable {
     }
 
     func finalize() -> AssistantMessage {
-        var m = snapshot()
+        var m = buildMessage(parseToolArgs: true)
         m.stopReason = stopReason
         return m
     }
@@ -779,11 +826,14 @@ final class AnthropicStreamState: @unchecked Sendable {
 
 func mapStopReason(_ raw: String) -> StopReason {
     switch raw {
-    case "end_turn": return .stop
+    case "end_turn", "stop_sequence": return .stop
     case "max_tokens": return .length
     case "tool_use": return .toolUse
-    case "stop_sequence": return .stop
-    default: return .stop
+    // pi maps a refused / safety-filtered turn to an error rather than a clean
+    // stop; unknown reasons are surfaced the same way (rather than silently
+    // masquerading as a successful completion) so new API values are caught.
+    case "refusal", "sensitive": return .error
+    default: return .error
     }
 }
 

--- a/Sources/KWWKAI/AssistantMessageStream.swift
+++ b/Sources/KWWKAI/AssistantMessageStream.swift
@@ -4,23 +4,38 @@ import Foundation
 /// final settled `AssistantMessage` via `result()`. The stream never throws
 /// from iteration — errors are encoded as `.error(...)` events and reflected
 /// in the final message's `stopReason`.
+///
+/// This is the **consumer** surface. It is single-consumer: exactly one task
+/// should iterate it (and optionally await `result()`). Producers push events
+/// through the paired `Continuation` obtained from `makeStream()`; providers
+/// inside this module push directly. Iteration and `result()` are
+/// cancellation-aware — cancelling the consuming task resumes them promptly
+/// (iteration ends, `result()` returns an aborted message).
 public final class AssistantMessageStream: AsyncSequence, Sendable {
     public typealias Element = AssistantMessageEvent
 
-    private let state = StreamState()
+    let state = StreamState()
 
-    public init() {}
+    init() {}
 
-    // MARK: - Producer API
+    /// Create a consumer stream paired with a producer `Continuation`. External
+    /// providers use this to feed events without exposing `push`/`end` on the
+    /// consumer object handed to callers.
+    public static func makeStream() -> (stream: AssistantMessageStream, continuation: Continuation) {
+        let stream = AssistantMessageStream()
+        return (stream, Continuation(state: stream.state))
+    }
+
+    // MARK: - Producer API (internal — in-module providers push directly)
 
     /// Push an event into the stream. Safe to call from any task.
-    public func push(_ event: AssistantMessageEvent) {
+    func push(_ event: AssistantMessageEvent) {
         state.push(event)
     }
 
     /// Mark the stream as finished and record the final settled message.
     /// Further `push` calls after `end` are ignored.
-    public func end(_ message: AssistantMessage) {
+    func end(_ message: AssistantMessage) {
         state.end(message)
     }
 
@@ -41,14 +56,32 @@ public final class AssistantMessageStream: AsyncSequence, Sendable {
             await state.nextEvent()
         }
     }
+
+    /// Producer handle for an `AssistantMessageStream`. Obtained from
+    /// `makeStream()`; hands events and the final message to the paired
+    /// consumer stream.
+    public struct Continuation: Sendable {
+        let state: StreamState
+
+        /// Push an event into the stream. Safe to call from any task.
+        public func push(_ event: AssistantMessageEvent) {
+            state.push(event)
+        }
+
+        /// Mark the stream finished and record the final settled message.
+        /// Further `push` calls are ignored.
+        public func end(_ message: AssistantMessage) {
+            state.end(message)
+        }
+    }
 }
 
 /// Thread-safe queue + awaiters for `AssistantMessageStream`.
 public final class StreamState: @unchecked Sendable {
     private let lock = NSLock()
     private var buffer: [AssistantMessageEvent] = []
-    private var eventWaiters: [CheckedContinuation<AssistantMessageEvent?, Never>] = []
-    private var resultWaiters: [CheckedContinuation<AssistantMessage, Never>] = []
+    private var eventWaiters: [(id: UUID, cont: CheckedContinuation<AssistantMessageEvent?, Never>)] = []
+    private var resultWaiters: [(id: UUID, cont: CheckedContinuation<AssistantMessage, Never>)] = []
     private var ended = false
     private var finalMessage: AssistantMessage?
 
@@ -61,7 +94,7 @@ public final class StreamState: @unchecked Sendable {
         if let waiter = eventWaiters.first {
             eventWaiters.removeFirst()
             lock.unlock()
-            waiter.resume(returning: event)
+            waiter.cont.resume(returning: event)
             return
         }
         buffer.append(event)
@@ -69,8 +102,8 @@ public final class StreamState: @unchecked Sendable {
     }
 
     func end(_ message: AssistantMessage) {
-        let eventWaitersToNotify: [CheckedContinuation<AssistantMessageEvent?, Never>]
-        let resultWaitersToNotify: [CheckedContinuation<AssistantMessage, Never>]
+        let eventWaitersToNotify: [(id: UUID, cont: CheckedContinuation<AssistantMessageEvent?, Never>)]
+        let resultWaitersToNotify: [(id: UUID, cont: CheckedContinuation<AssistantMessage, Never>)]
         lock.lock()
         if ended {
             lock.unlock()
@@ -83,39 +116,91 @@ public final class StreamState: @unchecked Sendable {
         resultWaitersToNotify = resultWaiters
         resultWaiters.removeAll()
         lock.unlock()
-        for w in eventWaitersToNotify { w.resume(returning: nil) }
-        for w in resultWaitersToNotify { w.resume(returning: message) }
+        for w in eventWaitersToNotify { w.cont.resume(returning: nil) }
+        for w in resultWaitersToNotify { w.cont.resume(returning: message) }
     }
 
     func nextEvent() async -> AssistantMessageEvent? {
-        await withCheckedContinuation { (cont: CheckedContinuation<AssistantMessageEvent?, Never>) in
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (cont: CheckedContinuation<AssistantMessageEvent?, Never>) in
+                lock.lock()
+                if !buffer.isEmpty {
+                    let event = buffer.removeFirst()
+                    lock.unlock()
+                    cont.resume(returning: event)
+                    return
+                }
+                if ended {
+                    lock.unlock()
+                    cont.resume(returning: nil)
+                    return
+                }
+                if Task.isCancelled {
+                    lock.unlock()
+                    cont.resume(returning: nil)
+                    return
+                }
+                eventWaiters.append((id: id, cont: cont))
+                lock.unlock()
+            }
+        } onCancel: {
+            // End iteration promptly on consumer-task cancellation. Whichever of
+            // this and a concurrent `push`/`end` removes the waiter first owns
+            // the resume, so there is no double-resume.
             lock.lock()
-            if !buffer.isEmpty {
-                let event = buffer.removeFirst()
+            guard let index = eventWaiters.firstIndex(where: { $0.id == id }) else {
                 lock.unlock()
-                cont.resume(returning: event)
                 return
             }
-            if ended {
-                lock.unlock()
-                cont.resume(returning: nil)
-                return
-            }
-            eventWaiters.append(cont)
+            let waiter = eventWaiters.remove(at: index)
             lock.unlock()
+            waiter.cont.resume(returning: nil)
         }
     }
 
     func awaitResult() async -> AssistantMessage {
-        await withCheckedContinuation { (cont: CheckedContinuation<AssistantMessage, Never>) in
-            lock.lock()
-            if let message = finalMessage {
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (cont: CheckedContinuation<AssistantMessage, Never>) in
+                lock.lock()
+                if let message = finalMessage {
+                    lock.unlock()
+                    cont.resume(returning: message)
+                    return
+                }
+                if Task.isCancelled {
+                    lock.unlock()
+                    cont.resume(returning: Self.cancelledResult())
+                    return
+                }
+                resultWaiters.append((id: id, cont: cont))
                 lock.unlock()
-                cont.resume(returning: message)
+            }
+        } onCancel: {
+            lock.lock()
+            guard let index = resultWaiters.firstIndex(where: { $0.id == id }) else {
+                lock.unlock()
                 return
             }
-            resultWaiters.append(cont)
+            let waiter = resultWaiters.remove(at: index)
             lock.unlock()
+            waiter.cont.resume(returning: Self.cancelledResult())
         }
+    }
+
+    /// Placeholder returned to a consumer that cancels its own `result()` await
+    /// before the producer settled the stream.
+    private static func cancelledResult() -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: "",
+            provider: "",
+            model: "",
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Consumer cancelled before result settled",
+            timestamp: Timestamp.now()
+        )
     }
 }

--- a/Sources/KWWKAI/BedrockProvider.swift
+++ b/Sources/KWWKAI/BedrockProvider.swift
@@ -11,7 +11,7 @@ import FoundationNetworking
 public final class BedrockProvider: APIProvider, @unchecked Sendable {
     public let api: String
     public let client: HTTPClient
-    /// Fallback region used when neither the model ARN, the model `baseUrl`
+    /// Fallback region used when neither the model ARN, the model `baseURL`
     /// host, nor `AWS_REGION`/`AWS_DEFAULT_REGION` pin a region.
     public let region: String
     public let credentialsProvider: @Sendable () async -> AWSSigV4.Credentials?
@@ -78,7 +78,7 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
         }()
         let effectiveRegion = BedrockRegion.resolve(
             modelId: model.id,
-            baseUrl: model.baseUrl,
+            baseURL: model.baseURL,
             env: environment,
             profileRegion: profileRegion
         )
@@ -159,9 +159,20 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
                 url: url, method: "POST", headers: headers, body: body
             )
             if response.statusCode >= 400 {
+                // Surface the error body (a JSON `{message}` on 4xx/5xx) like the
+                // other providers instead of a bare status code.
+                var bodyBytes = Data()
+                for try await chunk in stream {
+                    bodyBytes.append(chunk)
+                    if bodyBytes.count > 4096 { break }
+                }
+                let bodyText = String(data: bodyBytes, encoding: .utf8) ?? ""
+                let preview = bodyText.isEmpty
+                    ? ""
+                    : ": " + bodyText.replacingOccurrences(of: "\n", with: " ").prefix(500)
                 let msg = Self.makeError(
                     api: api, model: model,
-                    text: "Bedrock returned status \(response.statusCode)"
+                    text: "Bedrock returned status \(response.statusCode)\(preview)"
                 )
                 out.push(.error(reason: .error, error: msg))
                 out.end(msg)
@@ -169,11 +180,22 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
             }
             let state = BedrockStreamState(api: api, provider: model.provider, modelId: model.id)
             state.signal = options?.cancellation
-            try await drive(events: parseAWSEventStream(bytes: stream), out: out, state: state)
+            // Bridge external cancellation to the in-flight request (see
+            // AnthropicProvider.run for the rationale).
+            let driveTask = Task { try await self.drive(events: parseAWSEventStream(bytes: stream), out: out, state: state) }
+            let cancelReg = options?.cancellation?.onCancel { _ in driveTask.cancel() }
+            defer { cancelReg?.cancel() }
+            try await driveTask.value
         } catch {
-            let msg = Self.makeError(api: api, model: model, text: "\(error)")
-            out.push(.error(reason: .error, error: msg))
-            out.end(msg)
+            if options?.cancellation?.isCancelled == true {
+                let aborted = Self.makeAborted(api: api, model: model)
+                out.push(.error(reason: .aborted, error: aborted))
+                out.end(aborted)
+            } else {
+                let msg = Self.makeError(api: api, model: model, text: "\(error)")
+                out.push(.error(reason: .error, error: msg))
+                out.end(msg)
+            }
         }
     }
 
@@ -254,8 +276,7 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
                     state.appendText(index: index, text: text)
                     out.push(.textDelta(contentIndex: index, delta: text, partial: state.snapshot()))
                 }
-                if case .object(let reasoning) = delta["reasoningContent"] ?? .null,
-                   case .string(let text) = reasoning["text"] ?? .null {
+                if case .object(let reasoning) = delta["reasoningContent"] ?? .null {
                     let (index, firstSeen) = state.noteThinkingBlock(at: blockIndex)
                     if !emittedStart {
                         out.push(.start(partial: state.snapshot()))
@@ -264,8 +285,18 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
                     if firstSeen {
                         out.push(.thinkingStart(contentIndex: index, partial: state.snapshot()))
                     }
-                    state.appendThinking(index: index, text: text)
-                    out.push(.thinkingDelta(contentIndex: index, delta: text, partial: state.snapshot()))
+                    if case .string(let text) = reasoning["text"] ?? .null {
+                        state.appendThinking(index: index, text: text)
+                        out.push(.thinkingDelta(contentIndex: index, delta: text, partial: state.snapshot()))
+                    }
+                    // Capture the reasoning signature delta so a replayed thinking
+                    // block carries a valid signature — Claude-on-Bedrock rejects a
+                    // signed thinking block replayed without one, and `encodeMessages`
+                    // otherwise degrades it to plain text. Mirrors pi and the
+                    // AnthropicProvider's `signature_delta` handling.
+                    if case .string(let sig) = reasoning["signature"] ?? .null {
+                        state.appendSignature(index: index, signature: sig)
+                    }
                 }
                 if case .object(let toolUse) = delta["toolUse"] ?? .null,
                    case .string(let input) = toolUse["input"] ?? .null {
@@ -292,6 +323,12 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
             }
         }
 
+        if state.signal?.isCancelled == true {
+            let aborted = state.asAborted()
+            out.push(.error(reason: .aborted, error: aborted))
+            out.end(aborted)
+            return
+        }
         state.finalizePending { event in out.push(event) }
         let final = state.finalize()
         out.push(.done(reason: final.stopReason, message: final))
@@ -666,6 +703,19 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
             timestamp: Timestamp.now()
         )
     }
+
+    private static func makeAborted(api: String, model: Model) -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Request was aborted",
+            timestamp: Timestamp.now()
+        )
+    }
 }
 
 // MARK: - Mutable state
@@ -745,6 +795,14 @@ final class BedrockStreamState: @unchecked Sendable {
             if case .thinking(var th) = blocks[index] { th.thinking += text; blocks[index] = .thinking(th) }
         }
     }
+    func appendSignature(index: Int, signature: String) {
+        lock.withLock {
+            if case .thinking(var th) = blocks[index] {
+                th.thinkingSignature = (th.thinkingSignature ?? "") + signature
+                blocks[index] = .thinking(th)
+            }
+        }
+    }
     func appendToolCallArgs(index: Int, chunk: String) {
         lock.withLock {
             if case .toolUse(let id, let name, let json) = blocks[index] {
@@ -802,7 +860,12 @@ final class BedrockStreamState: @unchecked Sendable {
         }
     }
 
-    func snapshot() -> AssistantMessage {
+    /// Streaming snapshot. In-progress tool calls use an empty-object
+    /// placeholder rather than re-parsing the growing JSON buffer on every
+    /// delta (O(n^2)); full arguments are parsed once in `finishBlock`/`finalize`.
+    func snapshot() -> AssistantMessage { buildMessage(parseToolArgs: false) }
+
+    private func buildMessage(parseToolArgs: Bool) -> AssistantMessage {
         lock.withLock {
             AssistantMessage(
                 content: order.compactMap { idx -> AssistantBlock? in
@@ -810,7 +873,8 @@ final class BedrockStreamState: @unchecked Sendable {
                     case .text(let t): return .text(t)
                     case .thinking(let th): return .thinking(th)
                     case .toolUse(let id, let name, let json):
-                        return .toolCall(ToolCall(id: id, name: name, arguments: parseArgs(json)))
+                        let args: JSONValue = parseToolArgs ? parseArgs(json) : .object([:])
+                        return .toolCall(ToolCall(id: id, name: name, arguments: args))
                     case .none: return nil
                     }
                 },
@@ -825,7 +889,7 @@ final class BedrockStreamState: @unchecked Sendable {
         }
     }
 
-    func finalize() -> AssistantMessage { snapshot() }
+    func finalize() -> AssistantMessage { buildMessage(parseToolArgs: true) }
 
     func asAborted() -> AssistantMessage {
         stopReason = .aborted

--- a/Sources/KWWKAI/BedrockRegion.swift
+++ b/Sources/KWWKAI/BedrockRegion.swift
@@ -25,14 +25,14 @@ enum BedrockRegion {
     /// Region of a *standard* AWS Bedrock runtime endpoint host:
     /// `bedrock-runtime.<region>.amazonaws.com` (also `-fips` and `.cn`).
     /// Returns nil for custom/VPC/proxy endpoints so we don't pin those.
-    static func fromEndpointHost(_ baseUrl: String?) -> String? {
-        guard let baseUrl, !baseUrl.isEmpty else { return nil }
+    static func fromEndpointHost(_ baseURL: String?) -> String? {
+        guard let baseURL, !baseURL.isEmpty else { return nil }
         let host: String
-        if let url = URL(string: baseUrl), let h = url.host {
+        if let url = URL(string: baseURL), let h = url.host {
             host = h
         } else {
             // Bare host (no scheme).
-            host = baseUrl
+            host = baseURL
         }
         let lower = host.lowercased()
         let prefixes = ["bedrock-runtime-fips.", "bedrock-runtime."]
@@ -63,7 +63,7 @@ enum BedrockRegion {
     /// keeps configuredRegion (env) ranked above the endpoint host, matching pi.
     static func resolve(
         modelId: String,
-        baseUrl: String?,
+        baseURL: String?,
         env: [String: String],
         profileRegion: String? = nil
     ) -> String {
@@ -72,7 +72,7 @@ enum BedrockRegion {
         // 2. configuredRegion (AWS_REGION / AWS_DEFAULT_REGION).
         if let configured = fromEnv(env) { return configured }
         // 3. endpoint-host region, only when useExplicitEndpoint.
-        let endpointRegion = fromEndpointHost(baseUrl)
+        let endpointRegion = fromEndpointHost(baseURL)
         let hasAmbientProfile = !(env["AWS_PROFILE"] ?? "").isEmpty
         let useExplicitEndpoint = endpointRegion == nil
             || (fromEnv(env) == nil && !hasAmbientProfile)

--- a/Sources/KWWKAI/EnvAPIKeys.swift
+++ b/Sources/KWWKAI/EnvAPIKeys.swift
@@ -71,14 +71,14 @@ public enum EnvAPIKeys {
     }
 
     /// The configured env vars (non-empty) that can authenticate `provider`.
-    public static func foundEnvVars(for provider: String, env: [String: String] = [:]) -> [String] {
+    public static func foundEnvVars(for provider: String, env: [String: String]) -> [String] {
         guard let candidates = envVars[provider] else { return [] }
         return candidates.filter { (env[$0]?.isEmpty == false) }
     }
 
     /// The API key for `provider` from env, or nil. Does not cover OAuth-only
     /// providers' bearer tokens beyond the env-key form.
-    public static func apiKey(for provider: String, env: [String: String] = [:]) -> String? {
+    public static func apiKey(for provider: String, env: [String: String]) -> String? {
         if let first = foundEnvVars(for: provider, env: env).first {
             return env[first]
         }
@@ -88,7 +88,7 @@ public enum EnvAPIKeys {
     /// Whether ambient AWS credentials that `BedrockProvider` can consume are
     /// present. The provider supports static IAM keys, AWS_PROFILE shared
     /// credentials, Bedrock bearer tokens, and explicit skip-auth mode.
-    public static func hasBedrockAuth(env: [String: String] = [:]) -> Bool {
+    public static func hasBedrockAuth(env: [String: String]) -> Bool {
         let hasStaticKeys =
             (env["AWS_ACCESS_KEY_ID"]?.isEmpty == false) &&
             (env["AWS_SECRET_ACCESS_KEY"]?.isEmpty == false)
@@ -101,7 +101,7 @@ public enum EnvAPIKeys {
     /// Every provider that currently has a usable env key configured, in scan
     /// priority order (then alphabetical for the rest). Amazon Bedrock is
     /// appended when ambient AWS credentials are present.
-    public static func configuredProviders(env: [String: String] = [:]) -> [String] {
+    public static func configuredProviders(env: [String: String]) -> [String] {
         let ranked = scanPriority + envVars.keys.filter { !scanPriority.contains($0) }.sorted()
         var out = ranked.filter { !foundEnvVars(for: $0, env: env).isEmpty }
         if hasBedrockAuth(env: env) { out.append("amazon-bedrock") }
@@ -111,7 +111,7 @@ public enum EnvAPIKeys {
     /// Look up the first non-empty environment variable from `names`.
     public static func firstValue(
         of names: [String],
-        env: [String: String] = [:]
+        env: [String: String]
     ) -> String? {
         for name in names {
             if let v = env[name], !v.trimmingCharacters(in: .whitespaces).isEmpty { return v }
@@ -141,7 +141,7 @@ public enum EnvAPIKeys {
     /// Resolve Azure config from the environment (nil when no API key). Endpoint
     /// order: AZURE_OPENAI_BASE_URL > AZURE_OPENAI_ENDPOINT >
     /// https://{AZURE_OPENAI_RESOURCE_NAME}.openai.azure.com.
-    public static func azure(env: [String: String] = [:]) -> Azure? {
+    public static func azure(env: [String: String]) -> Azure? {
         guard let apiKey = firstValue(of: ["AZURE_OPENAI_API_KEY"], env: env) else { return nil }
         let apiVersion = firstValue(of: ["AZURE_OPENAI_API_VERSION"], env: env) ?? azureDefaultAPIVersion
         let rawBase: String?
@@ -179,7 +179,7 @@ public enum EnvAPIKeys {
     }
 
     /// Resolve Cloudflare credentials (nil when CLOUDFLARE_API_KEY absent).
-    public static func cloudflare(env: [String: String] = [:]) -> Cloudflare? {
+    public static func cloudflare(env: [String: String]) -> Cloudflare? {
         guard let apiKey = firstValue(of: ["CLOUDFLARE_API_KEY"], env: env) else { return nil }
         return Cloudflare(
             apiKey: apiKey,

--- a/Sources/KWWKAI/FauxProvider.swift
+++ b/Sources/KWWKAI/FauxProvider.swift
@@ -206,7 +206,7 @@ public func registerFauxProvider(_ options: RegisterFauxProviderOptions = .init(
             name: def.name ?? def.id,
             api: api,
             provider: provider,
-            baseUrl: FauxProvider.defaultBaseURL,
+            baseURL: FauxProvider.defaultBaseURL,
             reasoning: def.reasoning ?? false,
             input: def.input ?? [.text, .image],
             cost: def.cost ?? .init(),

--- a/Sources/KWWKAI/GoogleGeminiProvider.swift
+++ b/Sources/KWWKAI/GoogleGeminiProvider.swift
@@ -46,9 +46,9 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
         self.defaultAPIKey = defaultAPIKey
         self.extraHeaders = extraHeaders
         self.urlBuilder = urlBuilder ?? { model, options, fallback, key in
-            var base = model.baseUrl.isEmpty ? fallback.absoluteString : model.baseUrl
+            var base = model.baseURL.isEmpty ? fallback.absoluteString : model.baseURL
             while base.hasSuffix("/") { base.removeLast() }
-            // pi-mono's models.json bakes the API version into the baseUrl
+            // pi-mono's models.json bakes the API version into the baseURL
             // (`.../v1beta`) for Gemini entries, while callers constructing
             // providers by hand typically pass just the host root. Accept
             // both by only appending `/v1beta` when it's not already there.
@@ -110,9 +110,19 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
                 url: url, method: "POST", headers: headers, body: body
             )
             if response.statusCode >= 400 {
+                // Surface the JSON error body like the other providers.
+                var bodyBytes = Data()
+                for try await chunk in stream {
+                    bodyBytes.append(chunk)
+                    if bodyBytes.count > 4096 { break }
+                }
+                let bodyText = String(data: bodyBytes, encoding: .utf8) ?? ""
+                let preview = bodyText.isEmpty
+                    ? ""
+                    : ": " + bodyText.replacingOccurrences(of: "\n", with: " ").prefix(500)
                 let msg = Self.makeError(
                     api: api, model: model,
-                    text: "Gemini returned status \(response.statusCode)"
+                    text: "Gemini returned status \(response.statusCode)\(preview)"
                 )
                 out.push(.error(reason: .error, error: msg))
                 out.end(msg)
@@ -120,11 +130,22 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
             }
             let state = GoogleGeminiState(api: api, provider: model.provider, modelId: model.id)
             state.signal = options?.cancellation
-            try await drive(events: parseSSE(bytes: stream), out: out, state: state)
+            // Bridge external cancellation to the in-flight request (see
+            // AnthropicProvider.run for the rationale).
+            let driveTask = Task { try await self.drive(events: parseSSE(bytes: stream), out: out, state: state) }
+            let cancelReg = options?.cancellation?.onCancel { _ in driveTask.cancel() }
+            defer { cancelReg?.cancel() }
+            try await driveTask.value
         } catch {
-            let msg = Self.makeError(api: api, model: model, text: "\(error)")
-            out.push(.error(reason: .error, error: msg))
-            out.end(msg)
+            if options?.cancellation?.isCancelled == true {
+                let aborted = Self.makeAborted(api: api, model: model)
+                out.push(.error(reason: .aborted, error: aborted))
+                out.end(aborted)
+            } else {
+                let msg = Self.makeError(api: api, model: model, text: "\(error)")
+                out.push(.error(reason: .error, error: msg))
+                out.end(msg)
+            }
         }
     }
 
@@ -235,6 +256,12 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
             }
         }
 
+        if state.signal?.isCancelled == true {
+            let aborted = state.asAborted()
+            out.push(.error(reason: .aborted, error: aborted))
+            out.end(aborted)
+            return
+        }
         // Finalize any streamed text/thinking blocks.
         state.finalizeStreamingBlocks(emit: { event in out.push(event) })
         // If tool calls are present, Gemini expects `toolUse` semantics.
@@ -576,6 +603,19 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
             usage: Usage(),
             stopReason: .error,
             errorMessage: text,
+            timestamp: Timestamp.now()
+        )
+    }
+
+    private static func makeAborted(api: String, model: Model) -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Request was aborted",
             timestamp: Timestamp.now()
         )
     }

--- a/Sources/KWWKAI/HTTPClient.swift
+++ b/Sources/KWWKAI/HTTPClient.swift
@@ -6,21 +6,44 @@ import FoundationNetworking
 /// Minimal HTTP client abstraction used by streaming providers. Tests inject a
 /// stub implementation; production code uses `URLSessionHTTPClient`.
 public protocol HTTPClient: Sendable {
-    /// Open a streaming POST request and return an async byte stream of the
-    /// response body. The returned `response` is the initial HTTP response.
+    /// Open a streaming POST request and return an async stream of response
+    /// body chunks. Each element is one `didReceive data:` chunk exactly as it
+    /// arrived off the socket — consumers (e.g. `SSEParser`, `parseAWSEventStream`)
+    /// split it into lines/frames themselves. The returned `response` is the
+    /// initial HTTP response.
+    ///
+    /// The stream is single-consumer and finishes (optionally throwing) when the
+    /// request completes or errors. Cancelling the consuming task tears the
+    /// stream down, which aborts the underlying transport.
     func stream(
         url: URL,
         method: String,
         headers: [String: String],
         body: Data?
-    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>)
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>)
 }
 
-public struct URLSessionHTTPClient: HTTPClient {
+public final class URLSessionHTTPClient: HTTPClient, @unchecked Sendable {
+    /// The long-lived session that owns the connection pool. Reused across every
+    /// request so TCP/TLS connections are kept alive between API calls instead
+    /// of paying a fresh handshake per request.
     public let session: URLSession
+    private let delegate: StreamingSessionDelegate
 
     public init(session: URLSession? = nil) {
-        self.session = session ?? Self.makeIsolatedSession()
+        let delegate = StreamingSessionDelegate()
+        self.delegate = delegate
+        // A `URLSession`'s delegate is fixed at creation, so an injected session
+        // can only donate its configuration; we build our own session bound to
+        // the demultiplexing delegate. Cookies/cache stay disabled either way.
+        let configuration = session?.configuration ?? Self.isolatedConfiguration()
+        self.session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    }
+
+    deinit {
+        // Let in-flight tasks drain, then release the delegate the session
+        // retains. Without this the session (and its delegate) would leak.
+        session.finishTasksAndInvalidate()
     }
 
     public func stream(
@@ -28,103 +51,81 @@ public struct URLSessionHTTPClient: HTTPClient {
         method: String,
         headers: [String: String],
         body: Data?
-    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         var request = URLRequest(url: url)
         request.httpMethod = method
         for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
         request.httpBody = body
-        return try await streamViaDelegate(base: session, request: request)
+
+        let task = session.dataTask(with: request)
+        let id = task.taskIdentifier
+        // Register the body stream before `resume()` so early `didReceive`
+        // callbacks find a continuation to feed. The stream aborts the request
+        // when the consumer stops iterating (or its task is cancelled).
+        let stream = delegate.makeBodyStream(for: id, onCancel: { [weak task] in task?.cancel() })
+        task.resume()
+
+        do {
+            let http = try await delegate.awaitHeader(for: id)
+            return (http, stream)
+        } catch {
+            task.cancel()
+            throw error
+        }
     }
 }
 
 private extension URLSessionHTTPClient {
-    static func makeIsolatedSession() -> URLSession {
+    static func isolatedConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpCookieStorage = nil
         configuration.urlCredentialStorage = nil
         configuration.urlCache = nil
         configuration.httpShouldSetCookies = false
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        return URLSession(configuration: configuration)
+        return configuration
     }
 }
 
-/// Drives a `URLSessionDataTask` through a delegate that forwards the initial
-/// `HTTPURLResponse` and every `didReceive data:` chunk into an
-/// `AsyncThrowingStream<UInt8, Error>`. Each call spins up its own
-/// `URLSession` (delegates are per-session) and tears it down when the body
-/// stream is drained or the consumer cancels.
-///
-/// Uniform across Apple and Linux: Apple also has `URLSession.bytes(for:)`
-/// but keeping one code path saves us from debugging two subtly different
-/// streams. The delegate-based path is a thin shim over `URLSessionDataTask`
-/// — same behavior, same back-pressure semantics on both OSes.
-private func streamViaDelegate(
-    base: URLSession,
-    request: URLRequest
-) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
-    let delegate = StreamingDelegate()
-    let driver = URLSession(
-        configuration: base.configuration,
-        delegate: delegate,
-        delegateQueue: nil
-    )
-    let task = driver.dataTask(with: request)
-    let stream = delegate.makeByteStream(onCancel: { task.cancel() })
-    task.resume()
-
-    do {
-        let http = try await delegate.awaitResponse()
-        return (http, stream)
-    } catch {
-        task.cancel()
-        driver.finishTasksAndInvalidate()
-        throw error
+/// A single session-level delegate that demultiplexes callbacks by
+/// `dataTask.taskIdentifier` into per-request header/body continuations. One
+/// delegate (and one session) serves every concurrent request so the session's
+/// connection pool is shared.
+private final class StreamingSessionDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    /// Per-request state. A request is removed once both its header result has
+    /// been handed to `awaitHeader`'s continuation and its body stream has
+    /// finished — either side may complete first.
+    private struct TaskState {
+        var headerContinuation: CheckedContinuation<HTTPURLResponse, Error>?
+        var pendingHeader: Result<HTTPURLResponse, Error>?
+        var headerResolved = false
+        var headerDelivered = false
+        var bodyContinuation: AsyncThrowingStream<Data, Error>.Continuation?
+        /// Completion that arrived before the body stream was constructed.
+        var pendingCompletion: Error??
+        var bodyFinished = false
     }
-}
 
-private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let lock = NSLock()
-    private var headerContinuation: CheckedContinuation<HTTPURLResponse, Error>?
-    private var headerResolved = false
-    private var pendingHeaders: Result<HTTPURLResponse, Error>?
-    private var bodyContinuation: AsyncThrowingStream<UInt8, Error>.Continuation?
-    /// Error from `didCompleteWithError` that arrived before the body stream
-    /// was constructed. Replayed into the stream once it opens.
-    private var pendingCompletion: Error??
+    private var states: [Int: TaskState] = [:]
 
-    func awaitResponse() async throws -> HTTPURLResponse {
-        try await withCheckedThrowingContinuation { cont in
-            let pending: Result<HTTPURLResponse, Error>? = lock.withLock {
-                if let pending = pendingHeaders {
-                    pendingHeaders = nil
-                    headerResolved = true
-                    return pending
-                } else {
-                    headerContinuation = cont
-                    return nil
-                }
-            }
-            if let pending {
-                switch pending {
-                case .success(let http): cont.resume(returning: http)
-                case .failure(let err):  cont.resume(throwing: err)
-                }
-            }
-        }
-    }
+    // MARK: - Registration (called from `stream(...)`)
 
-    func makeByteStream(onCancel: @escaping @Sendable () -> Void) -> AsyncThrowingStream<UInt8, Error> {
-        AsyncThrowingStream<UInt8, Error> { continuation in
+    func makeBodyStream(for id: Int, onCancel: @escaping @Sendable () -> Void) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream<Data, Error> { continuation in
             let pending: Error?? = lock.withLock {
-                bodyContinuation = continuation
-                // Replay a completion that landed before the consumer started
-                // draining — typical when the server closed the connection
-                // between `didReceive response:` and the caller hooking in.
-                if let pending = pendingCompletion {
-                    pendingCompletion = nil
-                    return .some(pending)
+                var st = states[id] ?? TaskState()
+                // Replay a completion that landed before the consumer hooked in
+                // (server closed between `didReceive response:` and this call).
+                if let p = st.pendingCompletion {
+                    st.pendingCompletion = nil
+                    st.bodyFinished = true
+                    states[id] = st
+                    removeIfDoneLocked(id)
+                    return .some(p)
                 }
+                st.bodyContinuation = continuation
+                states[id] = st
                 return nil
             }
             if let pending {
@@ -135,83 +136,116 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchec
         }
     }
 
+    func awaitHeader(for id: Int) async throws -> HTTPURLResponse {
+        try await withCheckedThrowingContinuation { cont in
+            let pending: Result<HTTPURLResponse, Error>? = lock.withLock {
+                var st = states[id] ?? TaskState()
+                if let p = st.pendingHeader {
+                    st.pendingHeader = nil
+                    st.headerDelivered = true
+                    states[id] = st
+                    removeIfDoneLocked(id)
+                    return p
+                }
+                st.headerContinuation = cont
+                states[id] = st
+                return nil
+            }
+            if let pending {
+                switch pending {
+                case .success(let http): cont.resume(returning: http)
+                case .failure(let err):  cont.resume(throwing: err)
+                }
+            }
+        }
+    }
+
+    // MARK: - URLSessionDataDelegate
+
     func urlSession(
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
     ) {
+        let id = dataTask.taskIdentifier
         guard let http = response as? HTTPURLResponse else {
-            deliverHeader(.failure(HTTPClientError.invalidResponse))
+            deliverHeader(id, .failure(HTTPClientError.invalidResponse))
             completionHandler(.cancel)
             return
         }
-        deliverHeader(.success(http))
+        deliverHeader(id, .success(http))
         completionHandler(.allow)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        let cont = lock.withLock { bodyContinuation }
-        guard let cont else { return }
-        // `yield(contentsOf:)` on a Data wraps it in a Sequence<UInt8>, which
-        // yields without copying and keeps the stream back-pressured.
-        for byte in data { cont.yield(byte) }
+        let id = dataTask.taskIdentifier
+        let cont = lock.withLock { states[id]?.bodyContinuation }
+        // Deliver the whole chunk in one yield — one stream element per socket
+        // read, not one per byte.
+        cont?.yield(data)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let id = task.taskIdentifier
         enum HeaderAction { case none, resume(CheckedContinuation<HTTPURLResponse, Error>, Error) }
-        enum BodyAction { case none, finish(AsyncThrowingStream<UInt8, Error>.Continuation, Error?) }
+        enum BodyAction { case none, finish(AsyncThrowingStream<Data, Error>.Continuation, Error?) }
 
         let actions: (HeaderAction, BodyAction) = lock.withLock {
+            guard var st = states[id] else { return (.none, .none) }
             var headerAction: HeaderAction = .none
-            var bodyAction: BodyAction = .none
-
             // If `didReceive response:` never fired (DNS/connect failure),
             // surface the error on the header continuation instead.
-            if !headerResolved {
-                if let cont = headerContinuation {
-                    headerContinuation = nil
-                    headerResolved = true
+            if !st.headerResolved {
+                st.headerResolved = true
+                if let cont = st.headerContinuation {
+                    st.headerContinuation = nil
+                    st.headerDelivered = true
                     headerAction = .resume(cont, error ?? HTTPClientError.invalidResponse)
                 } else {
-                    pendingHeaders = .failure(error ?? HTTPClientError.invalidResponse)
-                    headerResolved = true
+                    st.pendingHeader = .failure(error ?? HTTPClientError.invalidResponse)
                 }
             }
-            if let body = bodyContinuation {
-                bodyContinuation = nil
+            var bodyAction: BodyAction = .none
+            if let body = st.bodyContinuation {
+                st.bodyContinuation = nil
+                st.bodyFinished = true
                 bodyAction = .finish(body, error)
             } else {
-                pendingCompletion = .some(error)
+                st.pendingCompletion = .some(error)
             }
+            states[id] = st
+            removeIfDoneLocked(id)
             return (headerAction, bodyAction)
         }
 
         switch actions.0 {
-        case .none:
-            break
-        case .resume(let cont, let error):
-            cont.resume(throwing: error)
+        case .none: break
+        case .resume(let cont, let error): cont.resume(throwing: error)
         }
         switch actions.1 {
-        case .none:
-            break
+        case .none: break
         case .finish(let body, let error):
-            if let error { body.finish(throwing: error) }
-            else { body.finish() }
+            if let error { body.finish(throwing: error) } else { body.finish() }
         }
-        session.finishTasksAndInvalidate()
     }
 
-    private func deliverHeader(_ result: Result<HTTPURLResponse, Error>) {
+    // MARK: - Helpers
+
+    private func deliverHeader(_ id: Int, _ result: Result<HTTPURLResponse, Error>) {
         let continuation: CheckedContinuation<HTTPURLResponse, Error>? = lock.withLock {
-            guard !headerResolved else { return nil }
-            headerResolved = true
-            if let cont = headerContinuation {
-                headerContinuation = nil
+            var st = states[id] ?? TaskState()
+            guard !st.headerResolved else { states[id] = st; return nil }
+            st.headerResolved = true
+            if let cont = st.headerContinuation {
+                st.headerContinuation = nil
+                st.headerDelivered = true
+                states[id] = st
+                removeIfDoneLocked(id)
                 return cont
             } else {
-                pendingHeaders = result
+                st.pendingHeader = result
+                states[id] = st
                 return nil
             }
         }
@@ -220,6 +254,13 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchec
             case .success(let http): continuation.resume(returning: http)
             case .failure(let err):  continuation.resume(throwing: err)
             }
+        }
+    }
+
+    private func removeIfDoneLocked(_ id: Int) {
+        guard let st = states[id] else { return }
+        if st.headerDelivered && st.bodyFinished {
+            states[id] = nil
         }
     }
 }
@@ -251,7 +292,7 @@ public extension HTTPClient {
             url: url, method: method, headers: headers, body: body
         )
         var buffer = Data()
-        for try await byte in stream { buffer.append(byte) }
+        for try await chunk in stream { buffer.append(chunk) }
         return (response, buffer)
     }
 }

--- a/Sources/KWWKAI/Model.swift
+++ b/Sources/KWWKAI/Model.swift
@@ -26,7 +26,7 @@ public struct Model: Codable, Sendable, Hashable {
     /// Opaque API identifier (e.g., "anthropic-messages", "openai-responses", "faux:xyz").
     public var api: String
     public var provider: String
-    public var baseUrl: String
+    public var baseURL: String
     public var reasoning: Bool
     public var input: [InputModality]
     public var cost: ModelCost
@@ -34,19 +34,27 @@ public struct Model: Codable, Sendable, Hashable {
     public var maxTokens: Int
     public var headers: [String: String]?
     /// Per-API compatibility overrides (cache format, thinking format, store
-    /// support, etc.). nil = auto-detect from baseUrl / provider defaults.
+    /// support, etc.). nil = auto-detect from baseURL / provider defaults.
     public var compat: ModelCompat?
     /// Maps pi thinking levels (off/minimal/low/medium/high/xhigh) to
     /// provider/model-specific wire values. A `.some(nil)` entry marks a level
     /// as unsupported; a missing key uses provider defaults.
     public var thinkingLevelMap: [String: String?]?
 
+    /// The wire/persisted key stays "baseUrl" (models.json, pi parity);
+    /// only the Swift property follows Foundation's URL casing.
+    enum CodingKeys: String, CodingKey {
+        case id, name, api, provider
+        case baseURL = "baseUrl"
+        case reasoning, input, cost, contextWindow, maxTokens, headers, compat, thinkingLevelMap
+    }
+
     public init(
         id: String,
         name: String? = nil,
         api: String,
         provider: String,
-        baseUrl: String = "",
+        baseURL: String = "",
         reasoning: Bool = false,
         input: [InputModality] = [.text],
         cost: ModelCost = .init(),
@@ -60,7 +68,7 @@ public struct Model: Codable, Sendable, Hashable {
         self.name = name ?? id
         self.api = api
         self.provider = provider
-        self.baseUrl = baseUrl
+        self.baseURL = baseURL
         self.reasoning = reasoning
         self.input = input
         self.cost = cost

--- a/Sources/KWWKAI/ModelsCatalog.swift
+++ b/Sources/KWWKAI/ModelsCatalog.swift
@@ -34,12 +34,21 @@ public enum ModelsCatalog {
     // MARK: - Loader
 
     private static func loadAll() -> [String: [String: Model]] {
-        guard let url = Bundle.module.url(forResource: "models", withExtension: "json"),
-              let data = try? Data(contentsOf: url) else {
-            return [:]
+        // The catalog is a bundled build resource; a missing or unparseable
+        // models.json is a broken build, not a runtime condition to paper
+        // over with an empty catalog (which would silently break every model
+        // lookup). Fail loudly so it's caught at first use.
+        guard let url = Bundle.module.url(forResource: "models", withExtension: "json") else {
+            fatalError("ModelsCatalog: bundled resource models.json is missing from the build")
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            fatalError("ModelsCatalog: cannot read bundled models.json at \(url.path): \(error)")
         }
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return [:]
+            fatalError("ModelsCatalog: bundled models.json is not a JSON object")
         }
         var out: [String: [String: Model]] = [:]
         for (provider, value) in root {
@@ -65,7 +74,7 @@ public enum ModelsCatalog {
               let provider = dict["provider"] as? String else {
             return nil
         }
-        let baseUrl = dict["baseUrl"] as? String ?? ""
+        let baseURL = dict["baseUrl"] as? String ?? ""
         let reasoning = dict["reasoning"] as? Bool ?? false
         let inputStrings = dict["input"] as? [String] ?? ["text"]
         let input: [InputModality] = inputStrings.compactMap { InputModality(rawValue: $0) }
@@ -110,7 +119,7 @@ public enum ModelsCatalog {
             name: name,
             api: api,
             provider: provider,
-            baseUrl: baseUrl,
+            baseURL: baseURL,
             reasoning: reasoning,
             input: input,
             cost: cost,

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -2,6 +2,11 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 /// Canonical credential shape used by all OAuth providers. `expires` is Unix
 /// time in milliseconds; `extras` holds provider-specific fields that must
@@ -81,6 +86,8 @@ public enum OAuthError: Error, LocalizedError {
     case transport(String)
     case invalidResponse(String)
     case refreshFailed(String)
+    case corruptStore(path: String, detail: String)
+    case persistFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -89,6 +96,9 @@ public enum OAuthError: Error, LocalizedError {
         case .transport(let text): return "OAuth transport error: \(text)"
         case .invalidResponse(let text): return "OAuth invalid response: \(text)"
         case .refreshFailed(let text): return "OAuth refresh failed: \(text)"
+        case .corruptStore(let path, let detail):
+            return "OAuth store at \(path) is unreadable (refusing to overwrite it): \(detail)"
+        case .persistFailed(let text): return "OAuth store write failed: \(text)"
         }
     }
 }
@@ -103,20 +113,29 @@ public actor OAuthStore {
     public let isPersistent: Bool
     private var credentials: [String: OAuthCredentials]
 
-    public init(url: URL? = nil) {
-        if let url {
-            self.url = url
-            self.isPersistent = true
-        } else {
-            self.url = URL(fileURLWithPath: "/dev/null")
-            self.isPersistent = false
-        }
-        if isPersistent,
-           let data = try? Data(contentsOf: self.url),
-           let decoded = try? JSONDecoder().decode([String: OAuthCredentials].self, from: data) {
-            self.credentials = decoded
-        } else {
+    /// In-memory, non-persistent store. `set()`/`remove()` are no-ops on disk.
+    public init() {
+        self.url = URL(fileURLWithPath: "/dev/null")
+        self.isPersistent = false
+        self.credentials = [:]
+    }
+
+    /// Load a persistent store from `url`. A missing file is a normal fresh
+    /// start (empty store). An existing file that cannot be read or decoded
+    /// throws `OAuthError.corruptStore` — we must not silently drop the logins
+    /// and then overwrite them on the next `set()`.
+    public init(url: URL) throws {
+        self.url = url
+        self.isPersistent = true
+        guard FileManager.default.fileExists(atPath: url.path) else {
             self.credentials = [:]
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            self.credentials = try JSONDecoder().decode([String: OAuthCredentials].self, from: data)
+        } catch {
+            throw OAuthError.corruptStore(path: url.path, detail: String(describing: error))
         }
     }
 
@@ -154,9 +173,23 @@ public actor OAuthStore {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(credentials)
-        try data.write(to: url, options: .atomic)
-        // Best-effort lockdown: 0600 since the file carries refresh tokens.
-        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+
+        // Create the file 0600 up front (no world-readable window, no
+        // chmod-after-write race), then rename(2) it over the destination so
+        // the swap is atomic and the live file keeps the temp file's 0600
+        // mode. Any failure throws — refresh tokens are too sensitive to
+        // persist best-effort.
+        let tmp = dir.appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        guard FileManager.default.createFile(
+            atPath: tmp.path, contents: data, attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw OAuthError.persistFailed("could not create temp store at \(tmp.path)")
+        }
+        if rename(tmp.path, url.path) != 0 {
+            let reason = String(cString: strerror(errno))
+            try? FileManager.default.removeItem(at: tmp)
+            throw OAuthError.persistFailed("rename into \(url.path) failed: \(reason)")
+        }
     }
 }
 
@@ -170,6 +203,10 @@ public actor OAuthManager {
     public let store: OAuthStore
     public let client: HTTPClient
     private var providers: [String: OAuthProvider]
+    /// In-flight refresh per provider id. Concurrent `apiKey(for:)` callers
+    /// await the same task instead of each launching their own refresh with
+    /// the same (rotated-on-use) refresh token.
+    private var inFlightRefresh: [String: Task<OAuthCredentials, Error>] = [:]
 
     public init(
         store: OAuthStore = OAuthStore(),
@@ -203,19 +240,52 @@ public actor OAuthManager {
             throw OAuthError.missing(providerId: providerId)
         }
         if credentials.isExpired {
-            credentials = try await provider.refresh(credentials, using: client)
-            try await store.set(credentials, for: providerId)
+            credentials = try await refresh(providerId, provider: provider, stale: credentials)
         }
         return try await provider.apiKey(from: credentials, using: client)
     }
 
+    /// Refresh (or join an in-flight refresh for) `providerId`. The first
+    /// caller starts the task and records it; concurrent callers await the
+    /// same task. The task re-reads the store on entry so a refresh that
+    /// landed while we were suspended is reused instead of re-run.
+    private func refresh(
+        _ providerId: String,
+        provider: OAuthProvider,
+        stale: OAuthCredentials
+    ) async throws -> OAuthCredentials {
+        if let existing = inFlightRefresh[providerId] {
+            return try await existing.value
+        }
+        let store = self.store
+        let client = self.client
+        let task = Task<OAuthCredentials, Error> {
+            let current = await store.get(providerId) ?? stale
+            if !current.isExpired { return current }
+            let refreshed = try await provider.refresh(current, using: client)
+            try await store.set(refreshed, for: providerId)
+            return refreshed
+        }
+        inFlightRefresh[providerId] = task
+        defer { inFlightRefresh[providerId] = nil }
+        return try await task.value
+    }
+
     /// Build an auth resolver closure. The resolver receives the active model;
     /// we map common provider ids to our OAuth ids and return a bearer token.
-    public nonisolated func resolver() -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
+    public nonisolated func resolver() -> @Sendable (Model, String?) async throws -> ResolvedProviderAuth? {
         let manager = self
         return { model, _ in
             let oauthId = Self.oauthId(forProvider: model.provider)
-            return try? await manager.resolvedAuth(for: oauthId)
+            do {
+                return try await manager.resolvedAuth(for: oauthId)
+            } catch OAuthError.missing, OAuthError.unknownProvider {
+                // No credentials stored for this provider ⇒ an anonymous
+                // request is the correct outcome. A refresh/exchange failure
+                // (any other error) propagates so the provider surfaces it
+                // rather than silently sending an unauthenticated request.
+                return nil
+            }
         }
     }
 

--- a/Sources/KWWKAI/OAuthCallbackServer.swift
+++ b/Sources/KWWKAI/OAuthCallbackServer.swift
@@ -235,6 +235,15 @@ private final class CallbackHandler: ChannelInboundHandler, @unchecked Sendable 
             server.resolveError(.invalidResponse(err))
             return
         }
+        // Only a request that actually carries the authorization `code`
+        // resolves the flow. Anything else hitting the path (browser favicon
+        // probe, health check, a preflight with no query) gets a 404 and the
+        // server keeps waiting — otherwise a stray request would kill the
+        // pending login with an empty parameter set.
+        guard params["code"] != nil else {
+            write(context: context, status: .notFound, html: server.errorHTMLFilled("missing authorization code"))
+            return
+        }
         write(context: context, status: .ok, html: server.successHTML)
         server.resolveSuccess(params)
     }

--- a/Sources/KWWKAI/OAuthLogin.swift
+++ b/Sources/KWWKAI/OAuthLogin.swift
@@ -11,46 +11,27 @@ import FoundationNetworking
 /// redirect ports differ.
 public enum OAuthLogin {
 
-    /// Hooks the orchestrator calls as the flow progresses. Defaults print to
-    /// stderr; GUI apps can plug their own handlers to render progress.
+    /// Hooks the orchestrator calls as the flow progresses. Both are required:
+    /// the SDK does not print to stderr or launch a browser on its own — the
+    /// embedding app decides how to surface the auth URL and progress (the
+    /// kwwk CLI supplies terminal implementations in `Login.swift`).
     public struct Callbacks: Sendable {
         public var onAuthURL: @Sendable (URL) -> Void
         public var onProgress: @Sendable (String) -> Void
-        public var onPrompt: @Sendable (String) async throws -> String
 
         public init(
-            onAuthURL: @escaping @Sendable (URL) -> Void = Self.defaultAuthURL,
-            onProgress: @escaping @Sendable (String) -> Void = Self.defaultProgress,
-            onPrompt: @escaping @Sendable (String) async throws -> String = Self.defaultPrompt
+            onAuthURL: @escaping @Sendable (URL) -> Void,
+            onProgress: @escaping @Sendable (String) -> Void
         ) {
             self.onAuthURL = onAuthURL
             self.onProgress = onProgress
-            self.onPrompt = onPrompt
-        }
-
-        public static let defaultAuthURL: @Sendable (URL) -> Void = { url in
-            let msg = "open in your browser:\n  \(url.absoluteString)\n"
-            FileHandle.standardError.write(Data(msg.utf8))
-            Browser.open(url)
-        }
-
-        public static let defaultProgress: @Sendable (String) -> Void = { msg in
-            FileHandle.standardError.write(Data("\(msg)\n".utf8))
-        }
-
-        public static let defaultPrompt: @Sendable (String) async throws -> String = { question in
-            FileHandle.standardError.write(Data("\(question) ".utf8))
-            guard let line = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-                throw OAuthError.transport("no terminal input")
-            }
-            return line
         }
     }
 
     // MARK: - Anthropic
 
     public static func loginAnthropic(
-        callbacks: Callbacks = Callbacks(),
+        callbacks: Callbacks,
         client: HTTPClient = URLSessionHTTPClient()
     ) async throws -> OAuthCredentials {
         let pkce = PKCE.random()
@@ -104,7 +85,7 @@ public enum OAuthLogin {
     // MARK: - OpenAI Codex
 
     public static func loginOpenAICodex(
-        callbacks: Callbacks = Callbacks(),
+        callbacks: Callbacks,
         client: HTTPClient = URLSessionHTTPClient()
     ) async throws -> OAuthCredentials {
         let pkce = PKCE.random()
@@ -177,7 +158,7 @@ public enum OAuthLogin {
 
     public static func loginGitHubCopilot(
         clientID: String = "Iv1.b507a08c87ecfe98",
-        callbacks: Callbacks = Callbacks(),
+        callbacks: Callbacks,
         client: HTTPClient = URLSessionHTTPClient()
     ) async throws -> OAuthCredentials {
         callbacks.onProgress("requesting GitHub device code…")
@@ -301,7 +282,7 @@ extension OAuthLogin {
         sessionToken: String,
         baseURL: URL = URL(string: "https://api.individual.githubcopilot.com")!,
         modelIds: [String],
-        callbacks: Callbacks = Callbacks(),
+        callbacks: Callbacks,
         client: HTTPClient = URLSessionHTTPClient()
     ) async {
         let baseString: String = {
@@ -334,31 +315,6 @@ extension OAuthLogin {
             } catch {
                 callbacks.onProgress("  · \(id): \(error.localizedDescription)")
             }
-        }
-    }
-}
-
-// MARK: - Browser launcher
-
-public enum Browser {
-    /// Best-effort URL opener. macOS uses `/usr/bin/open`; Linux tries
-    /// `xdg-open` then falls back to stderr so the user can click manually.
-    public static func open(_ url: URL) {
-        #if os(macOS)
-        let opener = "/usr/bin/open"
-        #else
-        let opener = "/usr/bin/xdg-open"
-        #endif
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: opener)
-        process.arguments = [url.absoluteString]
-        do {
-            try process.run()
-        } catch {
-            FileHandle.standardError.write(Data(
-                "please open manually:\n  \(url.absoluteString)\n".utf8
-            ))
         }
     }
 }

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 
 /// OpenAI /v1/chat/completions streaming provider. Also usable against any
 /// wire-compatible endpoint — Groq, xAI, OpenRouter, Cerebras, HuggingFace,
-/// Ollama, and OpenAI-compat proxies all work by swapping `model.baseUrl`.
+/// Ollama, and OpenAI-compat proxies all work by swapping `model.baseURL`.
 ///
 /// Differences from Anthropic:
 ///  - Single SSE event stream, `data: {json}` lines, terminated by
@@ -53,16 +53,16 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         self.defaultAPIKey = defaultAPIKey
         self.extraHeaders = extraHeaders
         self.urlBuilder = urlBuilder ?? { model, _, fallback in
-            var base = model.baseUrl.isEmpty ? fallback.absoluteString : model.baseUrl
+            var base = model.baseURL.isEmpty ? fallback.absoluteString : model.baseURL
             while base.hasSuffix("/") { base.removeLast() }
             // Cloudflare catalog entries may carry literal `{CLOUDFLARE_*}`
             // placeholders. The generic provider never reads the process
             // environment; provider variants that support Cloudflare pass
             // explicit values through their own URL builders.
             base = substituteCloudflarePlaceholders(in: base, value: { _ in nil })
-            // Tolerate catalog entries that bake `/v1` into baseUrl
+            // Tolerate catalog entries that bake `/v1` into baseURL
             // (pi-mono's models.generated.ts does this for OpenAI).
-            // Without this, the session baseUrl `https://api.openai.com`
+            // Without this, the session baseURL `https://api.openai.com`
             // → `/v1/chat/completions`, but a `/model` swap pulls in
             // `https://api.openai.com/v1` and we'd double-suffix.
             let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
@@ -141,11 +141,22 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             }
             let state = OpenAICompletionsState(api: api, provider: model.provider, modelId: model.id, model: model)
             state.signal = options?.cancellation
-            try await drive(events: parseSSE(bytes: stream), out: out, state: state)
+            // Bridge external cancellation to the in-flight request (see
+            // AnthropicProvider.run for the rationale).
+            let driveTask = Task { try await self.drive(events: parseSSE(bytes: stream), out: out, state: state) }
+            let cancelReg = options?.cancellation?.onCancel { _ in driveTask.cancel() }
+            defer { cancelReg?.cancel() }
+            try await driveTask.value
         } catch {
-            let msg = Self.makeError(api: api, model: model, text: "\(error)")
-            out.push(.error(reason: .error, error: msg))
-            out.end(msg)
+            if options?.cancellation?.isCancelled == true {
+                let aborted = Self.makeAborted(api: api, model: model)
+                out.push(.error(reason: .aborted, error: aborted))
+                out.end(aborted)
+            } else {
+                let msg = Self.makeError(api: api, model: model, text: "\(error)")
+                out.push(.error(reason: .error, error: msg))
+                out.end(msg)
+            }
         }
     }
 
@@ -390,7 +401,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         // (e.g. OpenRouter `anthropic/*`) — those are different, conflicting wire
         // shapes. Only apply native cache when we did NOT apply the anthropic one.
         let openAINativeCache = compat.cacheControlFormat != "anthropic"
-            && (model.baseUrl.contains("api.openai.com")
+            && (model.baseURL.contains("api.openai.com")
                 || (retention == .long && compat.supportsLongCacheRetention))
         if openAINativeCache, retention != .none,
            let sid = clampOpenAIPromptCacheKey(options?.sessionId) {
@@ -405,7 +416,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
     // MARK: - Reasoning / thinking format
 
     /// Subset of pi's resolved OpenAI-completions compat that the reasoning
-    /// encoder needs. Auto-detected from provider/baseUrl, then overlaid with
+    /// encoder needs. Auto-detected from provider/baseURL, then overlaid with
     /// any explicit `model.compat`.
     struct ResolvedCompletionsCompat {
         var supportsStore: Bool
@@ -429,7 +440,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
     }
 
     static func resolveCompat(_ model: Model) -> ResolvedCompletionsCompat {
-        let url = model.baseUrl.lowercased()
+        let url = model.baseURL.lowercased()
         let provider = model.provider
         func has(_ s: String) -> Bool { url.contains(s) }
         let isZai = provider == "zai" || provider == "zai-coding-cn" || has("api.z.ai") || has("bigmodel.cn")
@@ -923,14 +934,27 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         )
     }
 
+    private static func makeAborted(api: String, model: Model) -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Request was aborted",
+            timestamp: Timestamp.now()
+        )
+    }
+
     private static func errorBodyPreview(
-        from stream: AsyncThrowingStream<UInt8, Error>,
+        from stream: AsyncThrowingStream<Data, Error>,
         limit: Int = 4096
     ) async -> String {
         var data = Data()
         do {
-            for try await byte in stream {
-                data.append(byte)
+            for try await chunk in stream {
+                data.append(chunk)
                 if data.count >= limit {
                     break
                 }
@@ -1120,7 +1144,13 @@ final class OpenAICompletionsState: @unchecked Sendable {
         usage.cost = calculateCost(model: model, usage: usage)
     }
 
-    func snapshot() -> AssistantMessage {
+    /// Streaming snapshot. In-progress tool calls use an empty-object
+    /// placeholder rather than re-parsing the growing JSON buffer on every
+    /// delta (O(n^2)); full arguments are parsed once in
+    /// `finalizeStreamingBlocks`/`finalize`.
+    func snapshot() -> AssistantMessage { buildMessage(parseToolArgs: false) }
+
+    private func buildMessage(parseToolArgs: Bool) -> AssistantMessage {
         lock.withLock {
             AssistantMessage(
                 content: order.compactMap { idx -> AssistantBlock? in
@@ -1128,7 +1158,7 @@ final class OpenAICompletionsState: @unchecked Sendable {
                     case .text(let t): return .text(t)
                     case .thinking(let th): return .thinking(th)
                     case .toolUse(let id, let name, let json, let sig):
-                        let args = parseArguments(json)
+                        let args: JSONValue = parseToolArgs ? parseArguments(json) : .object([:])
                         return .toolCall(ToolCall(id: id, name: name, arguments: args, thoughtSignature: sig))
                     case .none: return nil
                     }
@@ -1166,12 +1196,12 @@ final class OpenAICompletionsState: @unchecked Sendable {
     }
 
     func finalize() -> AssistantMessage {
-        snapshot()
+        buildMessage(parseToolArgs: true)
     }
 
     func asAborted() -> AssistantMessage {
         stopReason = .aborted
-        var m = snapshot()
+        var m = buildMessage(parseToolArgs: true)
         m.errorMessage = "Request was aborted"
         return m
     }
@@ -1189,14 +1219,14 @@ final class OpenAICompletionsState: @unchecked Sendable {
 /// Expand Cloudflare base-URL placeholders (`{CLOUDFLARE_ACCOUNT_ID}` /
 /// `{CLOUDFLARE_GATEWAY_ID}`) from an explicit value source. Mirrors pi's
 /// `resolveCloudflareBaseUrl`: the catalog stores the literal tokens in
-/// `model.baseUrl` and they are substituted at request time.
+/// `model.baseURL` and they are substituted at request time.
 /// Unknown/missing values collapse to the empty string.
 func substituteCloudflarePlaceholders(
-    in baseUrl: String,
+    in baseURL: String,
     value: (String) -> String?
 ) -> String {
-    guard baseUrl.contains("{CLOUDFLARE_") else { return baseUrl }
-    var result = baseUrl
+    guard baseURL.contains("{CLOUDFLARE_") else { return baseURL }
+    var result = baseURL
     for token in ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID"] {
         let needle = "{\(token)}"
         guard result.contains(needle) else { continue }

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -59,9 +59,9 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
         self.bodyOverrides = bodyOverrides
         self.maxWebSocketFailures = max(1, maxWebSocketFailures)
         self.urlBuilder = urlBuilder ?? { model, _, fallback in
-            var base = model.baseUrl.isEmpty ? fallback.absoluteString : model.baseUrl
+            var base = model.baseURL.isEmpty ? fallback.absoluteString : model.baseURL
             while base.hasSuffix("/") { base.removeLast() }
-            // Tolerate catalog entries that bake `/v1` into baseUrl
+            // Tolerate catalog entries that bake `/v1` into baseURL
             // (pi-mono's models.generated.ts does this for OpenAI).
             let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
             return URL(string: "\(versioned)/responses") ?? fallback.appendingPathComponent("v1/responses")
@@ -183,7 +183,7 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                 // network captures.
                 var body = Data()
                 do {
-                    for try await byte in stream { body.append(byte) }
+                    for try await chunk in stream { body.append(chunk) }
                 } catch {
                     // ignore — best effort
                 }
@@ -198,11 +198,22 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             }
             let state = OpenAIResponsesState(api: api, provider: model.provider, modelId: model.id)
             state.signal = options?.cancellation
-            _ = try await drive(events: parseSSE(bytes: stream), out: out, state: state)
+            // Bridge external cancellation to the in-flight request (see
+            // AnthropicProvider.run for the rationale).
+            let driveTask = Task { _ = try await self.drive(events: parseSSE(bytes: stream), out: out, state: state) }
+            let cancelReg = options?.cancellation?.onCancel { _ in driveTask.cancel() }
+            defer { cancelReg?.cancel() }
+            try await driveTask.value
         } catch {
-            let msg = Self.makeError(api: api, model: model, text: "\(error)")
-            out.push(.error(reason: .error, error: msg))
-            out.end(msg)
+            if options?.cancellation?.isCancelled == true {
+                let aborted = Self.makeAborted(api: api, model: model)
+                out.push(.error(reason: .aborted, error: aborted))
+                out.end(aborted)
+            } else {
+                let msg = Self.makeError(api: api, model: model, text: "\(error)")
+                out.push(.error(reason: .error, error: msg))
+                out.end(msg)
+            }
         }
     }
 
@@ -342,7 +353,7 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             if result.completed, let responseId = result.message.responseId {
                 session.recordCompletedResponse(
                     responseId: responseId,
-                    itemsAdded: Self.encodeAssistantOutputItems(result.message)
+                    itemsAdded: Self.encodeAssistantOutputItems(result.message, model: model)
                 )
                 session.storeConnection(connection)
                 await options?.emitVerbose(
@@ -618,6 +629,16 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                         )
                     }
                     if let index = state.reasoningIndex(for: outputIndex) {
+                        // Persist the full reasoning item (including
+                        // `encrypted_content` and its `id`) on the thinking
+                        // block's signature so encrypted reasoning round-trips
+                        // across turns when the response isn't stored
+                        // server-side (`store: false`). Mirrors pi.
+                        if case .object(let item) = obj["item"] ?? .null,
+                           case .string = item["encrypted_content"] ?? .null,
+                           let serialized = Self.serializeReasoningItem(item) {
+                            state.setThinkingSignature(at: index, signature: serialized)
+                        }
                         let content = state.thinkingValue(at: index)
                         out.push(.thinkingEnd(contentIndex: index, content: content, partial: state.snapshot()))
                     }
@@ -644,6 +665,24 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                 out.push(.done(reason: final.stopReason, message: final))
                 out.end(final)
                 return OpenAIResponsesDriveResult(message: final, completed: true)
+
+            case "response.incomplete":
+                // Terminal event when the response is truncated (e.g.
+                // `max_output_tokens` reached). A length-truncated turn is a
+                // normal completion, not a transport failure — finish via the
+                // same success path as `response.completed` with `.length` so
+                // it isn't misreported as `.stop` over HTTP or as a WebSocket
+                // failure that eventually disables the transport.
+                if case .object(let response) = obj["response"] ?? .null {
+                    if case .object(let usage) = response["usage"] ?? .null {
+                        state.applyUsage(usage)
+                    }
+                }
+                state.stopReason = .length
+                let incomplete = state.finalize()
+                out.push(.done(reason: incomplete.stopReason, message: incomplete))
+                out.end(incomplete)
+                return OpenAIResponsesDriveResult(message: incomplete, completed: true)
 
             case "response.failed", "response.error":
                 let text: String = {
@@ -674,7 +713,20 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             }
         }
 
-        // Stream closed without explicit `response.completed`.
+        // Stream closed without an explicit terminal event. On the HTTP path a
+        // cancellation during a silent gap tears the stream down here; surface
+        // it as aborted rather than a clean stop. (The WebSocket path handles
+        // its own cancellation via `endedWithoutTerminalEvent` in runWebSocket.)
+        if finishOnStreamEnd, state.signal?.isCancelled == true {
+            let aborted = state.asAborted()
+            out.push(.error(reason: .aborted, error: aborted))
+            out.end(aborted)
+            return OpenAIResponsesDriveResult(
+                message: aborted,
+                completed: false,
+                endedWithoutTerminalEvent: true
+            )
+        }
         let final = state.finalize()
         if finishOnStreamEnd {
             out.push(.done(reason: final.stopReason, message: final))
@@ -698,7 +750,7 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
         var root: [String: JSONValue] = [
             "model": .string(model.id),
             "stream": .bool(true),
-            "input": .array(encodeInput(context: context)),
+            "input": .array(encodeInput(context: context, model: model)),
         ]
         if let maxTokens = options?.maxTokens ?? (model.maxTokens > 0 ? model.maxTokens : nil) {
             root["max_output_tokens"] = .int(maxTokens)
@@ -810,10 +862,10 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
     }
 
     /// Convert our Message transcript into OpenAI Responses' `input` array.
-    /// Each element is a typed item (`message`, `function_call`, or
-    /// `function_call_output`). Assistant messages with tool calls expand
+    /// Each element is a typed item (`reasoning`, `message`, `function_call`,
+    /// or `function_call_output`). Assistant messages with tool calls expand
     /// into multiple items.
-    private static func encodeInput(context: Context) -> [JSONValue] {
+    private static func encodeInput(context: Context, model: Model) -> [JSONValue] {
         var out: [JSONValue] = []
         for message in context.messages {
             switch message {
@@ -833,6 +885,20 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                 out.append(.object(["type": .string("message"), "role": .string("user"), "content": .array(parts)]))
 
             case .assistant(let a):
+                // Replay captured encrypted reasoning items so the model keeps
+                // its prior chain-of-thought across turns. Only valid for the
+                // same model/api/provider (encrypted_content is model-bound) and
+                // only when the stored signature is an actual reasoning item.
+                let sameModel = a.provider == model.provider
+                    && a.api == model.api && a.model == model.id
+                if sameModel {
+                    for block in a.content {
+                        guard case .thinking(let th) = block,
+                              let sig = th.thinkingSignature, !sig.isEmpty,
+                              let item = Self.parseReasoningItem(sig) else { continue }
+                        out.append(.object(item))
+                    }
+                }
                 let textParts: [JSONValue] = a.content.compactMap { block in
                     guard case .text(let t) = block, !t.text.isEmpty else { return nil }
                     return .object(["type": .string("output_text"), "text": .string(t.text)])
@@ -878,8 +944,29 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
         return out
     }
 
-    private static func encodeAssistantOutputItems(_ message: AssistantMessage) -> [JSONValue] {
-        encodeInput(context: Context(messages: [.assistant(message)]))
+    private static func encodeAssistantOutputItems(_ message: AssistantMessage, model: Model) -> [JSONValue] {
+        encodeInput(context: Context(messages: [.assistant(message)]), model: model)
+    }
+
+    /// Serialize a streamed reasoning item (the full `item` object from
+    /// `response.output_item.done`, including `encrypted_content` and `id`) to a
+    /// JSON string for storage on the thinking block's signature.
+    private static func serializeReasoningItem(_ item: [String: JSONValue]) -> String? {
+        guard let any = anyFromJSONValue(.object(item)),
+              let data = try? JSONSerialization.data(withJSONObject: any, options: [.sortedKeys]),
+              let s = String(data: data, encoding: .utf8) else { return nil }
+        return s
+    }
+
+    /// Parse a stored reasoning-item signature back into its object form,
+    /// validating that it is actually a `reasoning` item (so signatures from
+    /// other providers' formats are never mis-replayed as reasoning).
+    private static func parseReasoningItem(_ serialized: String) -> [String: JSONValue]? {
+        guard let data = serialized.data(using: .utf8),
+              let value = try? JSONDecoder().decode(JSONValue.self, from: data),
+              case .object(let obj) = value,
+              case .string("reasoning")? = obj["type"] else { return nil }
+        return obj
     }
 
     private static func encodeToolChoice(_ choice: ToolChoice?) -> JSONValue? {
@@ -912,6 +999,19 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
             usage: Usage(),
             stopReason: .error,
             errorMessage: text,
+            timestamp: Timestamp.now()
+        )
+    }
+
+    private static func makeAborted(api: String, model: Model) -> AssistantMessage {
+        AssistantMessage(
+            content: [],
+            api: api,
+            provider: model.provider,
+            model: model.id,
+            usage: Usage(),
+            stopReason: .aborted,
+            errorMessage: "Request was aborted",
             timestamp: Timestamp.now()
         )
     }
@@ -1326,6 +1426,15 @@ final class OpenAIResponsesState: @unchecked Sendable {
         }
     }
 
+    func setThinkingSignature(at index: Int, signature: String) {
+        lock.withLock {
+            if case .thinking(var th) = blocks[index] {
+                th.thinkingSignature = signature
+                blocks[index] = .thinking(th)
+            }
+        }
+    }
+
     func appendToolCallArgs(at index: Int, chunk: String) {
         lock.withLock {
             if case .toolUse(let id, let name, let json) = blocks[index] {
@@ -1369,7 +1478,13 @@ final class OpenAIResponsesState: @unchecked Sendable {
         usage.totalTokens = usage.input + usage.output + usage.cacheRead + usage.cacheWrite
     }
 
-    func snapshot() -> AssistantMessage {
+    /// Streaming snapshot. In-progress tool calls use an empty-object
+    /// placeholder rather than re-parsing the growing JSON buffer on every
+    /// delta (O(n^2)); full arguments are parsed once in `finalize`
+    /// (and in `toolCallValue` for the `toolCallEnd` event).
+    func snapshot() -> AssistantMessage { buildMessage(parseToolArgs: false) }
+
+    private func buildMessage(parseToolArgs: Bool) -> AssistantMessage {
         lock.withLock {
             AssistantMessage(
                 content: order.compactMap { idx -> AssistantBlock? in
@@ -1377,7 +1492,8 @@ final class OpenAIResponsesState: @unchecked Sendable {
                     case .text(let t): return .text(t)
                     case .thinking(let th): return .thinking(th)
                     case .toolUse(let id, let name, let json):
-                        return .toolCall(ToolCall(id: id, name: name, arguments: parseArguments(json)))
+                        let args: JSONValue = parseToolArgs ? parseArguments(json) : .object([:])
+                        return .toolCall(ToolCall(id: id, name: name, arguments: args))
                     case .none: return nil
                     }
                 },
@@ -1393,7 +1509,7 @@ final class OpenAIResponsesState: @unchecked Sendable {
         }
     }
 
-    func finalize() -> AssistantMessage { snapshot() }
+    func finalize() -> AssistantMessage { buildMessage(parseToolArgs: true) }
 
     func asAborted() -> AssistantMessage {
         stopReason = .aborted

--- a/Sources/KWWKAI/ProviderAttribution.swift
+++ b/Sources/KWWKAI/ProviderAttribution.swift
@@ -69,28 +69,28 @@ public enum ProviderAttribution {
     private static let cloudflareAIGatewayHost = "gateway.ai.cloudflare.com"
     private static let vercelGatewayHost = "ai-gateway.vercel.sh"
 
-    private static func matchesHost(_ baseUrl: String, _ expectedHost: String) -> Bool {
-        guard let host = URLComponents(string: baseUrl)?.host else { return false }
+    private static func matchesHost(_ baseURL: String, _ expectedHost: String) -> Bool {
+        guard let host = URLComponents(string: baseURL)?.host else { return false }
         return host == expectedHost
     }
 
-    private static func isOpenRouter(provider: String, baseUrl: String) -> Bool {
-        provider == "openrouter" || baseUrl.contains(openRouterHost)
+    private static func isOpenRouter(provider: String, baseURL: String) -> Bool {
+        provider == "openrouter" || baseURL.contains(openRouterHost)
     }
 
-    private static func isNvidiaNim(provider: String, baseUrl: String) -> Bool {
-        provider == "nvidia" || matchesHost(baseUrl, nvidiaNimHost)
+    private static func isNvidiaNim(provider: String, baseURL: String) -> Bool {
+        provider == "nvidia" || matchesHost(baseURL, nvidiaNimHost)
     }
 
-    private static func isCloudflare(provider: String, baseUrl: String) -> Bool {
+    private static func isCloudflare(provider: String, baseURL: String) -> Bool {
         provider == "cloudflare-workers-ai"
             || provider == "cloudflare-ai-gateway"
-            || matchesHost(baseUrl, cloudflareAPIHost)
-            || matchesHost(baseUrl, cloudflareAIGatewayHost)
+            || matchesHost(baseURL, cloudflareAPIHost)
+            || matchesHost(baseURL, cloudflareAIGatewayHost)
     }
 
-    private static func isVercelGateway(provider: String, baseUrl: String) -> Bool {
-        provider == "vercel-ai-gateway" || matchesHost(baseUrl, vercelGatewayHost)
+    private static func isVercelGateway(provider: String, baseURL: String) -> Bool {
+        provider == "vercel-ai-gateway" || matchesHost(baseURL, vercelGatewayHost)
     }
 
     /// Branded attribution headers to merge into a request for `provider`,
@@ -101,22 +101,22 @@ public enum ProviderAttribution {
     /// headers (explicit per-model `Model.headers` should win on conflict).
     public static func attributionHeaders(
         provider: String,
-        baseUrl: String = ""
+        baseURL: String = ""
     ) -> [String: String]? {
-        if isOpenRouter(provider: provider, baseUrl: baseUrl) {
+        if isOpenRouter(provider: provider, baseURL: baseURL) {
             return [
                 "HTTP-Referer": "https://kwwk.dev",
                 "X-OpenRouter-Title": "kwwk",
                 "X-OpenRouter-Categories": "cli-agent",
             ]
         }
-        if isNvidiaNim(provider: provider, baseUrl: baseUrl) {
+        if isNvidiaNim(provider: provider, baseURL: baseURL) {
             return ["X-BILLING-INVOKE-ORIGIN": "kwwk"]
         }
-        if isCloudflare(provider: provider, baseUrl: baseUrl) {
+        if isCloudflare(provider: provider, baseURL: baseURL) {
             return ["User-Agent": "kwwk-coding-agent"]
         }
-        if isVercelGateway(provider: provider, baseUrl: baseUrl) {
+        if isVercelGateway(provider: provider, baseURL: baseURL) {
             return [
                 "http-referer": "https://kwwk.dev",
                 "x-title": "kwwk",
@@ -127,7 +127,7 @@ public enum ProviderAttribution {
 
     /// Convenience overload taking a `Model`.
     public static func attributionHeaders(for model: Model) -> [String: String]? {
-        attributionHeaders(provider: model.provider, baseUrl: model.baseUrl)
+        attributionHeaders(provider: model.provider, baseURL: model.baseURL)
     }
 
     /// Merge attribution headers for `model` with any caller-supplied header

--- a/Sources/KWWKAI/ProviderVariants.swift
+++ b/Sources/KWWKAI/ProviderVariants.swift
@@ -102,7 +102,7 @@ public enum ProviderVariants {
             defaultBaseURL: baseURL,
             defaultAPIKey: apiKey,
             urlBuilder: { model, _, fallback in
-                var base = model.baseUrl.isEmpty ? fallbackBase : model.baseUrl
+                var base = model.baseURL.isEmpty ? fallbackBase : model.baseURL
                 while base.hasSuffix("/") { base.removeLast() }
                 base = substituteCloudflarePlaceholders(in: base) { token in
                     token == "CLOUDFLARE_ACCOUNT_ID" ? accountId : nil
@@ -141,7 +141,7 @@ public enum ProviderVariants {
             defaultBaseURL: baseURL,
             defaultAPIKey: apiKey,
             urlBuilder: { model, _, fallback in
-                var base = model.baseUrl.isEmpty ? fallbackBase : model.baseUrl
+                var base = model.baseURL.isEmpty ? fallbackBase : model.baseURL
                 while base.hasSuffix("/") { base.removeLast() }
                 base = substituteCloudflarePlaceholders(in: base) { token in
                     switch token {
@@ -313,14 +313,14 @@ public enum ProviderVariants {
         api: String = "anthropic-messages",
         baseURL: URL = URL(string: "https://api.individual.githubcopilot.com")!
     ) -> AnthropicProvider {
-        // AnthropicProvider's default urlBuilder reads `model.baseUrl`,
+        // AnthropicProvider's default urlBuilder reads `model.baseURL`,
         // which the Copilot catalog pins to `api.individual.githubcopilot.com`
         // — that would bypass the session's enterprise/business proxy
         // endpoint. We can't inject a urlBuilder on AnthropicProvider, so
-        // `defaultBaseURL` is the fallback when `model.baseUrl.isEmpty`.
+        // `defaultBaseURL` is the fallback when `model.baseURL.isEmpty`.
         // Callers who need enterprise routing should normalize
-        // `model.baseUrl` via `adoptFields` on `/model` switches, which
-        // keeps the session baseUrl across catalog swaps.
+        // `model.baseURL` via `adoptFields` on `/model` switches, which
+        // keeps the session baseURL across catalog swaps.
         AnthropicProvider(
             api: api,
             client: client,

--- a/Sources/KWWKAI/RegisterBuiltins.swift
+++ b/Sources/KWWKAI/RegisterBuiltins.swift
@@ -40,22 +40,22 @@ public func registerBuiltins(
     var registered: [String] = []
     if let key = anthropic {
         let provider = AnthropicProvider(client: client, defaultAPIKey: key)
-        await registry.register(provider, sourceId: sourceId)
+        await registry.register(provider, sourceId: sourceId, providerVendor: "anthropic")
         registered.append(provider.api)
     }
     if let key = openaiCompletions {
         let provider = OpenAICompletionsProvider(client: client, defaultAPIKey: key)
-        await registry.register(provider, sourceId: sourceId)
+        await registry.register(provider, sourceId: sourceId, providerVendor: "openai")
         registered.append(provider.api)
     }
     if let key = openaiResponses {
         let provider = OpenAIResponsesProvider(client: client, defaultAPIKey: key)
-        await registry.register(provider, sourceId: sourceId)
+        await registry.register(provider, sourceId: sourceId, providerVendor: "openai")
         registered.append(provider.api)
     }
     if let key = google {
         let provider = GoogleGeminiProvider(client: client, defaultAPIKey: key)
-        await registry.register(provider, sourceId: sourceId)
+        await registry.register(provider, sourceId: sourceId, providerVendor: "google")
         registered.append(provider.api)
     }
     return registered
@@ -94,7 +94,7 @@ public enum Models {
         name: "Claude Opus 4.8",
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25),
@@ -107,7 +107,7 @@ public enum Models {
         name: "Claude Sonnet 5",
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5),
@@ -124,7 +124,7 @@ public enum Models {
         name: "Claude Haiku 4.5",
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25),
@@ -137,7 +137,7 @@ public enum Models {
         name: "GPT-5.5",
         api: "openai-responses",
         provider: "openai",
-        baseUrl: "https://api.openai.com",
+        baseURL: "https://api.openai.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0),
@@ -150,7 +150,7 @@ public enum Models {
         name: "GPT-5.4 mini",
         api: "openai-responses",
         provider: "openai",
-        baseUrl: "https://api.openai.com",
+        baseURL: "https://api.openai.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0),
@@ -163,7 +163,7 @@ public enum Models {
         name: "Gemini 3.5 Flash",
         api: "google-generative-ai",
         provider: "google",
-        baseUrl: "https://generativelanguage.googleapis.com",
+        baseURL: "https://generativelanguage.googleapis.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 1.5, output: 9, cacheRead: 0.15, cacheWrite: 0),
@@ -176,7 +176,7 @@ public enum Models {
         name: "Gemini 3.1 Pro Preview",
         api: "google-generative-ai",
         provider: "google",
-        baseUrl: "https://generativelanguage.googleapis.com",
+        baseURL: "https://generativelanguage.googleapis.com",
         reasoning: true,
         input: [.text, .image],
         cost: ModelCost(input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0),
@@ -191,7 +191,7 @@ public enum Models {
             name: id,
             api: "openai-completions",
             provider: "xai",
-            baseUrl: "https://api.x.ai",
+            baseURL: "https://api.x.ai",
             reasoning: true,
             input: [.text],
             contextWindow: 131_072,
@@ -206,7 +206,7 @@ public enum Models {
             name: id,
             api: "openai-completions",
             provider: "groq",
-            baseUrl: "https://api.groq.com/openai",
+            baseURL: "https://api.groq.com/openai",
             reasoning: true,
             input: [.text],
             contextWindow: 131_072,
@@ -221,7 +221,7 @@ public enum Models {
             name: id,
             api: "openai-completions",
             provider: "openrouter",
-            baseUrl: "https://openrouter.ai/api",
+            baseURL: "https://openrouter.ai/api",
             reasoning: true,
             input: [.text],
             contextWindow: 131_072,

--- a/Sources/KWWKAI/SSEParser.swift
+++ b/Sources/KWWKAI/SSEParser.swift
@@ -16,12 +16,41 @@ public final class SSEParser: @unchecked Sendable {
     private var dataLines: [String] = []
     private var id: String?
     private var pending: [SSEMessage] = []
+    /// Trailing bytes from the previous `ingest(bytes:)` that formed an
+    /// incomplete multi-byte UTF-8 sequence. Prepended to the next chunk so a
+    /// character split across a network read is not dropped.
+    private var carryBytes = Data()
 
     public init() {}
 
     public func ingest(bytes: Data) {
-        guard let s = String(data: bytes, encoding: .utf8) else { return }
-        ingest(s)
+        var buffer = carryBytes
+        buffer.append(bytes)
+        let (decoded, remaining) = Self.decodeUTF8Prefix(buffer)
+        carryBytes = remaining
+        if !decoded.isEmpty { ingest(decoded) }
+    }
+
+    /// Split `data` into its longest UTF-8-decodable prefix and any trailing
+    /// bytes that form an incomplete multi-byte sequence (kept for the next
+    /// call). If the data contains a genuinely invalid sequence rather than a
+    /// boundary split, decode it lossily so the parser still makes progress.
+    static func decodeUTF8Prefix(_ data: Data) -> (String, Data) {
+        if data.isEmpty { return ("", Data()) }
+        if let s = String(data: data, encoding: .utf8) { return (s, Data()) }
+        // A UTF-8 sequence is at most 4 bytes, so an incomplete trailing
+        // character lives in the last 3 bytes. Trim them one at a time looking
+        // for a valid prefix.
+        var end = data.count
+        let lower = Swift.max(0, data.count - 3)
+        while end > lower {
+            end -= 1
+            let prefix = data.subdata(in: 0..<end)
+            if let s = String(data: prefix, encoding: .utf8) {
+                return (s, data.subdata(in: end..<data.count))
+            }
+        }
+        return (String(decoding: data, as: UTF8.self), Data())
     }
 
     public func ingest(_ text: String) {
@@ -86,25 +115,17 @@ public final class SSEParser: @unchecked Sendable {
 
 /// Parse a stream of bytes into an async sequence of `SSEMessage`.
 public func parseSSE(
-    bytes: AsyncThrowingStream<UInt8, Error>
+    bytes: AsyncThrowingStream<Data, Error>
 ) -> AsyncThrowingStream<SSEMessage, Error> {
     AsyncThrowingStream { continuation in
         let task = Task {
             let parser = SSEParser()
-            var chunk = [UInt8]()
             do {
-                for try await byte in bytes {
-                    chunk.append(byte)
-                    if byte == 0x0a {
-                        parser.ingest(bytes: Data(chunk))
-                        chunk.removeAll()
-                        for msg in parser.drain() {
-                            continuation.yield(msg)
-                        }
+                for try await chunk in bytes {
+                    parser.ingest(bytes: chunk)
+                    for msg in parser.drain() {
+                        continuation.yield(msg)
                     }
-                }
-                if !chunk.isEmpty {
-                    parser.ingest(bytes: Data(chunk))
                 }
                 for msg in parser.finish() {
                     continuation.yield(msg)

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -83,7 +83,7 @@ public struct AgentOptions: Sendable {
     /// Automatic context compaction. Disabled by default so SDK callers do
     /// not trigger extra model calls or transcript rewrites unless requested.
     public var autoCompact: AgentAutoCompactOptions?
-    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    public var authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
 
     public init(
         initialState: AgentInitialState,
@@ -104,7 +104,7 @@ public struct AgentOptions: Sendable {
         transformContext: TransformContextHook? = nil,
         betweenTurns: BetweenTurnsHook? = nil,
         autoCompact: AgentAutoCompactOptions? = nil,
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil
     ) {
         self.initialState = initialState
         self.streamFn = streamFn
@@ -139,25 +139,98 @@ public final class Agent: @unchecked Sendable {
     private var activeCancellation: CancellationHandle?
     private var idleWaiters: [CheckedContinuation<Void, Never>] = []
 
-    public var sessionId: String?
-    public var thinkingBudgets: ThinkingBudgets?
-    public var maxRetryDelayMs: Int?
-    public var maxTurns: Int?
-    public var toolExecution: ToolExecutionMode
-    public var toolChoice: ToolChoice?
-    public var parallelToolCalls: Bool?
-    public var beforeToolCall: BeforeToolCallHook?
-    public var afterToolCall: AfterToolCallHook?
-    public var userPromptSubmit: UserPromptSubmitHook?
-    public var convertToLlm: ConvertToLlmHook?
-    public var transformContext: TransformContextHook?
-    public var betweenTurns: BetweenTurnsHook?
-    public var autoCompact: AgentAutoCompactOptions?
-    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    /// Immutable session identity: one `Agent` == one session. Rotating to a
+    /// new session means building a fresh `Agent`/`SessionRecorder` through the
+    /// supported path (the CLI's `/new` and `/resume` re-point the recorder and
+    /// clear the live context). There is deliberately no in-place setter —
+    /// mutating it would leave tools, the recorder, and background attachments
+    /// scoped to different ids.
+    public let sessionId: String?
+
+    // Mutable run configuration. `loopConfig()` reads these on the run's task
+    // while the public setters may be invoked from any thread (steer() is
+    // documented "from any thread"), so every access funnels through `lock`.
+    // This is what justifies the `@unchecked Sendable` annotation — mirrors
+    // AgentState, whose fields are all lock-guarded the same way.
+    private var _thinkingBudgets: ThinkingBudgets?
+    private var _maxRetryDelayMs: Int?
+    private var _maxTurns: Int?
+    private var _toolExecution: ToolExecutionMode
+    private var _toolChoice: ToolChoice?
+    private var _parallelToolCalls: Bool?
+    private var _beforeToolCall: BeforeToolCallHook?
+    private var _afterToolCall: AfterToolCallHook?
+    private var _userPromptSubmit: UserPromptSubmitHook?
+    private var _convertToLlm: ConvertToLlmHook?
+    private var _transformContext: TransformContextHook?
+    private var _betweenTurns: BetweenTurnsHook?
+    private var _autoCompact: AgentAutoCompactOptions?
+    private var _authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
+    private var _retryBaseDelayMs: UInt64 = 1_000
+
+    public var thinkingBudgets: ThinkingBudgets? {
+        get { lock.withLock { _thinkingBudgets } }
+        set { lock.withLock { _thinkingBudgets = newValue } }
+    }
+    public var maxRetryDelayMs: Int? {
+        get { lock.withLock { _maxRetryDelayMs } }
+        set { lock.withLock { _maxRetryDelayMs = newValue } }
+    }
+    public var maxTurns: Int? {
+        get { lock.withLock { _maxTurns } }
+        set { lock.withLock { _maxTurns = newValue } }
+    }
+    public var toolExecution: ToolExecutionMode {
+        get { lock.withLock { _toolExecution } }
+        set { lock.withLock { _toolExecution = newValue } }
+    }
+    public var toolChoice: ToolChoice? {
+        get { lock.withLock { _toolChoice } }
+        set { lock.withLock { _toolChoice = newValue } }
+    }
+    public var parallelToolCalls: Bool? {
+        get { lock.withLock { _parallelToolCalls } }
+        set { lock.withLock { _parallelToolCalls = newValue } }
+    }
+    public var beforeToolCall: BeforeToolCallHook? {
+        get { lock.withLock { _beforeToolCall } }
+        set { lock.withLock { _beforeToolCall = newValue } }
+    }
+    public var afterToolCall: AfterToolCallHook? {
+        get { lock.withLock { _afterToolCall } }
+        set { lock.withLock { _afterToolCall = newValue } }
+    }
+    public var userPromptSubmit: UserPromptSubmitHook? {
+        get { lock.withLock { _userPromptSubmit } }
+        set { lock.withLock { _userPromptSubmit = newValue } }
+    }
+    public var convertToLlm: ConvertToLlmHook? {
+        get { lock.withLock { _convertToLlm } }
+        set { lock.withLock { _convertToLlm = newValue } }
+    }
+    public var transformContext: TransformContextHook? {
+        get { lock.withLock { _transformContext } }
+        set { lock.withLock { _transformContext = newValue } }
+    }
+    public var betweenTurns: BetweenTurnsHook? {
+        get { lock.withLock { _betweenTurns } }
+        set { lock.withLock { _betweenTurns = newValue } }
+    }
+    public var autoCompact: AgentAutoCompactOptions? {
+        get { lock.withLock { _autoCompact } }
+        set { lock.withLock { _autoCompact = newValue } }
+    }
+    public var authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? {
+        get { lock.withLock { _authResolver } }
+        set { lock.withLock { _authResolver = newValue } }
+    }
 
     /// Base delay (ms) used for exponential backoff between stream retries.
     /// Exposed internally so tests can shrink the 1-second default.
-    internal var retryBaseDelayMs: UInt64 = 1_000
+    internal var retryBaseDelayMs: UInt64 {
+        get { lock.withLock { _retryBaseDelayMs } }
+        set { lock.withLock { _retryBaseDelayMs = newValue } }
+    }
 
     private let steeringQueue: PendingMessageQueue
     private let followUpQueue: PendingMessageQueue
@@ -194,21 +267,24 @@ public final class Agent: @unchecked Sendable {
         self.streamFn = options.streamFn ?? { model, context, options in
             try await KWWKAI.stream(model: model, context: context, options: options)
         }
-        self.toolExecution = options.toolExecution
-        self.toolChoice = options.toolChoice
-        self.parallelToolCalls = options.parallelToolCalls
         self.sessionId = options.sessionId
-        self.thinkingBudgets = options.thinkingBudgets
-        self.maxRetryDelayMs = options.maxRetryDelayMs
-        self.maxTurns = options.maxTurns
-        self.beforeToolCall = options.beforeToolCall
-        self.afterToolCall = options.afterToolCall
-        self.userPromptSubmit = options.userPromptSubmit
-        self.convertToLlm = options.convertToLlm
-        self.transformContext = options.transformContext
-        self.betweenTurns = options.betweenTurns
-        self.autoCompact = options.autoCompact
-        self.authResolver = options.authResolver
+        // Assign backing storage directly — the public accessors are
+        // lock-guarded computed properties, so they can't be used until every
+        // stored property is initialized.
+        self._toolExecution = options.toolExecution
+        self._toolChoice = options.toolChoice
+        self._parallelToolCalls = options.parallelToolCalls
+        self._thinkingBudgets = options.thinkingBudgets
+        self._maxRetryDelayMs = options.maxRetryDelayMs
+        self._maxTurns = options.maxTurns
+        self._beforeToolCall = options.beforeToolCall
+        self._afterToolCall = options.afterToolCall
+        self._userPromptSubmit = options.userPromptSubmit
+        self._convertToLlm = options.convertToLlm
+        self._transformContext = options.transformContext
+        self._betweenTurns = options.betweenTurns
+        self._autoCompact = options.autoCompact
+        self._authResolver = options.authResolver
         self.steeringQueue = PendingMessageQueue(mode: options.steeringMode)
         self.followUpQueue = PendingMessageQueue(mode: options.followUpMode)
     }
@@ -224,8 +300,20 @@ public final class Agent: @unchecked Sendable {
     /// Queue a message to inject after the current assistant turn finishes.
     public func steer(_ message: Message) { steeringQueue.enqueue(message) }
 
+    /// Convenience: steer a plain-text user message.
+    public func steer(_ text: String) { steer(.user(UserMessage(text: text))) }
+
+    /// Convenience: steer a `UserMessage` without wrapping it in `.user(...)`.
+    public func steer(_ message: UserMessage) { steer(.user(message)) }
+
     /// Queue a message to run only after the agent would otherwise stop.
     public func followUp(_ message: Message) { followUpQueue.enqueue(message) }
+
+    /// Convenience: follow up with a plain-text user message.
+    public func followUp(_ text: String) { followUp(.user(UserMessage(text: text))) }
+
+    /// Convenience: follow up with a `UserMessage` without `.user(...)` wrapping.
+    public func followUp(_ message: UserMessage) { followUp(.user(message)) }
 
     public func clearSteeringQueue() { steeringQueue.clear() }
     public func clearFollowUpQueue() { followUpQueue.clear() }

--- a/Sources/KWWKAgent/AgentContextCompactor.swift
+++ b/Sources/KWWKAgent/AgentContextCompactor.swift
@@ -149,7 +149,7 @@ public enum AgentContextCompactor {
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String?,
         config: AgentContextCompactionConfig = .init(),
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         transformContext: TransformContextHook? = nil,
         convertToLlm: ConvertToLlmHook? = nil,
         streamFn: StreamFn? = nil,
@@ -247,7 +247,7 @@ public enum AgentContextCompactor {
         model: Model,
         sessionId: String?,
         config: AgentContextCompactionConfig = .init(),
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         streamFn: StreamFn? = nil,
         cancellation: CancellationHandle? = nil
     ) async throws -> String {
@@ -285,10 +285,10 @@ public enum AgentContextCompactor {
             tools: []
         )
 
-        let resolvedAuth = await authResolver?(model, sessionId)
+        let resolvedAuth = try await authResolver?(model, sessionId)
         var requestModel = model
         if let baseURL = resolvedAuth?.baseURL, !baseURL.isEmpty {
-            requestModel.baseUrl = baseURL
+            requestModel.baseURL = baseURL
         }
         let metadata: [String: JSONValue]? = {
             guard let authMetadata = resolvedAuth?.metadata, !authMetadata.isEmpty else { return nil }

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -22,7 +22,7 @@ public struct AgentLoopConfig: Sendable {
     public var retryBaseDelayMs: UInt64
     public var getSteeringMessages: @Sendable () async -> [Message]
     public var getFollowUpMessages: @Sendable () async -> [Message]
-    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    public var authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
     public var beforeToolCall: BeforeToolCallHook?
     public var afterToolCall: AfterToolCallHook?
     public var userPromptSubmit: UserPromptSubmitHook?
@@ -44,7 +44,7 @@ public struct AgentLoopConfig: Sendable {
         retryBaseDelayMs: UInt64 = 1_000,
         getSteeringMessages: @escaping @Sendable () async -> [Message] = { [] },
         getFollowUpMessages: @escaping @Sendable () async -> [Message] = { [] },
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         beforeToolCall: BeforeToolCallHook? = nil,
         afterToolCall: AfterToolCallHook? = nil,
         userPromptSubmit: UserPromptSubmitHook? = nil,
@@ -133,9 +133,12 @@ public enum AgentLoop {
             await emit(.messageEnd(message: prompt))
         }
 
+        // `run()` already emitted the run's first `turnStart` above; enter the
+        // loop with `firstTurn: true` so the first iteration consumes it
+        // instead of emitting a duplicate. Matches pi-agent-core's semantics.
         try await runLoop(
             currentContext: &currentContext,
-            firstTurn: false,
+            firstTurn: true,
             config: config,
             cancellation: cancellation,
             emit: emit,
@@ -179,9 +182,11 @@ public enum AgentLoop {
         await emit(.agentStart)
         await emit(.turnStart)
 
+        // `firstTurn: true` — the `turnStart` just emitted stands in for the
+        // loop's first iteration, so exactly one `turnStart` precedes the turn.
         try await runLoop(
             currentContext: &currentContext,
-            firstTurn: false,
+            firstTurn: true,
             config: config,
             cancellation: cancellation,
             emit: emit,
@@ -476,10 +481,10 @@ public enum AgentLoop {
             tools: context.tools.map { $0.toKWAITool() }
         )
 
-        let resolvedAuth = await config.authResolver?(config.model, config.sessionId)
+        let resolvedAuth = try await config.authResolver?(config.model, config.sessionId)
         var requestModel = config.model
         if let baseURL = resolvedAuth?.baseURL, !baseURL.isEmpty {
-            requestModel.baseUrl = baseURL
+            requestModel.baseURL = baseURL
         }
         let mergedMetadata: [String: JSONValue]? = {
             guard let authMetadata = resolvedAuth?.metadata, !authMetadata.isEmpty else { return nil }

--- a/Sources/KWWKAgent/BackgroundTaskManager.swift
+++ b/Sources/KWWKAgent/BackgroundTaskManager.swift
@@ -18,8 +18,10 @@ import KWWKAI
 /// Cross-cutting guarantees:
 ///   - Task IDs are unique within a Manager instance.
 ///   - Each task gets a distinct `outputFile` under `outputDir`.
-///   - Exactly one notification is enqueued per task (either completion or
-///     stall — whichever fires first wins; the other is suppressed).
+///   - Exactly one terminal notification is enqueued per task (completion or
+///     kill — whichever fires first wins; the other is suppressed). A stall
+///     notification is a non-terminal heads-up: it may precede the terminal
+///     one, so a stuck-then-finished task yields a stall AND a completion.
 ///   - Listeners are invoked sequentially in subscription order on the
 ///     Manager's isolation context.
 public actor BackgroundTaskManager {
@@ -523,7 +525,9 @@ public actor BackgroundTaskManager {
             outcome: nil,
             stalled: true
         )
-        tasks[taskId]?.notified = true
+        // A stall is a heads-up, not a terminal event: deliberately do NOT set
+        // `notified`, so the eventual completion/kill notification still fires.
+        // Returning true ends the watchdog, so exactly one stall is emitted.
         return true
     }
 

--- a/Sources/KWWKAgent/BashBackgroundRunner.swift
+++ b/Sources/KWWKAgent/BashBackgroundRunner.swift
@@ -54,7 +54,12 @@ public struct BashBackgroundRunner: BackgroundTaskRunner {
         let shellPath = self.shellPath
         let environment = self.environment
         let extraEnv = self.extraEnv
-        Task.detached {
+        // Dispatch, not Task.detached: BashRunnerImpl.run blocks in waitpid for
+        // the process's whole lifetime. On the narrow cooperative pool a few
+        // long-running tasks would starve every actor in the process (the
+        // manager's own kill() included); the dispatch pool grows under
+        // blocking.
+        DispatchQueue.global().async {
             let outcome = BashRunnerImpl.run(
                 command: command,
                 workDir: workDir,

--- a/Sources/KWWKAgent/BashBackgroundRunner.swift
+++ b/Sources/KWWKAgent/BashBackgroundRunner.swift
@@ -87,7 +87,7 @@ enum BashRunnerImpl {
         let control = BashProcessControl(pid: 0)
         let effectiveCommand: String
         if let workDir {
-            effectiveCommand = "cd \(shellQuote(workDir)) && \(command)"
+            effectiveCommand = "cd \(bashShellQuote(workDir)) && \(command)"
         } else {
             effectiveCommand = command
         }
@@ -121,24 +121,19 @@ enum BashRunnerImpl {
         )
     }
 
-    private static func shellQuote(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
 }
 
-/// Maps a finished `Process` to a `BackgroundTaskOutcome`. Shared between the
-/// spawn path (`BashRunnerImpl.run`) and the foreground-adopted path
-/// (`ForegroundBashExecution.awaitAdoptedCompletion`) so both produce
-/// identical success/summary/details for a given process state.
-enum BashProcessOutcome {
-    static func from(process: Process, cancelled: Bool) -> BackgroundTaskOutcome {
-        let status = SpawnedBashProcess.ExitStatus(
-            code: process.terminationStatus,
-            signaled: process.terminationReason == .uncaughtSignal && process.terminationStatus != 0
-        )
-        return from(status: status, cancelled: cancelled)
-    }
+/// POSIX-quote a single shell argument. Shared by the background runner (cwd
+/// prefix) and the bash tool's foreground/legacy paths.
+func bashShellQuote(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
 
+/// Maps a finished process's `ExitStatus` to a `BackgroundTaskOutcome`. Shared
+/// between the spawn path (`BashRunnerImpl.run`) and the foreground-adopted path
+/// (`ForegroundBashExecution.awaitAdoptedCompletion`) so both produce identical
+/// success/summary/details for a given process state.
+enum BashProcessOutcome {
     static func from(status: SpawnedBashProcess.ExitStatus, cancelled: Bool) -> BackgroundTaskOutcome {
         let code = status.code
         if cancelled {
@@ -169,8 +164,8 @@ enum BashProcessOutcome {
     }
 }
 
-struct SpawnedBashProcess {
-    struct ExitStatus {
+struct SpawnedBashProcess: Sendable {
+    struct ExitStatus: Sendable {
         var code: Int32
         var signaled: Bool
     }
@@ -193,6 +188,8 @@ struct SpawnedBashProcess {
 
     let pid: pid_t
 
+    /// Spawn a shell redirecting stdout+stderr into `outputFile` (truncated).
+    /// Bytes go straight from the kernel to disk without entering Swift memory.
     static func start(
         shellPath: String,
         command: String,
@@ -203,7 +200,30 @@ struct SpawnedBashProcess {
         let outputFd = open(outputFile.path, O_WRONLY | O_CREAT | O_TRUNC, 0o600)
         guard outputFd >= 0 else { throw SpawnError.openOutput(outputFile.path) }
         defer { close(outputFd) }
+        return try start(
+            shellPath: shellPath,
+            command: command,
+            stdoutFd: outputFd,
+            stderrFd: outputFd,
+            environment: environment,
+            extraEnv: extraEnv
+        )
+    }
 
+    /// Spawn a shell with stdin from /dev/null and stdout/stderr dup'd onto the
+    /// caller-owned `stdoutFd`/`stderrFd` (which may be the same fd — a file —
+    /// or distinct pipe write ends). The child is placed in its own process
+    /// group (`POSIX_SPAWN_SETPGROUP`, pgid 0) so signalling the group reaches
+    /// grandchildren. The caller retains ownership of the passed fds and must
+    /// close its own copies after this returns.
+    static func start(
+        shellPath: String,
+        command: String,
+        stdoutFd: Int32,
+        stderrFd: Int32,
+        environment: [String: String],
+        extraEnv: [String: String]
+    ) throws -> SpawnedBashProcess {
         let inputFd = open("/dev/null", O_RDONLY)
         guard inputFd >= 0 else { throw SpawnError.openDevNull }
         defer { close(inputFd) }
@@ -220,10 +240,18 @@ struct SpawnedBashProcess {
         defer { posix_spawn_file_actions_destroy(&actions) }
 
         try checkFileAction(posix_spawn_file_actions_adddup2(&actions, inputFd, STDIN_FILENO))
-        try checkFileAction(posix_spawn_file_actions_adddup2(&actions, outputFd, STDOUT_FILENO))
-        try checkFileAction(posix_spawn_file_actions_adddup2(&actions, outputFd, STDERR_FILENO))
+        try checkFileAction(posix_spawn_file_actions_adddup2(&actions, stdoutFd, STDOUT_FILENO))
+        try checkFileAction(posix_spawn_file_actions_adddup2(&actions, stderrFd, STDERR_FILENO))
         try checkFileAction(posix_spawn_file_actions_addclose(&actions, inputFd))
-        try checkFileAction(posix_spawn_file_actions_addclose(&actions, outputFd))
+        // Close the child's leftover copies of the source fds after dup2. Guard
+        // against closing a std fd, and against closing the same fd twice when
+        // stdout and stderr share it (the file case).
+        if stdoutFd > STDERR_FILENO {
+            try checkFileAction(posix_spawn_file_actions_addclose(&actions, stdoutFd))
+        }
+        if stderrFd > STDERR_FILENO && stderrFd != stdoutFd {
+            try checkFileAction(posix_spawn_file_actions_addclose(&actions, stderrFd))
+        }
 
         #if os(Linux)
         var attr = posix_spawnattr_t()

--- a/Sources/KWWKAgent/BashTool.swift
+++ b/Sources/KWWKAgent/BashTool.swift
@@ -77,72 +77,115 @@ public struct LocalBashOperations: BashOperations {
         timeout: Int?,
         cancellation: CancellationHandle?
     ) async throws -> BashExecutionResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: shellPath)
-        process.arguments = ["-c", command]
-        process.environment = environment
+        // Spawn via posix_spawn (SpawnedBashProcess) so the child gets its own
+        // process group — cancel/timeout then signals the whole group and
+        // reaches any grandchildren, not just the direct shell. Foundation's
+        // Process leaves the child in our group, so `kill` would miss them.
+        let effectiveCommand: String
         if let cwd {
-            process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+            effectiveCommand = "cd \(bashShellQuote(cwd)) && \(command)"
+        } else {
+            effectiveCommand = command
         }
 
+        // Isolate stdin from the parent (handled inside SpawnedBashProcess by
+        // dup'ing /dev/null onto STDIN): the coding TUI runs its own stdin in
+        // raw mode, so a child reading stdin would steal the user's keystrokes
+        // and interactive wizards would hang. /dev/null forces EOF on reads.
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
 
-        // Isolate stdin from the parent. The coding TUI runs its own stdin in
-        // raw mode — if we don't override, npm/prompting commands will read
-        // the user's keystrokes and the TUI will lose them, and interactive
-        // wizards (e.g. `npm create vite`) hang waiting for input that will
-        // never come. Attaching /dev/null forces EOF on any read.
-        if let devNull = FileHandle(forReadingAtPath: "/dev/null") {
-            process.standardInput = devNull
-        }
-
+        let control = BashProcessControl(pid: 0)
         let start = Date()
-        try process.run()
 
-        let control = BashProcessControl(pid: process.processIdentifier)
+        let spawned: SpawnedBashProcess
+        do {
+            spawned = try SpawnedBashProcess.start(
+                shellPath: shellPath,
+                command: effectiveCommand,
+                stdoutFd: stdoutPipe.fileHandleForWriting.fileDescriptor,
+                stderrFd: stderrPipe.fileHandleForWriting.fileDescriptor,
+                environment: environment,
+                extraEnv: [:]
+            )
+        } catch {
+            throw CodingToolError.commandFailed(stderr: "\(error)", exitCode: -1)
+        }
+        // Close our copies of the write ends so the read ends see EOF once the
+        // child exits and closes its dup'd copies.
+        try? stdoutPipe.fileHandleForWriting.close()
+        try? stderrPipe.fileHandleForWriting.close()
 
+        control.setPid(spawned.pid)
         cancellation?.onCancel { _ in control.terminate() }
 
+        var timeoutTask: Task<Void, Never>?
         if let timeout, timeout > 0 {
-            Task {
-                try? await Task.sleep(nanoseconds: UInt64(timeout) * 1_000_000)
+            timeoutTask = Task {
+                // A cancelled sleep means the process already exited — the
+                // deadline never arrived, so it must not count as a timeout.
+                guard (try? await Task.sleep(nanoseconds: UInt64(timeout) * 1_000_000)) != nil else { return }
                 control.timeoutAndTerminate()
             }
         }
 
-        // Wait for completion off the executor.
+        // Drain both pipes CONCURRENTLY with the wait. Reading only after
+        // waitpid would deadlock once the child fills the ~64KB pipe buffer:
+        // the child blocks in write(2) while we block in wait.
+        let outBox = OutputBox()
+        let errBox = OutputBox()
+        let statusBox = ExitStatusBox()
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let group = DispatchGroup()
+            let outHandle = stdoutPipe.fileHandleForReading
+            let errHandle = stderrPipe.fileHandleForReading
+            group.enter()
             DispatchQueue.global().async {
-                process.waitUntilExit()
-                cont.resume()
+                outBox.data = outHandle.readDataToEndOfFile()
+                group.leave()
             }
+            group.enter()
+            DispatchQueue.global().async {
+                errBox.data = errHandle.readDataToEndOfFile()
+                group.leave()
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                statusBox.status = spawned.wait()
+                group.leave()
+            }
+            group.notify(queue: .global()) { cont.resume() }
         }
+        timeoutTask?.cancel()
 
-        let stdout = readAll(stdoutPipe.fileHandleForReading)
-        let stderr = readAll(stderrPipe.fileHandleForReading)
+        let stdout = String(decoding: outBox.data, as: UTF8.self)
+        let stderr = String(decoding: errBox.data, as: UTF8.self)
         let duration = Int(Date().timeIntervalSince(start) * 1000)
-        let timedOut = control.didTimeOut
 
         if cancellation?.isCancelled == true {
             throw CodingToolError.aborted
         }
-        if timedOut {
+        if control.didTimeOut {
             throw CodingToolError.commandFailed(stderr: "Command timed out after \(timeout ?? 0)ms\n" + stderr, exitCode: -1)
         }
-        let status = process.terminationStatus
-        if status != 0 {
-            throw CodingToolError.commandFailed(stderr: stderr.isEmpty ? stdout : stderr, exitCode: status)
+        // The wait closure always sets `status` before the group completes.
+        let code = statusBox.status!.code
+        if code != 0 {
+            throw CodingToolError.commandFailed(stderr: stderr.isEmpty ? stdout : stderr, exitCode: code)
         }
-        return BashExecutionResult(stdout: stdout, stderr: stderr, exitCode: status, durationMs: duration, timedOut: false)
+        return BashExecutionResult(stdout: stdout, stderr: stderr, exitCode: code, durationMs: duration, timedOut: false)
     }
 }
 
-private func readAll(_ handle: FileHandle) -> String {
-    let data = handle.readDataToEndOfFile()
-    return String(data: data, encoding: .utf8) ?? ""
+/// `@unchecked Sendable` holders used to return values out of the concurrent
+/// pipe-drain closures. Written on dispatch threads, read by the awaiting task
+/// after `DispatchGroup.notify` establishes a happens-before edge.
+private final class OutputBox: @unchecked Sendable {
+    var data = Data()
+}
+
+private final class ExitStatusBox: @unchecked Sendable {
+    var status: SpawnedBashProcess.ExitStatus?
 }
 
 public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
@@ -364,39 +407,31 @@ private func runBashForegroundWithFlip(
 ) async throws -> AgentToolResult {
     let outputFile = await manager.allocateForegroundOutputFile()
 
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: shellPath)
-    process.arguments = ["-c", input.command]
-    process.environment = environment
-    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-
-    guard let writeHandle = try? FileHandle(forWritingTo: outputFile) else {
-        throw CodingToolError.commandFailed(
-            stderr: "could not open output file \(outputFile.path)",
-            exitCode: -1
-        )
-    }
-    process.standardOutput = writeHandle
-    process.standardError = writeHandle
-    if let devNull = FileHandle(forReadingAtPath: "/dev/null") {
-        process.standardInput = devNull
-    }
-
+    // posix_spawn onto the output file (own process group, stdout+stderr → file,
+    // stdin ← /dev/null). `cd`-prefix the command since posix_spawn has no cwd
+    // file action — same convention as the background runner.
+    let effectiveCommand = "cd \(bashShellQuote(cwd)) && \(input.command)"
     let control = BashProcessControl(pid: 0)
     let start = Date()
+
+    let spawned: SpawnedBashProcess
     do {
-        try process.run()
+        spawned = try SpawnedBashProcess.start(
+            shellPath: shellPath,
+            command: effectiveCommand,
+            outputFile: outputFile,
+            environment: environment,
+            extraEnv: [:]
+        )
     } catch {
-        try? writeHandle.close()
         try? FileManager.default.removeItem(at: outputFile)
         throw CodingToolError.commandFailed(stderr: "\(error)", exitCode: -1)
     }
-    control.setPid(process.processIdentifier)
+    control.setPid(spawned.pid)
     cancellation?.onCancel { _ in control.terminate() }
 
     let bundle = ForegroundBashExecution(
-        process: process,
-        writeHandle: writeHandle,
+        spawned: spawned,
         outputFile: outputFile,
         control: control,
         startedAt: start
@@ -404,14 +439,14 @@ private func runBashForegroundWithFlip(
 
     let exit = await bundle.waitUpTo(seconds: input.timeoutSeconds)
 
-    if let code = exit {
+    if let status = exit {
         // Completed within soft timeout.
-        try? bundle.writeHandle.close()
         let text = bundle.readOutput()
         try? FileManager.default.removeItem(at: outputFile)
         if cancellation?.isCancelled == true {
             throw CodingToolError.aborted
         }
+        let code = status.code
         if code != 0 {
             throw CodingToolError.commandFailed(stderr: text.isEmpty ? "command exited with code \(code)" : text, exitCode: code)
         }
@@ -419,8 +454,6 @@ private func runBashForegroundWithFlip(
         return AgentToolResult(
             content: [.text(TextContent(text: text))],
             details: .object([
-                "stdout": .string(text),
-                "stderr": .string(""),
                 "exitCode": .int(Int(code)),
                 "durationMs": .int(durationMs),
             ])
@@ -467,51 +500,67 @@ private func runBashLegacy(
         timeout: input.timeoutSeconds * 1000,
         cancellation: cancellation
     )
-    let body = [result.stdout, result.stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+    let body = boundBashOutput(
+        [result.stdout, result.stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+    )
     return AgentToolResult(
         content: [.text(TextContent(text: body))],
         details: .object([
-            "stdout": .string(result.stdout),
-            "stderr": .string(result.stderr),
             "exitCode": .int(Int(result.exitCode)),
             "durationMs": .int(result.durationMs),
         ])
     )
 }
 
+/// Bound bash output before it enters the transcript. Command output is most
+/// useful at the tail (errors and summaries land at the end), so keep the last
+/// lines/bytes within the read tool's budget. Callers that keep a full copy on
+/// disk (the flip/background paths) still expose it via the output file; this
+/// only bounds what the model sees inline, and is not duplicated into `details`.
+func boundBashOutput(_ text: String) -> String {
+    let result = Truncate.truncateTail(text)
+    guard result.truncated else { return result.content }
+    let omitted = result.totalLines - result.outputLines
+    let notice = "[output truncated: \(omitted) earlier line(s) omitted; showing last "
+        + "\(result.outputLines) of \(result.totalLines) lines, "
+        + "\(Truncate.formatSize(result.totalBytes)) total]\n"
+    return notice + result.content
+}
+
 // MARK: - Foreground/adopted process wrapper
 
-/// Sendable wrapper over the non-Sendable `Process` + `FileHandle`. Two roles:
+/// Sendable wrapper over a `SpawnedBashProcess`. Two roles:
 ///   * Race the soft timeout against process termination via `waitUpTo`.
 ///   * If the timeout wins, let the Manager's adopt closure await the same
 ///     cached termination result and map it to a `BackgroundTaskOutcome`.
+///
+/// A single background thread runs the blocking `waitpid`; its cached result
+/// fans out to every registered `onExit` callback, so the soft-timeout race and
+/// a later adopted wait share one reap.
 private final class ForegroundBashExecution: @unchecked Sendable {
-    let process: Process
-    let writeHandle: FileHandle
+    let spawned: SpawnedBashProcess
     let outputFile: URL
     let control: BashProcessControl
     let startedAt: Date
     private let lock = NSLock()
     private var exitWaiterStarted = false
-    private var exitStatus: Int32?
-    private var exitCallbacks: [@Sendable (Int32) -> Void] = []
+    private var exitStatus: SpawnedBashProcess.ExitStatus?
+    private var exitCallbacks: [@Sendable (SpawnedBashProcess.ExitStatus) -> Void] = []
 
     init(
-        process: Process,
-        writeHandle: FileHandle,
+        spawned: SpawnedBashProcess,
         outputFile: URL,
         control: BashProcessControl,
         startedAt: Date
     ) {
-        self.process = process
-        self.writeHandle = writeHandle
+        self.spawned = spawned
         self.outputFile = outputFile
         self.control = control
         self.startedAt = startedAt
     }
 
-    func waitUpTo(seconds: Int) async -> Int32? {
-        return await withCheckedContinuation { (cont: CheckedContinuation<Int32?, Never>) in
+    func waitUpTo(seconds: Int) async -> SpawnedBashProcess.ExitStatus? {
+        return await withCheckedContinuation { (cont: CheckedContinuation<SpawnedBashProcess.ExitStatus?, Never>) in
             let oneShot = OneShotContinuation(cont)
             self.onExit { status in
                 oneShot.resume(returning: status)
@@ -524,31 +573,40 @@ private final class ForegroundBashExecution: @unchecked Sendable {
 
     func awaitAdoptedCompletion(cancellation: CancellationHandle) async -> BackgroundTaskOutcome {
         cancellation.onCancel { [control] _ in control.terminate() }
-        _ = await awaitExitStatus()
-        try? writeHandle.close()
+        let status = await awaitExitStatus()
         return BashProcessOutcome.from(
-            process: process,
+            status: status,
             cancelled: control.didCancel || cancellation.isCancelled
         )
     }
 
+    /// Read the completed command's output, bounded to the read tool's budget.
+    /// Reads only the tail window of the file so a multi-GB log never lands in
+    /// memory; the full output stays on disk at `outputFile`.
     func readOutput() -> String {
-        guard let data = try? Data(contentsOf: outputFile) else { return "" }
-        // Cap at 1MB to avoid context bombs on small-looking commands that
-        // spewed output before finishing.
-        let capped = data.prefix(1_000_000)
-        return String(data: capped, encoding: .utf8) ?? ""
+        guard let handle = try? FileHandle(forReadingFrom: outputFile) else { return "" }
+        defer { try? handle.close() }
+        let size = (try? handle.seekToEnd()) ?? 0
+        if size == 0 { return "" }
+        // Read a generous tail window, then apply the line/byte budget on top.
+        let window: UInt64 = 4 * 1024 * 1024
+        let startOffset = size > window ? size - window : 0
+        guard (try? handle.seek(toOffset: startOffset)) != nil,
+              let data = try? handle.read(upToCount: Int(size - startOffset)) else {
+            return ""
+        }
+        return boundBashOutput(String(decoding: data, as: UTF8.self))
     }
 
-    private func awaitExitStatus() async -> Int32 {
-        await withCheckedContinuation { (cont: CheckedContinuation<Int32, Never>) in
+    private func awaitExitStatus() async -> SpawnedBashProcess.ExitStatus {
+        await withCheckedContinuation { (cont: CheckedContinuation<SpawnedBashProcess.ExitStatus, Never>) in
             onExit { status in cont.resume(returning: status) }
         }
     }
 
-    private func onExit(_ callback: @escaping @Sendable (Int32) -> Void) {
+    private func onExit(_ callback: @escaping @Sendable (SpawnedBashProcess.ExitStatus) -> Void) {
         startExitWaiterIfNeeded()
-        let status: Int32? = lock.withLock {
+        let status: SpawnedBashProcess.ExitStatus? = lock.withLock {
             if let exitStatus { return exitStatus }
             exitCallbacks.append(callback)
             return nil
@@ -566,23 +624,21 @@ private final class ForegroundBashExecution: @unchecked Sendable {
         }
         guard shouldStart else { return }
 
-        process.terminationHandler = { [weak self] process in
-            self?.finishExit(status: process.terminationStatus)
-        }
-        if !process.isRunning {
-            finishExit(status: process.terminationStatus)
+        let spawned = self.spawned
+        DispatchQueue.global().async { [weak self] in
+            let status = spawned.wait()
+            self?.finishExit(status: status)
         }
     }
 
-    private func finishExit(status: Int32) {
-        let callbacks: [@Sendable (Int32) -> Void] = lock.withLock {
+    private func finishExit(status: SpawnedBashProcess.ExitStatus) {
+        let callbacks: [@Sendable (SpawnedBashProcess.ExitStatus) -> Void] = lock.withLock {
             if exitStatus != nil { return [] }
             exitStatus = status
             let callbacks = exitCallbacks
             exitCallbacks.removeAll()
             return callbacks
         }
-        process.terminationHandler = nil
         for callback in callbacks {
             callback(status)
         }

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -1,12 +1,14 @@
 import Foundation
 import KWWKAI
 
-/// Which coding tools to register on a freshly-built agent. Use `.all` for the
-/// full set, `.readOnly` for a sandboxed reviewer-style agent, or compose
-/// an arbitrary subset (`[.read, .grep, .bash]`).
+/// Which coding tools to register on a freshly-built agent. Use `.standard`
+/// for the full non-PTY set, `.allIncludingTmux` to also register tmux,
+/// `.readOnly` for a sandboxed reviewer-style agent, or compose an arbitrary
+/// subset (`[.read, .grep, .bash]`).
 ///
-/// `.tmux` requires an explicit `tmuxManager`; otherwise construction traps
-/// instead of probing PATH or silently omitting a requested tool.
+/// `.tmux` requires an explicit `tmuxManager`; otherwise `makeCodingAgent`
+/// throws `CodingAgentConfigError.tmuxRequiresManager` at configuration time
+/// rather than probing PATH or silently omitting a requested tool.
 /// `.taskStatus` and `.waitTask` are only honored when a `backgroundManager`
 /// is supplied. `.bash` works without a manager (legacy pipe executor) —
 /// it just loses `run_in_background` and the auto-background-on-timeout flip.
@@ -31,11 +33,6 @@ public struct CodingTools: OptionSet, Sendable {
     /// Common editing tools. Includes shell and mutation capabilities; SDK
     /// callers must opt in explicitly when they want those effects.
     public static let standard: CodingTools = [
-        .read, .write, .edit, .bash, .grep, .find, .ls, .taskStatus, .waitTask,
-    ]
-
-    /// Everything except tmux, which requires an explicit executable path.
-    public static let all: CodingTools = [
         .read, .write, .edit, .bash, .grep, .find, .ls, .taskStatus, .waitTask,
     ]
 
@@ -70,7 +67,7 @@ public struct CodingAgentConfig: Sendable {
     /// When empty, no `agent` tool is registered.
     public var subagents: [SubagentDefinition]
     public var sessionId: String
-    public var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    public var authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
     public var autoCompactThreshold: Double?
     public var autoCompactConfig: AgentContextCompactionConfig
     /// Soft foreground timeout for bash commands. The command auto-moves to
@@ -95,7 +92,7 @@ public struct CodingAgentConfig: Sendable {
         backgroundManager: BackgroundTaskManager? = nil,
         subagents: [SubagentDefinition] = [],
         sessionId: String = UUID().uuidString,
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         autoCompactThreshold: Double? = 0.75,
         autoCompactConfig: AgentContextCompactionConfig = .init(),
         bashEnvironment: [String: String],
@@ -140,25 +137,78 @@ public extension CodingAgentConfig {
     }
 }
 
+/// Raised by `makeCodingAgent` when a configuration cannot be satisfied.
+public enum CodingAgentConfigError: Error, LocalizedError, Equatable {
+    /// `.tmux` was requested (on the agent's own tools or a subagent's) without
+    /// an explicit `TmuxSessionManager`. `context` names where the request came
+    /// from.
+    case tmuxRequiresManager(context: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .tmuxRequiresManager(let context):
+            return "CodingTools.tmux requires an explicit TmuxSessionManager (\(context))"
+        }
+    }
+}
+
+/// Result of `makeCodingAgent`: the built agent plus an optional handle to
+/// detach the auto-continue background bridge.
+public struct CodingAgent: Sendable {
+    public let agent: Agent
+    /// Detaches the auto-continue background bridge that `makeCodingAgent`
+    /// installs when a `backgroundManager` is supplied. `nil` when no manager
+    /// was attached. The bridge autonomously starts a new (billable) model run
+    /// when a background task completes while the agent is idle; call this to
+    /// stop that behavior. In-flight background tasks keep running.
+    public let detachBackground: (@Sendable () async -> Void)?
+
+    public init(agent: Agent, detachBackground: (@Sendable () async -> Void)?) {
+        self.agent = agent
+        self.detachBackground = detachBackground
+    }
+}
+
 /// Build a coding agent with the selected coding tools pre-wired.
 ///
 /// ```swift
-/// let agent = await makeCodingAgent(CodingAgentConfig(
+/// let agent = try await makeCodingAgent(CodingAgentConfig(
 ///     model: model,
 ///     cwd: "/Users/me/project",
 ///     tools: .standard,
 ///     backgroundManager: BackgroundTaskManager(),
 ///     bashEnvironment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
-/// ))
+/// )).agent
 /// try await agent.prompt("list the swift files")
 /// ```
 ///
+/// Throws `CodingAgentConfigError.tmuxRequiresManager` when `.tmux` is
+/// requested (on `config.tools` or any subagent's tools) without a
+/// `tmuxManager`, so the misconfiguration surfaces at build time instead of
+/// crashing when the model first calls the tool.
+///
 /// If `config.backgroundManager` is non-nil, the agent is automatically
-/// attached so completion notifications surface as steered user messages.
-public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
+/// attached so completion notifications surface as steered user messages — and
+/// that bridge will autonomously start new (billable) model runs when
+/// background tasks complete. Call the returned `CodingAgent.detachBackground`
+/// handle to stop that; ignore it to keep the default auto-continue behavior.
+public func makeCodingAgent(_ config: CodingAgentConfig) async throws -> CodingAgent {
     let cwd = config.cwd
     let bgManager = config.backgroundManager
     let sessionId = config.sessionId
+
+    // Fail fast at configuration time: a nil tmuxManager with `.tmux` selected
+    // (directly or via a subagent) must not defer to a crash at tool-call time.
+    if config.tools.contains(.tmux), config.tmuxManager == nil {
+        throw CodingAgentConfigError.tmuxRequiresManager(context: "config.tools")
+    }
+    for definition in config.subagents {
+        guard let subagentTools = definition.tools else { continue }
+        if subagentTools.contains(.tmux), config.tmuxManager == nil {
+            throw CodingAgentConfigError.tmuxRequiresManager(context: "subagent '\(definition.name)'")
+        }
+    }
+
     let autoCompact = config.autoCompactThreshold.map {
         AgentAutoCompactOptions(
             threshold: $0,
@@ -167,7 +217,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
         )
     }
 
-    var tools = await buildCodingToolList(
+    var tools = try await buildCodingToolList(
         cwd: cwd,
         selected: config.tools,
         backgroundManager: bgManager,
@@ -220,11 +270,12 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> Agent {
     ))
     subagentParent.attach(agent)
 
+    var detachBackground: (@Sendable () async -> Void)?
     if let bgManager {
-        _ = await agent.attachBackgroundManager(bgManager, sessionId: sessionId)
+        detachBackground = await agent.attachBackgroundManager(bgManager, sessionId: sessionId)
     }
 
-    return agent
+    return CodingAgent(agent: agent, detachBackground: detachBackground)
 }
 
 internal func buildCodingToolList(
@@ -237,7 +288,7 @@ internal func buildCodingToolList(
     bashEnvironment: [String: String],
     bashShellPath: String = kwwkDefaultShellPath,
     tmuxManager: TmuxSessionManager? = nil
-) async -> [AgentTool] {
+) async throws -> [AgentTool] {
     var tools: [AgentTool] = []
     if selected.contains(.read)  { tools.append(createReadTool(cwd: cwd)) }
     if selected.contains(.write) { tools.append(createWriteTool(cwd: cwd)) }
@@ -264,7 +315,7 @@ internal func buildCodingToolList(
     }
     if selected.contains(.tmux) {
         guard let tmuxManager else {
-            preconditionFailure("CodingTools.tmux requires an explicit TmuxSessionManager")
+            throw CodingAgentConfigError.tmuxRequiresManager(context: "buildCodingToolList")
         }
         if let tmuxTool = await createTmuxTool(
             manager: tmuxManager,

--- a/Sources/KWWKAgent/CodingTools.swift
+++ b/Sources/KWWKAgent/CodingTools.swift
@@ -113,14 +113,35 @@ public struct GrepParams: Sendable {
     }
 }
 
+public struct GrepContextLine: Sendable, Equatable {
+    public var line: Int
+    public var text: String
+    public init(line: Int, text: String) {
+        self.line = line
+        self.text = text
+    }
+}
+
 public struct GrepMatch: Sendable, Equatable {
     public var file: String
     public var line: Int
     public var text: String
-    public init(file: String, line: Int, text: String) {
+    /// Context lines immediately before/after the match (empty when the
+    /// `context` parameter is 0). Each carries its own 1-based line number.
+    public var before: [GrepContextLine]
+    public var after: [GrepContextLine]
+    public init(
+        file: String,
+        line: Int,
+        text: String,
+        before: [GrepContextLine] = [],
+        after: [GrepContextLine] = []
+    ) {
         self.file = file
         self.line = line
         self.text = text
+        self.before = before
+        self.after = after
     }
 }
 

--- a/Sources/KWWKAgent/EditTool.swift
+++ b/Sources/KWWKAgent/EditTool.swift
@@ -21,7 +21,11 @@ public struct LocalEditOperations: EditOperations {
         try Data(contentsOf: URL(fileURLWithPath: absolutePath))
     }
     public func writeFile(_ absolutePath: String, content: Data) async throws {
-        try content.write(to: URL(fileURLWithPath: absolutePath), options: .atomic)
+        // In-place write (open + truncate), not an atomic rename: preserves the
+        // inode, symlink target, hard links, and permissions of an existing
+        // file — matching pi's `fs.writeFile`. Edits always target a file that
+        // already exists (access() ran first), so the create mode is a fallback.
+        try PathUtils.writeFileInPlace(absolutePath, data: content)
     }
     public func access(_ absolutePath: String) async throws {
         try checkPOSIXAccess(absolutePath, mode: editAccessExistsMode)

--- a/Sources/KWWKAgent/FileMutationQueue.swift
+++ b/Sources/KWWKAgent/FileMutationQueue.swift
@@ -1,12 +1,18 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 /// Per-path serial queue for file mutations. Matches pi-coding-agent's
 /// `withFileMutationQueue` — overlapping edits and writes on the same physical
 /// file run strictly one-after-the-other, while unrelated files run in parallel.
 ///
-/// Uniqueness is determined by the file's inode when the file exists;
-/// otherwise the absolute path is used. This keeps symlink siblings on the
-/// same queue.
+/// Uniqueness is determined by the file's canonical (realpath-resolved) path,
+/// so different spellings and symlink siblings collapse onto the same queue.
+/// The tools write in place (open + truncate) so a file's identity is stable
+/// across mutations. Mirrors pi's `realpathSync`-with-fallback keying.
 public actor FileMutationQueue {
     public static let shared = FileMutationQueue()
 
@@ -43,12 +49,17 @@ public actor FileMutationQueue {
     }
 
     private func queueKey(for path: String) -> String {
-        // If the file exists, key by inode so symlinks collapse.
-        var stats = stat()
-        if stat(path, &stats) == 0 {
-            return "inode:\(stats.st_dev):\(stats.st_ino)"
+        // Resolve to the canonical path so symlink siblings, hard links, and
+        // "../"-relative spellings collapse onto one queue. realpath fails when
+        // the final component does not exist yet (a fresh write) — fall back to
+        // the normalized absolute path, matching pi's realpathSync fallback.
+        #if canImport(Darwin) || canImport(Glibc)
+        if let resolved = realpath(path, nil) {
+            defer { free(resolved) }
+            return String(cString: resolved)
         }
-        return "path:\(path)"
+        #endif
+        return URL(fileURLWithPath: path).standardized.path
     }
 }
 

--- a/Sources/KWWKAgent/Glob.swift
+++ b/Sources/KWWKAgent/Glob.swift
@@ -1,11 +1,22 @@
 import Foundation
 
+/// Directory names pruned during recursive tool walks (find, grep). Mirrors
+/// pi's fd/ripgrep defaults, which skip VCS metadata and dependency trees.
+let ignoredWalkDirectoryNames: Set<String> = [".git", ".hg", ".svn", "node_modules"]
+
 public enum Glob {
 
     /// Match a path against a glob pattern supporting `*`, `?`, and `**`.
     public static func matches(path: String, pattern: String) -> Bool {
-        let regex = patternToRegex(pattern)
-        return path.range(of: regex, options: .regularExpression) != nil
+        guard let regex = try? NSRegularExpression(pattern: patternToRegex(pattern)) else {
+            return false
+        }
+        return matches(path: path, compiled: regex)
+    }
+
+    private static func matches(path: String, compiled: NSRegularExpression) -> Bool {
+        let ns = path as NSString
+        return compiled.firstMatch(in: path, options: [], range: NSRange(location: 0, length: ns.length)) != nil
     }
 
     /// Translate a glob pattern into an anchored regex string.
@@ -28,7 +39,10 @@ public enum Glob {
                 out += "[^/]*"
             } else if ch == "?" {
                 out += "[^/]"
-            } else if "().+|^$\\{}".contains(ch) {
+            } else if "[]().+|^$\\{}".contains(ch) {
+                // Escape regex metacharacters (including `[` and `]`) so a glob
+                // like `file[1].txt` matches those literal brackets instead of
+                // being read as a regex character class.
                 out += "\\\(ch)"
             } else {
                 out.append(ch)
@@ -40,19 +54,33 @@ public enum Glob {
     }
 
     /// Walk `root` recursively and return absolute file paths matching `pattern`.
+    /// The pattern is compiled once, and well-known VCS/dependency directories
+    /// are pruned during the walk.
     public static func expand(root: String, pattern: String, limit: Int? = nil) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: patternToRegex(pattern)) else {
+            return []
+        }
         let fm = FileManager.default
-        guard let enumerator = fm.enumerator(at: URL(fileURLWithPath: root), includingPropertiesForKeys: [.isRegularFileKey]) else {
+        guard let enumerator = fm.enumerator(
+            at: URL(fileURLWithPath: root),
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
+        ) else {
             return []
         }
         var results: [String] = []
         let prefix = root.hasSuffix("/") ? root.count : root.count + 1
         for case let url as URL in enumerator {
-            guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
-                  values.isRegularFile == true else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            if values?.isDirectory == true {
+                if ignoredWalkDirectoryNames.contains(url.lastPathComponent) {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+            guard values?.isRegularFile == true else { continue }
             var relative = url.path
             if relative.count > prefix { relative = String(relative.dropFirst(prefix)) }
-            if matches(path: relative, pattern: pattern) {
+            if matches(path: relative, compiled: regex) {
                 results.append(url.path)
                 if let limit, results.count >= limit { break }
             }

--- a/Sources/KWWKAgent/GrepTool.swift
+++ b/Sources/KWWKAgent/GrepTool.swift
@@ -35,60 +35,129 @@ public struct LocalGrepOperations: GrepOperations {
 
         var results: [GrepMatch] = []
         let files = isDirectory.boolValue
-            ? collectFiles(at: rootURL)
+            ? collectFiles(at: rootURL, glob: params.glob)
             : [rootURL]
 
         let limit = params.limit ?? Truncate.grepDefaultLimit
         let maxLineChars = Truncate.grepMaxLineLength
         let maxTotalBytes = Truncate.grepMaxTotalBytes
+        let context = max(0, params.context)
         var totalBytes = 0
 
         outer: for fileURL in files {
-            guard let data = try? Data(contentsOf: fileURL),
-                  let text = String(data: data, encoding: .utf8) else { continue }
+            guard let data = try? Data(contentsOf: fileURL) else { continue }
+            // Skip files that look binary (ripgrep, which pi shells out to,
+            // does the same by ignoring files with NUL bytes).
+            if looksBinary(data) { continue }
+            guard let text = String(data: data, encoding: .utf8) else { continue }
             let lines = text.components(separatedBy: "\n")
             for (i, line) in lines.enumerated() {
                 let ns = line as NSString
-                if pattern.firstMatch(in: line, options: [], range: NSRange(location: 0, length: ns.length)) != nil {
-                    let truncated = Truncate.truncateLine(line, maxChars: maxLineChars)
-                    let match = GrepMatch(
-                        file: fileURL.path,
-                        line: i + 1,
-                        text: truncated.text
-                    )
-                    let entryBytes = "\(match.file):\(match.line):\(match.text)\n".utf8.count
-                    if totalBytes + entryBytes > maxTotalBytes && !results.isEmpty {
-                        // Mark the last result so the caller knows we
-                        // stopped because of the byte budget.
-                        results.append(GrepMatch(
-                            file: "",
-                            line: 0,
-                            text: "[truncated: total output exceeded \(Truncate.formatSize(maxTotalBytes))]"
-                        ))
-                        break outer
-                    }
-                    totalBytes += entryBytes
-                    results.append(match)
-                    if results.count >= limit { break outer }
+                guard pattern.firstMatch(in: line, options: [], range: NSRange(location: 0, length: ns.length)) != nil else { continue }
+                let match = makeMatch(
+                    file: fileURL.path,
+                    lines: lines,
+                    index: i,
+                    context: context,
+                    maxLineChars: maxLineChars
+                )
+                let entryBytes = blockBytes(match)
+                if totalBytes + entryBytes > maxTotalBytes && !results.isEmpty {
+                    // Mark the last result so the caller knows we
+                    // stopped because of the byte budget.
+                    results.append(GrepMatch(
+                        file: "",
+                        line: 0,
+                        text: "[truncated: total output exceeded \(Truncate.formatSize(maxTotalBytes))]"
+                    ))
+                    break outer
                 }
+                totalBytes += entryBytes
+                results.append(match)
+                if results.count >= limit { break outer }
             }
         }
         return results
     }
 
-    private func collectFiles(at rootURL: URL) -> [URL] {
-        let fm = FileManager.default
-        guard let enumerator = fm.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey]) else {
-            return []
-        }
-        var out: [URL] = []
-        for case let url as URL in enumerator {
-            if let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
-               values.isRegularFile == true {
-                out.append(url)
+    private func makeMatch(
+        file: String,
+        lines: [String],
+        index i: Int,
+        context: Int,
+        maxLineChars: Int
+    ) -> GrepMatch {
+        let text = Truncate.truncateLine(lines[i], maxChars: maxLineChars).text
+        var before: [GrepContextLine] = []
+        var after: [GrepContextLine] = []
+        if context > 0 {
+            for j in max(0, i - context)..<i {
+                before.append(GrepContextLine(line: j + 1, text: Truncate.truncateLine(lines[j], maxChars: maxLineChars).text))
+            }
+            let end = min(lines.count - 1, i + context)
+            if i < end {
+                for j in (i + 1)...end {
+                    after.append(GrepContextLine(line: j + 1, text: Truncate.truncateLine(lines[j], maxChars: maxLineChars).text))
+                }
             }
         }
+        return GrepMatch(file: file, line: i + 1, text: text, before: before, after: after)
+    }
+
+    private func blockBytes(_ m: GrepMatch) -> Int {
+        var total = "\(m.file):\(m.line):\(m.text)\n".utf8.count
+        for c in m.before { total += "\(m.file)-\(c.line)-\(c.text)\n".utf8.count }
+        for c in m.after { total += "\(m.file)-\(c.line)-\(c.text)\n".utf8.count }
+        return total
+    }
+
+    private func looksBinary(_ data: Data) -> Bool {
+        data.prefix(8192).contains(0)
+    }
+
+    private func collectFiles(at rootURL: URL, glob: String?) -> [URL] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
+        ) else {
+            return []
+        }
+        // Compile the glob regex once, up front, rather than per visited file.
+        // A glob without a slash filters on the basename at any depth (ripgrep's
+        // `--glob '*.ts'` semantics); one with a slash matches the path relative
+        // to the search root.
+        let globRegex = glob.flatMap { try? NSRegularExpression(pattern: Glob.patternToRegex($0)) }
+        let globMatchesRelative = glob?.contains("/") ?? false
+        let rootPath = rootURL.standardizedFileURL.path
+        var out: [URL] = []
+        for case let url as URL in enumerator {
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            if values?.isDirectory == true {
+                // Prune VCS metadata and dependency trees during traversal.
+                if ignoredWalkDirectoryNames.contains(url.lastPathComponent) {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+            guard values?.isRegularFile == true else { continue }
+            if let globRegex {
+                let candidate = globMatchesRelative
+                    ? relativePath(of: url.path, under: rootPath)
+                    : url.lastPathComponent
+                let ns = candidate as NSString
+                if globRegex.firstMatch(in: candidate, options: [], range: NSRange(location: 0, length: ns.length)) == nil {
+                    continue
+                }
+            }
+            out.append(url)
+        }
         return out
+    }
+
+    private func relativePath(of path: String, under root: String) -> String {
+        let prefix = root.hasSuffix("/") ? root.count : root.count + 1
+        return path.count > prefix ? String(path.dropFirst(prefix)) : path
     }
 }
 
@@ -133,6 +202,13 @@ public func createGrepTool(cwd: String, options: GrepToolOptions = .init()) -> A
             }
             else { path = cwd }
 
+            let glob: String? = {
+                if case .string(let g) = obj["glob"] ?? .null {
+                    let trimmed = g.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                return nil
+            }()
             let ignoreCase: Bool = {
                 if case .bool(let v) = obj["ignoreCase"] ?? .null { return v }
                 return false
@@ -140,6 +216,11 @@ public func createGrepTool(cwd: String, options: GrepToolOptions = .init()) -> A
             let literal: Bool = {
                 if case .bool(let v) = obj["literal"] ?? .null { return v }
                 return false
+            }()
+            let context: Int = {
+                if case .int(let v) = obj["context"] ?? .null { return max(0, v) }
+                if case .double(let v) = obj["context"] ?? .null { return max(0, Int(v)) }
+                return 0
             }()
             let limit: Int? = {
                 if case .int(let v) = obj["limit"] ?? .null { return v }
@@ -150,8 +231,10 @@ public func createGrepTool(cwd: String, options: GrepToolOptions = .init()) -> A
             let matches = try await ops.grep(params: GrepParams(
                 pattern: pattern,
                 path: path,
+                glob: glob,
                 ignoreCase: ignoreCase,
                 literal: literal,
+                context: context,
                 limit: limit
             ))
 
@@ -166,18 +249,30 @@ public func createGrepTool(cwd: String, options: GrepToolOptions = .init()) -> A
                 )
             }
 
-            var lines = effectiveMatches.map { "\($0.file):\($0.line):\($0.text)" }
+            var lines: [String] = []
+            for m in effectiveMatches {
+                for c in m.before { lines.append("\(m.file)-\(c.line)-\(c.text)") }
+                lines.append("\(m.file):\(m.line):\(m.text)")
+                for c in m.after { lines.append("\(m.file)-\(c.line)-\(c.text)") }
+            }
             if byteTruncated {
                 lines.append("[truncated: total output exceeded \(Truncate.formatSize(maxTotalBytes))]")
             }
             let body = lines.joined(separator: "\n")
 
             let encoded: [JSONValue] = effectiveMatches.map { m in
-                .object([
+                var obj: [String: JSONValue] = [
                     "file": .string(m.file),
                     "line": .int(m.line),
                     "text": .string(m.text),
-                ])
+                ]
+                if !m.before.isEmpty {
+                    obj["before"] = .array(m.before.map { .object(["line": .int($0.line), "text": .string($0.text)]) })
+                }
+                if !m.after.isEmpty {
+                    obj["after"] = .array(m.after.map { .object(["line": .int($0.line), "text": .string($0.text)]) })
+                }
+                return .object(obj)
             }
 
             var details: [String: JSONValue] = [

--- a/Sources/KWWKAgent/PathUtils.swift
+++ b/Sources/KWWKAgent/PathUtils.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 public enum PathUtils {
     private static let unicodeSpaceScalars = Set<UInt32>(
@@ -44,6 +49,36 @@ public enum PathUtils {
             }
         }
         return out
+    }
+
+    /// Write `data` to `path` in place: open the existing file (following any
+    /// symlink in the path) and truncate it, or create it with `createMode`
+    /// when missing. Preserves the inode, hard-link siblings, symlink target,
+    /// and existing permissions — matching pi's `fs.writeFile`, unlike an
+    /// atomic temp-file rename which allocates a new inode and detaches
+    /// symlinks/hard links.
+    public static func writeFileInPlace(_ path: String, data: Data, createMode: mode_t = 0o644) throws {
+        #if canImport(Darwin) || canImport(Glibc)
+        let fd = path.withCString { open($0, O_WRONLY | O_CREAT | O_TRUNC, createMode) }
+        if fd < 0 {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(fd) }
+        try data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            guard let base = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let written = write(fd, base.advanced(by: offset), buffer.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                offset += written
+            }
+        }
+        #else
+        try data.write(to: URL(fileURLWithPath: path))
+        #endif
     }
 
     /// Detect a supported image MIME type by sniffing leading magic bytes.

--- a/Sources/KWWKAgent/ReadTool.swift
+++ b/Sources/KWWKAgent/ReadTool.swift
@@ -2,18 +2,15 @@ import Foundation
 import KWWKAI
 
 public struct ReadToolOptions: Sendable {
-    public var autoResizeImages: Bool
     public var operations: ReadOperations
     public var maxLines: Int
     public var maxBytes: Int
 
     public init(
-        autoResizeImages: Bool = true,
         operations: ReadOperations = LocalReadOperations(),
         maxLines: Int = Truncate.defaultMaxLines,
         maxBytes: Int = Truncate.defaultMaxBytes
     ) {
-        self.autoResizeImages = autoResizeImages
         self.operations = operations
         self.maxLines = maxLines
         self.maxBytes = maxBytes
@@ -85,7 +82,9 @@ public func createReadTool(cwd: String, options: ReadToolOptions = .init()) -> A
             let absolutePath = PathUtils.resolveToCwd(rawPath, cwd: cwd)
             try await ops.access(absolutePath)
 
-            // Image path.
+            // Image path. The image is base64-inlined as-is: there is no
+            // resizing or downscaling, so a large image contributes its full
+            // encoded byte count to the request.
             if let mimeType = try await ops.detectImageMimeType(absolutePath) {
                 let buffer = try await ops.readFile(absolutePath)
                 let base64 = buffer.base64EncodedString()
@@ -103,21 +102,29 @@ public func createReadTool(cwd: String, options: ReadToolOptions = .init()) -> A
             guard let text = String(data: buffer, encoding: .utf8) else {
                 throw CodingToolError.invalidArgument("read: file is not valid UTF-8")
             }
-            let allLines = text.components(separatedBy: "\n")
-            let totalLines = allLines.count
+            // Total line count via a single newline pass — cheap and
+            // allocation-free, unlike materializing every line as a String.
+            let totalLines = text.utf8.reduce(1) { $0 + ($1 == 0x0A ? 1 : 0) }
             let startLine = (offset.map { max(0, $0 - 1) }) ?? 0
             let startDisplay = startLine + 1
-            if startLine >= allLines.count {
-                throw CodingToolError.offsetOutOfRange(offset: offset ?? 0, totalLines: allLines.count)
+            if startLine >= totalLines {
+                throw CodingToolError.offsetOutOfRange(offset: offset ?? 0, totalLines: totalLines)
             }
 
             var userLimitedLines: Int?
             let selectedContent: String
             if let limit {
-                let endLine = min(startLine + limit, allLines.count)
-                selectedContent = allLines[startLine..<endLine].joined(separator: "\n")
-                userLimitedLines = endLine - startLine
+                // Only split up to the requested window instead of every line
+                // in the file: `maxSplits` stops scanning past the window and
+                // keeps the remainder as one unsplit chunk, which we drop.
+                let needed = startLine + limit
+                let head = text.split(separator: "\n", maxSplits: needed, omittingEmptySubsequences: false)
+                let windowEnd = min(needed, head.count)
+                selectedContent = head[startLine..<windowEnd].joined(separator: "\n")
+                userLimitedLines = windowEnd - startLine
             } else {
+                // No limit: everything from the offset to EOF is needed anyway.
+                let allLines = text.components(separatedBy: "\n")
                 selectedContent = allLines[startLine...].joined(separator: "\n")
             }
 
@@ -130,7 +137,8 @@ public func createReadTool(cwd: String, options: ReadToolOptions = .init()) -> A
             var returnDetails: JSONValue?
 
             if trunc.firstLineExceedsLimit {
-                let firstLineSize = Truncate.formatSize(allLines[startLine].utf8.count)
+                let firstWindowLineBytes = selectedContent.utf8.prefix { $0 != 0x0A }.count
+                let firstLineSize = Truncate.formatSize(firstWindowLineBytes)
                 outputText = "[Line \(startDisplay) is \(firstLineSize), exceeds \(Truncate.formatSize(maxBytes)) limit.]"
                 returnDetails = encodeTruncation(trunc)
             } else if trunc.truncated {
@@ -143,8 +151,8 @@ public func createReadTool(cwd: String, options: ReadToolOptions = .init()) -> A
                     outputText += "\n\n[Showing lines \(startDisplay)-\(endDisplay) of \(totalLines) (\(Truncate.formatSize(maxBytes)) limit). Use offset=\(nextOffset) to continue.]"
                 }
                 returnDetails = encodeTruncation(trunc)
-            } else if let ul = userLimitedLines, startLine + ul < allLines.count {
-                let remaining = allLines.count - (startLine + ul)
+            } else if let ul = userLimitedLines, startLine + ul < totalLines {
+                let remaining = totalLines - (startLine + ul)
                 let nextOffset = startLine + ul + 1
                 outputText = "\(trunc.content)\n\n[\(remaining) more lines in file. Use offset=\(nextOffset) to continue.]"
             } else {

--- a/Sources/KWWKAgent/SessionRecorder.swift
+++ b/Sources/KWWKAgent/SessionRecorder.swift
@@ -48,10 +48,12 @@ public final class SessionRecorder: @unchecked Sendable {
         self.persistedCount = persistedCount
     }
 
-    /// Ensure the session file exists with a header. Call once before the
-    /// first run when starting a fresh session.
+    /// Ensure the session file exists with a header, creating it only when it
+    /// does not already exist. Safe to call after resuming — it never truncates
+    /// an existing transcript, so a resumed session's history is preserved even
+    /// if a caller forgets the `resumed` guard.
     public func ensureCreated() async {
-        _ = try? await store.create(id: sessionId, cwd: cwd, model: model, provider: provider)
+        _ = try? await store.createIfMissing(id: sessionId, cwd: cwd, model: model, provider: provider)
     }
 
     /// Subscribe to `agent` and persist its transcript as it grows. Returns an

--- a/Sources/KWWKAgent/SessionResume.swift
+++ b/Sources/KWWKAgent/SessionResume.swift
@@ -57,13 +57,17 @@ public struct ResolvedResume: Sendable {
 
 extension SessionStore {
     /// Resolve a `SessionResume` for `cwd`, loading the stored transcript when
-    /// a matching session exists. A fresh `UUID` id is minted otherwise. Never
-    /// throws — an unreadable/missing target degrades to a fresh session.
+    /// a matching session exists. A fresh `UUID` id is minted for `.none` /
+    /// `.pickInteractive` / a `.latestForCwd` with no prior session. An
+    /// explicit `.id(...)` whose format is invalid throws
+    /// `SessionStoreError.invalidId` rather than silently substituting a random
+    /// session — a caller asking for a named session should hear about a typo,
+    /// not scatter transcripts across UUID files.
     public func resolveResume(
         _ resume: SessionResume,
         cwd: String,
         freshId: String = UUID().uuidString
-    ) async -> ResolvedResume {
+    ) async throws -> ResolvedResume {
         switch resume {
         case .none:
             return ResolvedResume(sessionId: freshId)
@@ -89,7 +93,7 @@ extension SessionStore {
 
         case .id(let id):
             guard SessionStore.isValidSessionId(id) else {
-                return ResolvedResume(sessionId: freshId)
+                throw SessionStoreError.invalidId(id)
             }
             do {
                 let loaded = try load(id: id)

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -269,6 +269,11 @@ public actor SessionStore {
         case notFound(String)
         case invalidId(String)
         case storageDisabled
+        /// A transcript line failed to decode. Carries the file path and the
+        /// 1-based line number so schema drift / corruption is diagnosable
+        /// instead of silently dropping messages.
+        case undecodableEntry(path: String, line: Int)
+        case writeFailed(path: String)
     }
 
     // MARK: - Paths
@@ -290,9 +295,14 @@ public actor SessionStore {
 
     private func ensureDirectory() throws {
         guard isPersistent else { throw SessionStoreError.storageDisabled }
+        // 0700: session transcripts carry the full conversation plus every tool
+        // result (bash output, file contents). Lock the directory to the owner
+        // at creation, mirroring BackgroundTaskManager's 0700 output dir — no
+        // chmod-after-create race.
         try FileManager.default.createDirectory(
             at: directory,
-            withIntermediateDirectories: true
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
         )
     }
 
@@ -307,7 +317,8 @@ public actor SessionStore {
     // MARK: - Create / append
 
     /// Create a new session file with a versioned header. Overwrites any
-    /// existing file for the same id. Returns the written header.
+    /// existing file for the same id — use `createIfMissing` to preserve a
+    /// resumed transcript. Returns the written header.
     @discardableResult
     public func create(
         id: String,
@@ -320,8 +331,33 @@ public actor SessionStore {
         let line = try Self.encoder.encode(header)
         var data = line
         data.append(0x0A)  // newline
-        try data.write(to: try path(for: id), options: .atomic)
+        let url = try path(for: id)
+        // Create with 0600 at write time (no chmod-after-write window): the
+        // transcript is the same class of sensitive data the 0600 task logs
+        // protect. createFile truncates an existing file, matching this
+        // method's overwrite contract.
+        guard FileManager.default.createFile(
+            atPath: url.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw SessionStoreError.writeFailed(path: url.path)
+        }
         return header
+    }
+
+    /// Create the session file (header only) only when it does not already
+    /// exist. Never truncates an existing transcript, so resuming a session
+    /// and then calling this is a safe no-op. Backs `SessionRecorder.ensureCreated`.
+    public func createIfMissing(
+        id: String,
+        cwd: String,
+        model: String? = nil,
+        provider: String? = nil
+    ) throws {
+        let url = try path(for: id)
+        guard !FileManager.default.fileExists(atPath: url.path) else { return }
+        try create(id: id, cwd: cwd, model: model, provider: provider)
     }
 
     /// Append a single transcript message to a session, creating the file
@@ -452,12 +488,20 @@ public actor SessionStore {
         var thinkingLevel: String?
         var title: String?
 
-        for line in lines.dropFirst() {
-            guard let data = String(line).data(using: .utf8),
-                  let entry = try? Self.decoder.decode(Entry.self, from: data) else {
-                // Skip malformed/partial trailing lines (e.g. a crash mid-write)
-                // rather than failing the whole load.
-                continue
+        // Line 1 is the header; entries start at line 2. An entry that fails
+        // to decode (schema drift after an up/downgrade, mid-file corruption)
+        // is an error — throwing with the exact line keeps a resumed context
+        // from silently losing messages out of the middle of a conversation.
+        for (offset, line) in lines.dropFirst().enumerated() {
+            let lineNumber = offset + 2
+            guard let data = String(line).data(using: .utf8) else {
+                throw SessionStoreError.undecodableEntry(path: url.path, line: lineNumber)
+            }
+            let entry: Entry
+            do {
+                entry = try Self.decoder.decode(Entry.self, from: data)
+            } catch {
+                throw SessionStoreError.undecodableEntry(path: url.path, line: lineNumber)
             }
             switch entry {
             case .message(_, let message):
@@ -545,18 +589,24 @@ public actor SessionStore {
         var title: String?
         var messageCount = 0
         for line in lines.dropFirst() {
-            guard let data = String(line).data(using: .utf8),
-                  let entry = try? Self.decoder.decode(Entry.self, from: data) else { continue }
-            switch entry {
-            case .message:
+            // Listing only needs a message count plus the latest meta values, so
+            // never JSON-decode the message bodies (full transcripts, embedded
+            // base64 images) — that is what made `--continue` startup pay for
+            // the entire on-disk history. The encoder writes `.sortedKeys`, so a
+            // transcript-message entry is always `{"message":{…`; classify by
+            // that prefix and skip the decode. Only the small/rare `meta` lines
+            // are decoded (compaction markers are irrelevant to listing).
+            if line.hasPrefix("{\"message\":") {
                 messageCount += 1
-            case .meta(_, let m, let p, _, let ti):
-                if let m { model = m }
-                if let p { provider = p }
-                if let ti { title = ti }
-            case .compaction:
                 continue
             }
+            guard line.contains("\"type\":\"meta\""),
+                  let data = String(line).data(using: .utf8),
+                  case .meta(_, let m, let p, _, let ti)? =
+                    try? Self.decoder.decode(Entry.self, from: data) else { continue }
+            if let m { model = m }
+            if let p { provider = p }
+            if let ti { title = ti }
         }
 
         let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?

--- a/Sources/KWWKAgent/SubagentDefinition.swift
+++ b/Sources/KWWKAgent/SubagentDefinition.swift
@@ -87,7 +87,7 @@ public struct BuiltinSubagentSelection: OptionSet, Sendable, Hashable {
         return selection
     }
 
-    public static let validNames = "general, Explore, Plan, all, none"
+    public static let validNames = "general, explore, plan, all, none"
 }
 
 public extension SubagentDefinition {
@@ -123,7 +123,7 @@ public extension SubagentDefinition {
         tools: CodingTools = .readOnly
     ) -> SubagentDefinition {
         SubagentDefinition(
-            name: "Explore",
+            name: "explore",
             description: "Use for read-only codebase exploration, file discovery, and call-chain analysis.",
             prompt: """
             You are a read-only code exploration specialist.
@@ -149,7 +149,7 @@ public extension SubagentDefinition {
         tools: CodingTools = .readOnly
     ) -> SubagentDefinition {
         SubagentDefinition(
-            name: "Plan",
+            name: "plan",
             description: "Use for read-only implementation planning before code changes.",
             prompt: """
             You are a read-only implementation planner.

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -12,7 +12,7 @@ public func createAgentTool(
     parentAutoCompact: AgentAutoCompactOptions? = nil,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
-    authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
     bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
@@ -49,7 +49,7 @@ public func createAgentTool(
     parentTools: CodingTools,
     backgroundManager: BackgroundTaskManager? = nil,
     sessionId: String? = nil,
-    fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    fallbackAuthResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
     bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
@@ -87,7 +87,7 @@ internal struct SubagentParentSnapshot: Sendable {
     var thinkingBudgets: ThinkingBudgets?
     var maxRetryDelayMs: Int?
     var autoCompact: AgentAutoCompactOptions?
-    var authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    var authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
 }
 
 internal final class SubagentParentBox: @unchecked Sendable {
@@ -99,7 +99,7 @@ internal final class SubagentParentBox: @unchecked Sendable {
     private let fallbackThinkingBudgets: ThinkingBudgets?
     private let fallbackMaxRetryDelayMs: Int?
     private let fallbackAutoCompact: AgentAutoCompactOptions?
-    private let fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    private let fallbackAuthResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
 
     init(
         fallbackModel: Model,
@@ -108,7 +108,7 @@ internal final class SubagentParentBox: @unchecked Sendable {
         fallbackThinkingBudgets: ThinkingBudgets?,
         fallbackMaxRetryDelayMs: Int?,
         fallbackAutoCompact: AgentAutoCompactOptions?,
-        fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+        fallbackAuthResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
     ) {
         self.fallbackModel = fallbackModel
         self.fallbackTools = fallbackTools
@@ -373,17 +373,21 @@ private struct SubagentRegistry: Sendable {
         for definition in subagents {
             let name = definition.name.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else { continue }
-            if definitions[name] == nil {
+            // Key lookups case-insensitively to match the selection parser
+            // (BuiltinSubagentSelection.named lowercases its input); `names`
+            // keeps the definition's own spelling for the tool-schema enum.
+            let key = name.lowercased()
+            if definitions[key] == nil {
                 names.append(name)
             }
-            definitions[name] = definition
+            definitions[key] = definition
         }
         self.names = names
         self.definitions = definitions
     }
 
     func definition(named name: String) -> SubagentDefinition? {
-        definitions[name]
+        definitions[name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
     }
 }
 
@@ -580,7 +584,7 @@ public struct SubagentRunner: Sendable {
         parentAutoCompact: AgentAutoCompactOptions? = nil,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600,
@@ -615,7 +619,7 @@ public struct SubagentRunner: Sendable {
         parentTools: CodingTools,
         backgroundManager: BackgroundTaskManager? = nil,
         sessionId: String? = nil,
-        fallbackAuthResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        fallbackAuthResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600,
@@ -695,7 +699,8 @@ public struct SubagentRunner: Sendable {
 
     private func definition(named rawName: String) throws -> SubagentDefinition {
         let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let definition = subagents.first(where: { $0.name == trimmed }) {
+        let key = trimmed.lowercased()
+        if let definition = subagents.first(where: { $0.name.lowercased() == key }) {
             return definition
         }
         let names = subagents
@@ -848,7 +853,7 @@ private struct SubagentInvocationRunner: Sendable {
             toolOverride: modelOverride
         )
         let selectedTools = definition.tools ?? parent.tools
-        let tools = await buildCodingToolList(
+        let tools = try await buildCodingToolList(
             cwd: cwd,
             selected: selectedTools,
             backgroundManager: backgroundManager,
@@ -1047,7 +1052,7 @@ private func adoptRuntimeFields(from current: Model, into picked: Model) -> Mode
     var rebuilt = picked
     rebuilt.api = current.api
     rebuilt.provider = current.provider
-    rebuilt.baseUrl = current.baseUrl
+    rebuilt.baseURL = current.baseURL
     rebuilt.headers = current.headers
     return rebuilt
 }

--- a/Sources/KWWKAgent/TmuxSessionManager.swift
+++ b/Sources/KWWKAgent/TmuxSessionManager.swift
@@ -27,6 +27,11 @@ public actor TmuxSessionManager {
     public let socketName: String
     public let sessionName: String
     private let tmuxPath: String
+    /// Exact environment the tmux server (and therefore every pane process) is
+    /// spawned with. Required — like `CodingAgentConfig.bashEnvironment` — so
+    /// the host's environment (API keys and all) is never silently inherited by
+    /// pane commands the model runs.
+    private let environment: [String: String]
 
     private var probed: Bool = false
     private var available: Bool = false
@@ -35,6 +40,9 @@ public actor TmuxSessionManager {
 
     /// - Parameters:
     ///   - tmuxPath: Explicit path to the tmux executable.
+    ///   - environment: Exact environment for the tmux server and its panes.
+    ///     No default: passing the host environment is a deliberate caller
+    ///     choice, matching the bash tool's isolation contract.
     ///   - socketName: Defaults to `kw-<pid>` so multiple kw processes
     ///     don't collide on the same socket. Tests override for isolation.
     ///   - sessionName: tmux session name under the socket. Defaults to
@@ -42,12 +50,14 @@ public actor TmuxSessionManager {
     ///     `duplicate session` errors.
     public init(
         tmuxPath: String,
+        environment: [String: String],
         socketName: String? = nil,
         sessionName: String = "kw"
     ) {
         self.socketName = socketName ?? "kw-\(ProcessInfo.processInfo.processIdentifier)"
         self.sessionName = sessionName
         self.tmuxPath = tmuxPath
+        self.environment = environment
     }
 
     public var isAvailable: Bool {
@@ -253,13 +263,25 @@ public actor TmuxSessionManager {
     private func runTmuxSync(args: [String]) -> ProcResult {
         var allArgs = ["-L", socketName]
         allArgs.append(contentsOf: args)
-        return TmuxSessionManager.runProcessSync(executable: tmuxPath, args: allArgs)
+        return TmuxSessionManager.runProcessSync(
+            executable: tmuxPath,
+            args: allArgs,
+            environment: environment
+        )
     }
 
-    nonisolated static func runProcessSync(executable: String, args: [String]) -> ProcResult {
+    nonisolated static func runProcessSync(
+        executable: String,
+        args: [String],
+        environment: [String: String]
+    ) -> ProcResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
+        // Set the tmux server / pane environment explicitly. Without this the
+        // server inherits the host's full environment and leaks it into every
+        // pane the model drives.
+        process.environment = environment
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.standardOutput = stdoutPipe
@@ -270,16 +292,40 @@ public actor TmuxSessionManager {
         } catch {
             return ProcResult(exitCode: 127, stdout: "", stderr: "\(error)")
         }
+        // Drain both pipes CONCURRENTLY with the wait. Reading only after
+        // waitUntilExit deadlocks once tmux writes more than the ~64KB pipe
+        // buffer (e.g. `capture-pane` over a long scrollback): tmux blocks in
+        // write(2) while we block in wait.
+        let outBox = TmuxDataBox()
+        let errBox = TmuxDataBox()
+        let group = DispatchGroup()
+        let outHandle = stdoutPipe.fileHandleForReading
+        let errHandle = stderrPipe.fileHandleForReading
+        group.enter()
+        DispatchQueue.global().async {
+            outBox.data = outHandle.readDataToEndOfFile()
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global().async {
+            errBox.data = errHandle.readDataToEndOfFile()
+            group.leave()
+        }
         process.waitUntilExit()
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        group.wait()
         return ProcResult(
             exitCode: process.terminationStatus,
-            stdout: stdout,
-            stderr: stderr
+            stdout: String(decoding: outBox.data, as: UTF8.self),
+            stderr: String(decoding: errBox.data, as: UTF8.self)
         )
     }
 
+}
+
+/// `@unchecked Sendable` holder for draining a pipe on a background queue.
+/// Written on the read thread, read after `DispatchGroup.wait` synchronizes.
+private final class TmuxDataBox: @unchecked Sendable {
+    var data = Data()
 }
 
 public struct ProcResult: Sendable {

--- a/Sources/KWWKAgent/TmuxTool.swift
+++ b/Sources/KWWKAgent/TmuxTool.swift
@@ -193,9 +193,13 @@ public func createTmuxTool(
                     throw CodingToolError.invalidArgument("tmux: `pane_id` is required for action=capture")
                 }
                 let lines: Int? = {
-                    if case .int(let v) = obj["lines"] ?? .null { return v }
-                    if case .double(let v) = obj["lines"] ?? .null { return Int(v) }
-                    return nil
+                    let raw: Int
+                    if case .int(let v) = obj["lines"] ?? .null { raw = v }
+                    else if case .double(let v) = obj["lines"] ?? .null { raw = Int(v) }
+                    else { return nil }
+                    // Clamp the model-controlled count: a huge value makes tmux
+                    // emit megabytes of scrollback and bloats the transcript.
+                    return min(max(raw, 1), 10_000)
                 }()
                 let text = try await manager.capture(paneId, lines: lines)
                 return AgentToolResult(

--- a/Sources/KWWKAgent/Truncate.swift
+++ b/Sources/KWWKAgent/Truncate.swift
@@ -105,6 +105,71 @@ public enum Truncate {
         )
     }
 
+    /// Tail truncation — keep the last N lines/bytes. Command output (bash,
+    /// test runs) is most useful at the end, where errors and summaries land,
+    /// so this is the counterpart to `truncateHead` for tool output that we
+    /// want to bound without losing the tail.
+    public static func truncateTail(
+        _ content: String,
+        maxLines: Int = defaultMaxLines,
+        maxBytes: Int = defaultMaxBytes
+    ) -> Result {
+        let totalBytes = content.utf8.count
+        // A trailing newline terminates the last line — it does not start an
+        // empty one. Without this, `seq 1 3` counts 4 lines and the kept tail
+        // ends in "" instead of "3".
+        let body = content.hasSuffix("\n") ? String(content.dropLast()) : content
+        let lines = body.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let totalLines = lines.count
+
+        if totalLines <= maxLines && totalBytes <= maxBytes {
+            return Result(
+                content: content,
+                truncated: false,
+                truncatedBy: nil,
+                totalLines: totalLines,
+                totalBytes: totalBytes,
+                outputLines: totalLines,
+                outputBytes: totalBytes,
+                lastLinePartial: false,
+                firstLineExceedsLimit: false,
+                maxLines: maxLines,
+                maxBytes: maxBytes
+            )
+        }
+
+        var kept: [String] = []
+        var outBytes = 0
+        var truncatedBy = "lines"
+        for line in lines.reversed() {
+            if kept.count >= maxLines {
+                truncatedBy = "lines"
+                break
+            }
+            let lineBytes = line.utf8.count + (kept.isEmpty ? 0 : 1)
+            if outBytes + lineBytes > maxBytes {
+                truncatedBy = "bytes"
+                break
+            }
+            kept.append(line)
+            outBytes += lineBytes
+        }
+        let output = kept.reversed().joined(separator: "\n")
+        return Result(
+            content: output,
+            truncated: true,
+            truncatedBy: truncatedBy,
+            totalLines: totalLines,
+            totalBytes: totalBytes,
+            outputLines: kept.count,
+            outputBytes: output.utf8.count,
+            lastLinePartial: false,
+            firstLineExceedsLimit: false,
+            maxLines: maxLines,
+            maxBytes: maxBytes
+        )
+    }
+
     /// Truncate a single line to `maxChars` characters, adding a suffix if needed.
     public static func truncateLine(
         _ line: String, maxChars: Int = grepMaxLineLength

--- a/Sources/KWWKAgent/WriteTool.swift
+++ b/Sources/KWWKAgent/WriteTool.swift
@@ -14,7 +14,11 @@ public struct LocalWriteOperations: WriteOperations {
     public init() {}
 
     public func writeFile(_ absolutePath: String, content: Data) async throws {
-        try content.write(to: URL(fileURLWithPath: absolutePath), options: .atomic)
+        // In-place write (open + truncate): when the path is an existing file
+        // or symlink, this writes through it and preserves the inode, symlink
+        // target, hard links, and permissions rather than replacing them via an
+        // atomic rename. Mirrors pi's `fs.writeFile`.
+        try PathUtils.writeFileInPlace(absolutePath, data: content)
     }
 
     public func createParentDirectories(_ absolutePath: String) async throws {

--- a/Sources/KWWKCli/ANSI.swift
+++ b/Sources/KWWKCli/ANSI.swift
@@ -13,18 +13,52 @@ enum ANSI {
         var width = 0
         let scalars = Array(s.unicodeScalars)
         var i = 0
+        // An emoji ZWJ sequence (base ZWJ base …) renders as a single glyph:
+        // the scalars after a Zero-Width Joiner fold into the preceding base
+        // and contribute no extra columns. Likewise a regional-indicator pair
+        // (a flag) is one 2-column glyph. Track the join state across scalars.
+        var prevWasZWJ = false
+        var prevWasRI = false
         while i < scalars.count {
             let v = scalars[i].value
             if v == 0x1B {
                 i = skipEscape(scalars, from: i)
+                prevWasZWJ = false; prevWasRI = false
                 continue
             }
             // Skip APC payload (BEL-terminated) + other C0 controls.
-            if v < 0x20 || v == 0x7F { i += 1; continue }
-            width += columnWidth(of: v)
+            if v < 0x20 || v == 0x7F { i += 1; prevWasZWJ = false; prevWasRI = false; continue }
+            if v == 0x200D { prevWasZWJ = true; prevWasRI = false; i += 1; continue }
+            let isRI = v >= 0x1F1E6 && v <= 0x1F1FF
+            if prevWasZWJ || (isRI && prevWasRI) {
+                // Joined into the previous glyph — no additional columns.
+            } else {
+                width += columnWidth(of: v)
+            }
+            prevWasZWJ = false
+            prevWasRI = isRI && !prevWasRI
             i += 1
         }
         return width
+    }
+
+    /// Visible column width of one grapheme cluster (a `Character`). An emoji
+    /// ZWJ sequence collapses to a single 2-column glyph; skin-tone modifiers
+    /// and variation selectors are zero-width; a regional-indicator pair is one
+    /// 2-column flag. Everything else is the sum of its scalar widths.
+    static func graphemeWidth(_ ch: Character) -> Int {
+        let scalars = ch.unicodeScalars
+        if scalars.contains(where: { $0.value == 0x200D }) { return 2 }
+        var w = 0
+        var prevWasRI = false
+        for s in scalars {
+            let v = s.value
+            let isRI = v >= 0x1F1E6 && v <= 0x1F1FF
+            if isRI && prevWasRI { prevWasRI = false; continue }
+            w += columnWidth(of: v)
+            prevWasRI = isRI
+        }
+        return w
     }
 
     /// Visible column width of a single Unicode scalar. Returns 0 for
@@ -51,6 +85,9 @@ enum ANSI {
             (0x2060, 0x206F),
             (0xFE00, 0xFE0F),   // Variation selectors
             (0xFE20, 0xFE2F),
+            (0x1F3FB, 0x1F3FF), // Emoji skin-tone modifiers — compose onto
+                                // their base emoji, so they add no columns.
+            (0xE0100, 0xE01EF), // Variation Selectors Supplement
         ]) { return 0 }
 
         // Wide (width 2) — condensed UAX-11 W/F ranges.
@@ -102,9 +139,18 @@ enum ANSI {
             (0xFE30, 0xFE6F),
             (0xFF00, 0xFF60),   // Fullwidth ASCII + punctuation
             (0xFFE0, 0xFFE6),
+            (0x1F004, 0x1F004), // Mahjong red dragon
+            (0x1F0CF, 0x1F0CF), // Playing card black joker
+            (0x1F18E, 0x1F18E), // Negative squared AB
+            (0x1F191, 0x1F19A), // Squared CL … VS
+            (0x1F1E6, 0x1F1FF), // Regional indicators (flags)
+            (0x1F200, 0x1F2FF), // Enclosed ideographic supplement
             (0x1F300, 0x1F64F), // Misc symbols + emoji
             (0x1F680, 0x1F6FF),
+            (0x1F7E0, 0x1F7EB), // Colored circles + squares
+            (0x1F7F0, 0x1F7F0),
             (0x1F900, 0x1F9FF),
+            (0x1FA70, 0x1FAFF), // Symbols and Pictographs Extended-A
             (0x20000, 0x2FFFD), // CJK Unified Ideographs Ext B..F
             (0x30000, 0x3FFFD),
         ]) { return 2 }

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -9,7 +9,7 @@ struct ResolvedAuth: Sendable {
     /// For OAuth-backed providers (Codex, Anthropic OAuth, ...), an
     /// `authResolver` that calls back into `OAuthManager.apiKey(for:)` so
     /// tokens refresh on demand. Nil for static api-key providers.
-    let authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)?
+    let authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
     /// Every provider registered this session, so `/model` can list + switch
     /// across all logged-in accounts. Single-login / env auth yields one slot.
     let providerSlots: [ProviderSlot]
@@ -21,7 +21,7 @@ struct ResolvedAuth: Sendable {
     init(
         model: Model,
         modelLabel: String,
-        authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+        authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
         providerSlots: [ProviderSlot] = [],
         authResolvers: SessionAuthResolvers? = nil
     ) {
@@ -93,7 +93,7 @@ func resolveAgentAuth(
     modelOverride: String? = nil,
     context1m: Bool = false
 ) async throws -> ResolvedAuth {
-    let store = OAuthStore(url: OAuthStore.defaultURL())
+    let store = try OAuthStore(url: OAuthStore.defaultURL())
     let all = await store.all()
 
     if !all.isEmpty {
@@ -190,8 +190,14 @@ private func registerAllStored(
             continue
         }
         let mo = storeId == activeStoreId ? activeModelId : nil
+        // Only the active provider primes its OAuth token at startup — the
+        // others register their scoped provider + resolver + slot and refresh
+        // lazily on first use (a `/model` switch). Priming every stored login
+        // fired an OAuth refresh/exchange network round-trip per account on
+        // every launch, for accounts the session may never touch.
         guard let resolved = try await registerStored(
-            storeId: storeId, store: store, modelOverride: mo, context1m: context1m
+            storeId: storeId, store: store, modelOverride: mo, context1m: context1m,
+            primeToken: storeId == activeStoreId
         ) else { continue }
         seenScopes.insert(scope)
         if let r = resolved.authResolver {
@@ -229,15 +235,20 @@ func registerStored(
     storeId: String,
     store: OAuthStore,
     modelOverride: String?,
-    context1m: Bool
+    context1m: Bool,
+    // When false, skip the eager OAuth token refresh/exchange network call at
+    // registration and read any needed endpoint/account claims from the stored
+    // credentials instead. The provider's resolver still refreshes on demand at
+    // first request. Passed false for non-active providers at startup.
+    primeToken: Bool = true
 ) async throws -> ResolvedAuth? {
     guard let creds = await store.get(storeId) else { return nil }
     switch storeId {
     case "openai-codex":
-        return await registerCodex(store: store, creds: creds, modelOverride: modelOverride)
+        return await registerCodex(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "anthropic":
         return await registerAnthropicOAuth(
-            store: store, creds: creds, modelOverride: modelOverride, context1m: context1m
+            store: store, creds: creds, modelOverride: modelOverride, context1m: context1m, primeToken: primeToken
         )
     case "anthropic-api-key":
         return await registerAnthropicAPIKey(creds: creds, modelOverride: modelOverride)
@@ -250,7 +261,7 @@ func registerStored(
     case "openrouter":
         return await registerOpenRouter(creds: creds, modelOverride: modelOverride)
     case "github-copilot":
-        return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride)
+        return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     default:
         FileHandle.standardError.write(Data(
             "kwwk: stored credentials for '\(storeId)' aren't wired up; skipping.\n".utf8
@@ -270,9 +281,14 @@ func registerStoredProviderLive(
     context1m: Bool = false,
     store: OAuthStore? = nil
 ) async -> ProviderSlot? {
-    let store = store ?? OAuthStore(url: OAuthStore.defaultURL())
+    let resolvedStore: OAuthStore
+    if let store { resolvedStore = store }
+    else {
+        guard let opened = try? OAuthStore(url: OAuthStore.defaultURL()) else { return nil }
+        resolvedStore = opened
+    }
     guard let resolved = try? await registerStored(
-        storeId: storeId, store: store, modelOverride: nil, context1m: context1m
+        storeId: storeId, store: resolvedStore, modelOverride: nil, context1m: context1m
     ) else { return nil }
     // Keep the scope's provider instance and its resolver consistent: an
     // OAuth provider installs a resolver; a static api-key provider has none
@@ -365,7 +381,7 @@ private func registerAzureEnv(_ azure: EnvAPIKeys.Azure, modelOverride: String?)
     let model = Model(
         id: modelId, name: catalog?.name ?? modelId,
         api: "azure-openai-responses", provider: "azure-openai-responses",
-        baseUrl: azure.baseURL, reasoning: catalog?.reasoning ?? true,
+        baseURL: azure.baseURL, reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text, .image],
         contextWindow: catalog?.contextWindow ?? 200_000, maxTokens: catalog?.maxTokens ?? 128_000
     )
@@ -398,13 +414,13 @@ private func registerCloudflareEnv(_ cf: EnvAPIKeys.Cloudflare, gateway: Bool, m
     //
     // Workers AI catalog entries are themselves openai-completions models, so we
     // borrow their metadata. AI Gateway catalog entries describe the *native*
-    // (e.g. anthropic) wire whose baseUrl doesn't match the openai-compat gateway
+    // (e.g. anthropic) wire whose baseURL doesn't match the openai-compat gateway
     // endpoint, so we ignore the catalog there and use the compat fallback base.
     let catalog = gateway ? nil : ModelsCatalog.model(provider: providerId, id: modelId)
     let model = Model(
         id: modelId, name: catalog?.name ?? modelId,
         api: providerId, provider: providerId,
-        baseUrl: catalog?.baseUrl ?? fallbackBase, reasoning: catalog?.reasoning ?? false,
+        baseURL: catalog?.baseURL ?? fallbackBase, reasoning: catalog?.reasoning ?? false,
         input: catalog?.input ?? [.text],
         contextWindow: catalog?.contextWindow ?? 128_000, maxTokens: catalog?.maxTokens ?? 16_384,
         compat: catalog?.compat, thinkingLevelMap: catalog?.thinkingLevelMap
@@ -413,11 +429,11 @@ private func registerCloudflareEnv(_ cf: EnvAPIKeys.Cloudflare, gateway: Bool, m
     return ResolvedAuth(model: model, modelLabel: "\(modelId) · \(label) (env)", authResolver: nil)
 }
 
-/// Derive the AWS region for a Bedrock model from its catalog baseUrl host
+/// Derive the AWS region for a Bedrock model from its catalog baseURL host
 /// (`bedrock-runtime.<region>.amazonaws.com`), falling back to AWS_REGION /
 /// us-east-1. Keeps EU/APAC-hosted models from being misrouted to us-east-1.
 private func bedrockRegion(for model: Model, environment: [String: String]) -> String {
-    if let host = URL(string: model.baseUrl)?.host {
+    if let host = URL(string: model.baseURL)?.host {
         let parts = host.split(separator: ".")
         if parts.count >= 3, parts[0] == "bedrock-runtime" {
             return String(parts[1])
@@ -438,11 +454,11 @@ private func pickEnvModel(provider: String, id: String?) -> Model? {
     let models = ModelsCatalog.models(for: provider)
     if let id, !id.isEmpty {
         // Honor an override id even if it isn't catalogued, inheriting the
-        // provider's wire api/baseUrl from any sibling model.
+        // provider's wire api/baseURL from any sibling model.
         if let sibling = models.first {
             return Model(
                 id: id, name: id, api: sibling.api, provider: provider,
-                baseUrl: sibling.baseUrl, reasoning: sibling.reasoning,
+                baseURL: sibling.baseURL, reasoning: sibling.reasoning,
                 input: sibling.input, cost: sibling.cost,
                 contextWindow: sibling.contextWindow, maxTokens: sibling.maxTokens,
                 headers: sibling.headers, compat: sibling.compat
@@ -472,27 +488,29 @@ private func registerEnvProviders(for provider: String, apiKey: String) async ->
 }
 
 private func registerEnvProvider(api: String, provider: String, apiKey: String) async -> Bool {
+    // Tag each flat env registration with its vendor so a model whose
+    // `provider` differs can never fall back onto this vendor's key.
     switch api {
     case "openai-completions":
-        await APIRegistry.shared.register(OpenAICompletionsProvider(defaultAPIKey: apiKey))
+        await APIRegistry.shared.register(OpenAICompletionsProvider(defaultAPIKey: apiKey), providerVendor: provider)
         return true
     case "openai-responses":
-        await APIRegistry.shared.register(OpenAIResponsesProvider(defaultAPIKey: apiKey))
+        await APIRegistry.shared.register(OpenAIResponsesProvider(defaultAPIKey: apiKey), providerVendor: provider)
         return true
     case "google-generative-ai":
-        await APIRegistry.shared.register(GoogleGeminiProvider(defaultAPIKey: apiKey))
+        await APIRegistry.shared.register(GoogleGeminiProvider(defaultAPIKey: apiKey), providerVendor: provider)
         return true
     case "mistral-conversations":
-        await APIRegistry.shared.register(MistralConversationsProvider(defaultAPIKey: apiKey))
+        await APIRegistry.shared.register(MistralConversationsProvider(defaultAPIKey: apiKey), providerVendor: provider)
         return true
     case "anthropic-messages":
         if provider == "anthropic" {
-            await APIRegistry.shared.register(AnthropicProvider(defaultAPIKey: apiKey))
+            await APIRegistry.shared.register(AnthropicProvider(defaultAPIKey: apiKey), providerVendor: provider)
         } else {
             await APIRegistry.shared.register(AnthropicProvider(
                 defaultAPIKey: apiKey,
                 authHeaderBuilder: { key in ["Authorization": cliBearerHeaderValue(key)] }
-            ))
+            ), providerVendor: provider)
         }
         return true
     default:
@@ -505,15 +523,20 @@ private func registerEnvProvider(api: String, provider: String, apiKey: String) 
 private func registerCodex(
     store: OAuthStore,
     creds: OAuthCredentials,
-    modelOverride: String? = nil
+    modelOverride: String? = nil,
+    primeToken: Bool = true
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     // Grab a fresh token if expired. If the refresh fails we still register
     // the provider — the authResolver below will retry on the next request
-    // and surface the error to the user there.
-    _ = try? await manager.apiKey(for: "openai-codex")
+    // and surface the error to the user there. When not priming, read the
+    // stored `accountId` (persisted at login) and let the resolver refresh
+    // lazily on first use.
+    if primeToken {
+        _ = try? await manager.apiKey(for: "openai-codex")
+    }
 
-    let refreshed = await store.get("openai-codex") ?? creds
+    let refreshed = primeToken ? (await store.get("openai-codex") ?? creds) : creds
     let accountId: String? = {
         if case .string(let s) = refreshed.extras["accountId"] ?? .null { return s }
         return nil
@@ -532,7 +555,7 @@ private func registerCodex(
         name: catalogEntry?.name ?? modelId,
         api: "chatgpt-codex",
         provider: "chatgpt-codex",
-        baseUrl: "https://chatgpt.com",
+        baseURL: "https://chatgpt.com",
         reasoning: catalogEntry?.reasoning ?? true,
         input: catalogEntry?.input ?? [.text, .image],
         contextWindow: catalogEntry?.contextWindow ?? 272_000,
@@ -555,10 +578,15 @@ private func registerAnthropicOAuth(
     store: OAuthStore,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
-    context1m: Bool = false
+    context1m: Bool = false,
+    primeToken: Bool = true
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
-    _ = try? await manager.apiKey(for: "anthropic")
+    // Prime the token only for the active provider; otherwise the resolver
+    // refreshes lazily on the first request.
+    if primeToken {
+        _ = try? await manager.apiKey(for: "anthropic")
+    }
 
     // Opt into the 1M-context beta when requested. Sent alongside the OAuth
     // beta as a single comma-separated `anthropic-beta` header value, which
@@ -582,7 +610,7 @@ private func registerAnthropicOAuth(
         name: catalog?.name ?? modelId,
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text, .image],
         contextWindow: context1m ? 1_000_000 : (catalog?.contextWindow ?? defaultContext),
@@ -602,7 +630,8 @@ private func registerAnthropicOAuth(
 private func registerGitHubCopilot(
     store: OAuthStore,
     creds: OAuthCredentials,
-    modelOverride: String? = nil
+    modelOverride: String? = nil,
+    primeToken: Bool = true
 ) async -> ResolvedAuth {
     let manager = OAuthManager(store: store)
     // Prime the session token — Copilot's `refresh` is actually a PAT →
@@ -610,9 +639,13 @@ private func registerGitHubCopilot(
     // We ignore the returned token; the resolver below re-fetches on demand
     // (`OAuthManager` caches until `expires_at` so we don't round-trip
     // every request). The refresh also persists the proxy endpoint into
-    // `extras["endpoint"]`, which we read below.
-    _ = try? await manager.apiKey(for: "github-copilot")
-    let refreshed = await store.get("github-copilot") ?? creds
+    // `extras["endpoint"]`, which we read below. For a non-active provider we
+    // skip the eager exchange and read the endpoint the previous session's
+    // login already persisted; the resolver primes it on first use.
+    if primeToken {
+        _ = try? await manager.apiKey(for: "github-copilot")
+    }
+    let refreshed = primeToken ? (await store.get("github-copilot") ?? creds) : creds
 
     // Copilot Business / Enterprise get a proxy-endpoint claim (e.g.
     // `https://api.business.githubcopilot.com`) that the session-token
@@ -659,17 +692,17 @@ private func registerGitHubCopilot(
         name: defaultId,
         api: "openai-completions",
         provider: "github-copilot",
-        baseUrl: baseURLString,
+        baseURL: baseURLString,
         reasoning: false,
         input: [.text, .image],
         contextWindow: 200_000,
         maxTokens: 128_000
     )
     // Use catalog model for wire-format api + capabilities, but stamp
-    // the session's resolved `baseUrl` on it — catalog entries hardcode
+    // the session's resolved `baseURL` on it — catalog entries hardcode
     // `api.individual.githubcopilot.com` which would bypass the
     // Business/Enterprise proxy. `adoptFields` preserves this session
-    // baseUrl across `/model` switches, so every Copilot model routes
+    // baseURL across `/model` switches, so every Copilot model routes
     // through the right host.
     let model: Model = {
         guard let catalog = ModelsCatalog.model(provider: "github-copilot", id: defaultId)
@@ -679,7 +712,7 @@ private func registerGitHubCopilot(
             name: catalog.name,
             api: catalog.api,
             provider: catalog.provider,
-            baseUrl: baseURLString,
+            baseURL: baseURLString,
             reasoning: catalog.reasoning,
             input: catalog.input,
             cost: catalog.cost,
@@ -717,7 +750,7 @@ private func registerAnthropicAPIKey(
         name: catalog?.name ?? modelId,
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: baseURL,
+        baseURL: baseURL,
         reasoning: catalog?.reasoning ?? false,
         input: catalog?.input ?? [.text, .image],
         contextWindow: catalog?.contextWindow ?? 200_000,
@@ -746,7 +779,7 @@ private func registerOpenAIAPIKey(
         name: catalog?.name ?? modelId,
         api: "openai-responses",
         provider: "openai",
-        baseUrl: baseURL,
+        baseURL: baseURL,
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text, .image],
         contextWindow: catalog?.contextWindow ?? 200_000,
@@ -776,9 +809,9 @@ private func registerGoogleAPIKey(
         api: "google-generative-ai",
         provider: "google",
         // Host root — `GoogleGeminiProvider`'s urlBuilder appends `/v1beta`
-        // itself (and tolerates a baseUrl that already includes it, which
+        // itself (and tolerates a baseURL that already includes it, which
         // is what catalog models carry).
-        baseUrl: baseURL,
+        baseURL: baseURL,
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text, .image],
         contextWindow: catalog?.contextWindow ?? 1_048_576,
@@ -819,7 +852,7 @@ private func registerOpenRouter(
         name: catalog?.name ?? modelId,
         api: "openai-completions",
         provider: "openrouter",
-        baseUrl: catalog?.baseUrl ?? "https://openrouter.ai/api/v1",
+        baseURL: catalog?.baseURL ?? "https://openrouter.ai/api/v1",
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text],
         cost: catalog?.cost ?? ModelCost(),
@@ -856,7 +889,7 @@ private func registerOpenAICompatible(
         name: modelId,
         api: "openai-completions",
         provider: "openai-compatible",
-        baseUrl: baseURL,
+        baseURL: baseURL,
         reasoning: false,
         input: [.text],
         contextWindow: 131_072,
@@ -889,9 +922,16 @@ private func oauthResolver(
     providerId: String,
     scheme: AuthScheme,
     baseURL: String? = nil
-) -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
+) -> @Sendable (Model, String?) async throws -> ResolvedProviderAuth? {
     { _, _ in
-        guard let token = try? await manager.apiKey(for: providerId) else { return nil }
-        return ResolvedProviderAuth(token: token, scheme: scheme, baseURL: baseURL)
+        do {
+            let token = try await manager.apiKey(for: providerId)
+            return ResolvedProviderAuth(token: token, scheme: scheme, baseURL: baseURL)
+        } catch OAuthError.missing, OAuthError.unknownProvider {
+            // Not logged in for this provider ⇒ anonymous. Any other failure
+            // (refresh/exchange error) propagates so the request surfaces it
+            // instead of silently going out unauthenticated.
+            return nil
+        }
     }
 }

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -105,7 +105,7 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
 /// `/model` — opens a modal listing every model across **all** providers
 /// logged in this session (grouped by provider), and switches to the picked
 /// one. The pick is routed through the target provider's session template
-/// (`adoptFields`) so its wire api / provider scope / baseUrl / headers are
+/// (`adoptFields`) so its wire api / provider scope / baseURL / headers are
 /// correct, then stored on `agent.state.model` for the next request. The swap
 /// is session-scoped (restart = back to the launch default).
 @MainActor
@@ -237,14 +237,19 @@ private func handleLoginCommand(_ ctx: SlashContext, _ args: String) async {
                     onSubmit: { values in
                         modal.close()
                         Task { @MainActor in
-                            await completeAPIKeyLogin(
-                                values: values,
-                                storeId: storeId,
-                                extrasKeys: extrasKeys,
-                                ctx: ctx,
-                                authResolvers: authResolvers,
-                                store: OAuthStore(url: OAuthStore.defaultURL())
-                            )
+                            do {
+                                let store = try OAuthStore(url: OAuthStore.defaultURL())
+                                await completeAPIKeyLogin(
+                                    values: values,
+                                    storeId: storeId,
+                                    extrasKeys: extrasKeys,
+                                    ctx: ctx,
+                                    authResolvers: authResolvers,
+                                    store: store
+                                )
+                            } catch {
+                                ctx.notify(Style.dimmed("  /login: \(error.localizedDescription)"))
+                            }
                         }
                     },
                     onCancel: {
@@ -375,7 +380,11 @@ func activateFreshLogin(
 /// logged-out sentinel state when the last provider goes.
 @MainActor
 private func handleLogoutCommand(_ ctx: SlashContext, _ args: String) async {
-    await performLogout(ctx, args, store: OAuthStore(url: OAuthStore.defaultURL()))
+    do {
+        await performLogout(ctx, args, store: try OAuthStore(url: OAuthStore.defaultURL()))
+    } catch {
+        ctx.notify(Style.dimmed("  /logout: \(error.localizedDescription)"))
+    }
 }
 
 /// `/logout` body with the credential store injected, so tests can drive it
@@ -449,7 +458,7 @@ func performLogout(_ ctx: SlashContext, _ args: String, store: OAuthStore) async
 /// regimes:
 ///
 ///   - **Same provider** (`current.provider == picked.provider`): the
-///     catalog entry already carries the correct wire api, baseUrl, and
+///     catalog entry already carries the correct wire api, baseURL, and
 ///     headers — e.g. Copilot models vary per-model across
 ///     openai-completions / anthropic-messages / openai-responses, and
 ///     we registered all three variants at login. Just take `picked`
@@ -466,13 +475,13 @@ func performLogout(_ ctx: SlashContext, _ args: String, store: OAuthStore) async
 func adoptFields(from current: Model, into picked: Model) -> Model {
     if current.provider == picked.provider {
         // Same provider — adopt picked's identity, wire (api), and
-        // capabilities, but keep the session's `baseUrl`. The session
-        // baseUrl carries two things the catalog doesn't:
+        // capabilities, but keep the session's `baseURL`. The session
+        // baseURL carries two things the catalog doesn't:
         //   - Enterprise / Business Copilot's proxy host (refreshed
         //     from the session token's `endpoints.api` claim)
         //   - A user-supplied custom host for `openai-compatible` or
         //     `anthropic-api-key` / `openai-api-key` logins
-        // The catalog entry's `baseUrl` is the canonical upstream
+        // The catalog entry's `baseURL` is the canonical upstream
         // (`https://api.openai.com/v1`, etc.), which can round-trip
         // into double-`/v1` when our providers append their own
         // suffix. Holding the session value is both correct and
@@ -482,7 +491,7 @@ func adoptFields(from current: Model, into picked: Model) -> Model {
             name: picked.name,
             api: picked.api,
             provider: picked.provider,
-            baseUrl: current.baseUrl,
+            baseURL: current.baseURL,
             reasoning: picked.reasoning,
             input: picked.input,
             cost: picked.cost,
@@ -499,7 +508,7 @@ func adoptFields(from current: Model, into picked: Model) -> Model {
         name: picked.name,
         api: current.api,
         provider: current.provider,
-        baseUrl: current.baseUrl,
+        baseURL: current.baseURL,
         reasoning: picked.reasoning,
         input: picked.input,
         cost: picked.cost,
@@ -686,6 +695,16 @@ private func previewQueuedMessage(_ msg: Message, max: Int = 80) -> String {
 /// automatic path uses the same KWWKAgent compactor directly from `Agent`.
 @MainActor
 private func handleCompactCommand(_ ctx: SlashContext, _ args: String) async {
+    // Route the manual compact through the same busy machinery as a normal
+    // run: flip the compacting spinner on and make the Enter handler treat the
+    // round-trip as busy, so a prompt submitted mid-compact queues (steers)
+    // instead of starting a turn that the compactor would clobber when it
+    // overwrites `agent.state.messages`. The "summarizing…" notice prints
+    // BEFORE the (multi-second) round-trip, not after it.
+    ctx.setCompacting(true)
+    defer { ctx.setCompacting(false) }
+    ctx.notify(Style.dimmed("  /compact: summarizing the conversation…"))
+
     let outcome = await performCompact(
         agent: ctx.agent,
         backgroundManager: ctx.backgroundManager,
@@ -701,7 +720,6 @@ private func handleCompactCommand(_ ctx: SlashContext, _ args: String) async {
         // Show a compact record + durable boundary so the user can
         // scroll up later and see where the compact happened.
         await ctx.recordCompaction(n)
-        ctx.notify(Style.dimmed("  /compact: summarizing \(n) messages…"))
         ctx.commitScrollback { width in
             renderCompactBoundary(
                 messagesCompacted: n,

--- a/Sources/KWWKCli/CLIAmbient.swift
+++ b/Sources/KWWKCli/CLIAmbient.swift
@@ -14,7 +14,7 @@ func cliTmuxManager(environment: [String: String]) throws -> TmuxSessionManager 
     guard let tmuxPath = executableNamed("tmux", environment: environment) else {
         throw CLIAmbientError.tmuxNotFound
     }
-    return TmuxSessionManager(tmuxPath: tmuxPath)
+    return TmuxSessionManager(tmuxPath: tmuxPath, environment: environment)
 }
 
 private func executableNamed(_ name: String, environment: [String: String]) -> String? {

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -13,7 +13,7 @@ func runCodingTUIInternal(
     cwd: String,
     tools: CodingTools,
     builtinSubagents: BuiltinSubagentSelection = .all,
-    authResolver: (@Sendable (Model, String?) async -> ResolvedProviderAuth?)? = nil,
+    authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
     providerSlots: [ProviderSlot] = [],
     authResolvers: SessionAuthResolvers? = nil,
     autoCompactThreshold: Double? = 0.75,
@@ -27,26 +27,22 @@ func runCodingTUIInternal(
     // Resolve session persistence up front: a fresh id by default, or a
     // stored transcript when `--resume` / `--session` was passed.
     let sessionStore = SessionStore(directory: SessionStore.defaultDirectory())
-    // `--resume` opens an interactive picker across all projects; resolve the
-    // user's choice to a concrete session id before loading. Cancelling exits
-    // cleanly (pi parity: "No session selected", exit 0).
-    var effectiveResume = resume
-    if resume == .pickInteractive {
-        if let chosen = await SessionPicker.choose(store: sessionStore) {
-            effectiveResume = .id(chosen)
-        } else {
-            FileHandle.standardError.write(Data("No session selected\n".utf8))
-            Foundation.exit(0)
-        }
-    }
-    let resolvedResume = await sessionStore.resolveResume(effectiveResume, cwd: cwd)
+    // `--resume` opens the same polished arrow-key picker that `/resume` uses,
+    // rather than a bare numbered stdin prompt. The picker needs the TUI +
+    // ModalHost to exist, so we start in a fresh session and open the resume
+    // modal on the first frame (see `openResumePickerOnStart` below); its
+    // confirm handler hot-swaps persistence into the chosen session exactly
+    // like `/resume`. Cancelling the picker leaves the fresh session in place.
+    let openResumePickerOnStart = (resume == .pickInteractive)
+    let effectiveResume: SessionResume = openResumePickerOnStart ? .none : resume
+    let resolvedResume = try await sessionStore.resolveResume(effectiveResume, cwd: cwd)
     let sessionId = resolvedResume.sessionId
 
     let environment = ProcessInfo.processInfo.environment
     let tmuxManager = tools.contains(.tmux)
         ? try cliTmuxManager(environment: environment)
         : nil
-    let agent = await makeCodingAgent(CodingAgentConfig(
+    let agent = try await makeCodingAgent(CodingAgentConfig(
         model: model,
         cwd: cwd,
         tools: tools,
@@ -60,7 +56,7 @@ func runCodingTUIInternal(
         bashEnvironment: environment,
         bashShellPath: cliShellPath(environment: environment),
         tmuxManager: tmuxManager
-    ))
+    )).agent
 
     // Seed the transcript from disk when resuming so the model continues
     // where it left off.
@@ -367,6 +363,10 @@ func runCodingTUIInternal(
     }
 
     var isAutoCompacting = false
+    // Set for the duration of a manual `/compact` (via the SlashContext
+    // `setCompacting` hook). Mirrors `isAutoCompacting` in the Enter busy gate
+    // so a prompt typed mid-compact queues instead of racing the compactor.
+    var isManualCompacting = false
     updateFrameStatus()
 
     // Retry bookkeeping for `/retry`: remembers the last submitted prompt and
@@ -381,6 +381,31 @@ func runCodingTUIInternal(
     // `resetSessionTransientState` — a stale cursor into a drained queue must
     // not survive into a fresh or restored session.
     let dequeueCycle = DequeueCycleState()
+
+    // Background-task poll controller. The poll refreshes the "N bg running"
+    // count + abort/retry countdowns, but only needs to run while something is
+    // actually live: a turn is in flight (which may spawn tasks) or at least
+    // one background task is still running. `ensurePoll` (re)starts it on
+    // activity; the loop stops itself once idle so an idle prompt isn't
+    // re-queried and repainted 4×/second for nothing.
+    let pollHandle = PollHandle()
+    let ensurePoll: @MainActor @Sendable () -> Void = {
+        guard pollHandle.task == nil else { return }
+        pollHandle.task = Task { @MainActor in
+            defer { pollHandle.task = nil }
+            while !Task.isCancelled {
+                let running = await bgManager.list(sessionId: sessionId)
+                    .filter { $0.status == .running }.count
+                runningBackgroundTasks = running
+                updateFrameStatus()
+                runner.tui.requestRender()
+                // Nothing left to animate the count → stop. A later turn or
+                // background task restarts the poll via `ensurePoll`.
+                if running == 0 && !agent.state.isStreaming { break }
+                try? await Task.sleep(nanoseconds: 250_000_000)
+            }
+        }
+    }
 
     // Keep the renderer's display mode in sync with the agent's state on
     // every event, so `/thinking show|hide` (which only mutates agent
@@ -526,6 +551,9 @@ func runCodingTUIInternal(
                 break
             default: break
             }
+            // A turn is live (and may spawn background tasks) — make sure the
+            // bg-task poll is running so the count + countdowns stay fresh.
+            if agent.state.isStreaming { ensurePoll() }
             updateFrameStatus()
             runner.tui.requestRender()
         }
@@ -663,6 +691,15 @@ func runCodingTUIInternal(
             recomputeTranscript()
             updateFrameStatus()
             runner.tui.requestRender()
+        },
+        setCompacting: { active in
+            isManualCompacting = active
+            // Show the compacting spinner (frameMode.isActive drives the
+            // dedicated spinner tick) for the whole round-trip, and clear back
+            // to idle when it finishes.
+            frameMode = active ? .compacting(messageCount: agent.state.messages.count) : .idle
+            updateFrameStatus()
+            runner.tui.requestRender()
         }
     )
 
@@ -693,7 +730,7 @@ func runCodingTUIInternal(
             guard !text.isEmpty else { return }
 
             let parsed = SlashInput.parse(text)
-            let busy = agent.state.isStreaming || isAutoCompacting
+            let busy = agent.state.isStreaming || isAutoCompacting || isManualCompacting
 
             // Logged-out gate: with no registered provider a prompt has
             // nowhere to route — surface the /login hint instead of letting
@@ -880,12 +917,52 @@ func runCodingTUIInternal(
         }
     }
 
-    // Ctrl-C: always exits (single tap). Keep it as the hard-stop key so
-    // there's always a predictable way out.
+    // Ctrl-C: pi/omp two-stage convention. The first press does the least
+    // destructive useful thing — cancel a live generation, else clear a
+    // non-empty input, else arm the exit and hint — and a second press within
+    // the window quits. This stops a single accidental Ctrl-C from tearing the
+    // app down mid-stream. (Ctrl-D on an empty input is still the one-tap exit.)
+    let ctrlC = CtrlCState()
     runner.bind(.ctrl("c")) { _ in
         Task { @MainActor in
-            await agent.abortAndKillBackgroundTasks()
-            runner.exit()
+            let now = Date()
+            let armed = ctrlC.lastPress.map { now.timeIntervalSince($0) < CtrlCState.window } ?? false
+            if armed {
+                await agent.abortAndKillBackgroundTasks()
+                runner.exit()
+                return
+            }
+            ctrlC.lastPress = now
+            if modal.isOpen {
+                modal.routeCancel()
+                return
+            }
+            if agent.state.isStreaming {
+                // Cancel the active generation, mirroring Esc's abort path. The
+                // "Ctrl-C to force quit" state line already tells the user a
+                // second press exits, so no extra scrollback notice here.
+                agent.abort()
+                frameMode = .aborting
+                agent.clearSteeringQueue()
+                if let t = retryArmTarget(
+                    summary: nil,
+                    aborted: true,
+                    trackedActive: retry.trackedActive,
+                    messages: agent.state.messages
+                ) {
+                    retry.lastText = t.text
+                    retry.lastImages = t.images
+                    retry.failed = true
+                }
+                retry.trackedActive = false
+            } else if !frame.input.value.isEmpty {
+                frame.input.value = ""
+                runner.tui.commit(["", Style.dimmed("  cleared — press Ctrl-C again to exit")])
+            } else {
+                runner.tui.commit(["", Style.dimmed("  press Ctrl-C again to exit")])
+            }
+            updateFrameStatus()
+            runner.tui.requestRender()
         }
     }
 
@@ -961,21 +1038,12 @@ func runCodingTUIInternal(
         }
     }
 
-    // Background-task poll. Refreshes the "N bg running" count + retry/abort
-    // countdowns at a relaxed 250ms cadence. The spinner is NOT advanced here
-    // anymore — it has its own faster tick below — so a slow bg poll can't make
-    // the animation visibly step.
-    let frameStatusTask = Task { @MainActor in
-        try? await Task.sleep(nanoseconds: 250_000_000)
-        while !Task.isCancelled {
-            let running = await bgManager.list(sessionId: sessionId)
-                .filter { $0.status == .running }.count
-            runningBackgroundTasks = running
-            updateFrameStatus()
-            runner.tui.requestRender()
-            try? await Task.sleep(nanoseconds: 250_000_000)
-        }
-    }
+    // The background-task poll (see `ensurePoll` above) refreshes the
+    // "N bg running" count + retry/abort countdowns at a relaxed 250ms cadence,
+    // but only while a turn or a background task is live — it is started on
+    // demand rather than spinning forever. The spinner is NOT advanced there —
+    // it has its own faster tick below — so a slow bg poll can't make the
+    // animation visibly step.
 
     // Dedicated spinner tick, decoupled from the bg poll. ~90ms gives the
     // 10-frame braille set a smooth, continuous spin. We only advance + repaint
@@ -1000,17 +1068,32 @@ func runCodingTUIInternal(
         await tmuxManager?.teardown()
     }
 
+    // `--resume`: open the arrow-key session picker on the first frame, reusing
+    // the exact `/resume` modal + confirm/hot-swap. Opening it before `run()`
+    // is safe — `modal.open` just stages the overlay; the first render (once
+    // the runner starts) paints it, and the ModalInputRouter already routes
+    // keys to it. Cancel leaves the fresh session in place.
+    if openResumePickerOnStart, let resumeCmd = slashRegistry.find("resume") {
+        await resumeCmd.handler(slashContext, "")
+    }
+
     do {
         try await runner.run()
     } catch {
-        frameStatusTask.cancel()
+        pollHandle.task?.cancel()
         spinnerTask.cancel()
         await shutdown()
         throw error
     }
-    frameStatusTask.cancel()
+    pollHandle.task?.cancel()
     spinnerTask.cancel()
     await shutdown()
+    // A signal-driven teardown (SIGINT/SIGTERM) records a non-zero exit code.
+    // `runner.run()` no longer calls `Foundation.exit` itself, so the graceful
+    // shutdown above always runs first; propagate the code now.
+    if runner.exitCode != 0 {
+        Foundation.exit(runner.exitCode)
+    }
 }
 
 // MARK: - Helpers
@@ -1035,6 +1118,23 @@ final class WelcomeHeaderState: @unchecked Sendable {
     func snapshot() -> WelcomeContext {
         lock.withLock { context }
     }
+}
+
+/// Tracks the last Ctrl-C press so a second press within `window` exits while
+/// a lone press cancels/clears (pi's two-stage Ctrl-C). Reference type so the
+/// @MainActor keybinding closure can mutate it under Swift 6 concurrency.
+@MainActor
+final class CtrlCState {
+    static let window: TimeInterval = 1.5
+    var lastPress: Date?
+}
+
+/// Holds the on-demand background-task poll task so the @MainActor closures
+/// that start and cancel it can share one mutable handle (a captured `var` is
+/// rejected under Swift 6 strict concurrency).
+@MainActor
+final class PollHandle {
+    var task: Task<Void, Never>?
 }
 
 /// Whether the goal-continuation loop's logged-out "/login" hint has already
@@ -1355,7 +1455,7 @@ private func codingFrameStateLine(
 
     switch mode {
     case .compacting(let count):
-        parts.append(Theme.paint("\(spinner) auto-compacting \(count)", Theme.warn, bold: true))
+        parts.append(Theme.paint("\(spinner) compacting \(count)", Theme.warn, bold: true))
         parts.append(Theme.faintText("new prompts queue"))
     case .aborting:
         parts.append(Theme.paint("\(spinner) aborting", Theme.warn, bold: true))
@@ -1412,14 +1512,19 @@ func handlePastedBody(
     tui: TUI,
     inlineLimit: Int = 80
 ) {
-    // Clipboard-image takes precedence: on macOS the user can ⌘V a
-    // screenshot whose bytes never reach stdin — the terminal sends
-    // an empty/degenerate paste body while NSPasteboard holds the
-    // real image. Peek the pasteboard before interpreting the body.
-    if let image = ClipboardImageReader.readIfPresent() {
-        let token = attachments.addClipboardImage(data: image.data, mimeType: image.mimeType)
-        input.insert("\(token) ")
-        tui.requestRender()
+    // Pasted TEXT always wins. Only when the bracketed-paste body carries no
+    // text do we fall back to the clipboard image: on macOS a ⌘V of a
+    // screenshot delivers an empty/whitespace paste body while NSPasteboard
+    // holds the real image. Peeking the pasteboard first (the old behavior)
+    // discarded genuinely pasted text whenever a stale image lingered on the
+    // clipboard.
+    if body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let image = ClipboardImageReader.readIfPresent() {
+            let token = attachments.addClipboardImage(data: image.data, mimeType: image.mimeType)
+            input.insert("\(token) ")
+            tui.requestRender()
+        }
+        // Empty paste with no clipboard image: nothing to insert.
         return
     }
 

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -42,14 +42,14 @@ func runHeadlessInternal(
     // Resolve session persistence: a fresh id by default, or a stored
     // transcript when `--resume` / `--session` was passed.
     let store = SessionStore(directory: SessionStore.defaultDirectory())
-    let resolvedResume = await store.resolveResume(resume, cwd: cwd)
+    let resolvedResume = try await store.resolveResume(resume, cwd: cwd)
     let sessionId = resolvedResume.sessionId
 
     let environment = ProcessInfo.processInfo.environment
     let tmuxManager = tools.contains(.tmux)
         ? try cliTmuxManager(environment: environment)
         : nil
-    let agent = await makeCodingAgent(CodingAgentConfig(
+    let agent = try await makeCodingAgent(CodingAgentConfig(
         model: resolved.model,
         cwd: cwd,
         tools: tools,
@@ -63,7 +63,7 @@ func runHeadlessInternal(
         bashEnvironment: environment,
         bashShellPath: cliShellPath(environment: environment),
         tmuxManager: tmuxManager
-    ))
+    )).agent
     agent.state.thinkingLevel = thinkingLevel
 
     // Seed the transcript from disk when resuming so the model continues

--- a/Sources/KWWKCli/InputComponent.swift
+++ b/Sources/KWWKCli/InputComponent.swift
@@ -517,39 +517,40 @@ final class InputComponent: Component, Focusable, @unchecked Sendable {
         return out
     }
 
-    /// Visible column width of a single `Character` — sums the per-scalar
-    /// widths (a precomposed `Character` like "é" normally has width 1;
-    /// CJK ideographs width 2).
+    /// Visible column width of a single `Character` (grapheme cluster). Uses
+    /// the shared grapheme-aware width so modern emoji stay 2 columns: a ZWJ
+    /// family/profession sequence collapses to one glyph, skin-tone modifiers
+    /// and variation selectors add nothing, and a regional-indicator pair is a
+    /// single 2-column flag — matching how the terminal advances its cursor.
+    ///
+    /// A grapheme whose scalars are *all* zero-width (a lone combining mark or
+    /// ZWSP — reachable when a bracketed paste is inserted verbatim) genuinely
+    /// occupies no columns. `insertCursorMarker` accounts it as 0 too, so we
+    /// must NOT floor it to 1: flooring would advance the layout column past
+    /// where the marker pass lands, dropping the cursor one column too far
+    /// right. Normal text (width ≥ 1) is unaffected.
     private func charColumnWidth(_ ch: Character) -> Int {
-        var w = 0
-        for scalar in ch.unicodeScalars {
-            w += ANSI.columnWidth(of: scalar.value)
-        }
-        // A grapheme whose scalars are *all* zero-width (a lone combining mark
-        // or ZWSP — reachable when a bracketed paste is inserted verbatim)
-        // genuinely occupies no columns. `insertCursorMarker` accounts it as 0
-        // too, so we must NOT floor it to 1 here: flooring would advance the
-        // layout column past where the marker pass lands, dropping the cursor
-        // one column too far right. Normal text (width ≥ 1) is unaffected.
-        return w
+        ANSI.graphemeWidth(ch)
     }
 
-    /// Insert a zero-width cursor marker into `line` at the given
-    /// visible column (counting scalar widths ANSI-style). If the
-    /// column is at or past the visible end, the marker goes at the
-    /// end — the TUI's cursor positioner handles "just past last col"
-    /// naturally.
+    /// Insert a zero-width cursor marker into `line` at the given visible
+    /// column. Walks grapheme clusters with the same width accounting as
+    /// `layoutRows` (`charColumnWidth`), so a ZWJ emoji or flag is treated as
+    /// one 2-column glyph and the marker lands on the same column the layout
+    /// pass computed. If the column is at or past the visible end, the marker
+    /// goes at the end — the TUI's cursor positioner handles "just past last
+    /// col" naturally.
     private func insertCursorMarker(in line: String, atCol col: Int) -> String {
         var out = ""
         var visible = 0
         var inserted = false
-        for scalar in line.unicodeScalars {
+        for ch in line {
             if !inserted && visible >= col {
                 out += CURSOR_MARKER
                 inserted = true
             }
-            out.unicodeScalars.append(scalar)
-            visible += ANSI.columnWidth(of: scalar.value)
+            out.append(ch)
+            visible += charColumnWidth(ch)
         }
         if !inserted {
             out += CURSOR_MARKER
@@ -629,9 +630,12 @@ final class InputComponent: Component, Focusable, @unchecked Sendable {
             case ("y", true, false): yank()
             case ("y", false, true): yankPop()
             // Single-level undo. Ctrl+_ is byte 0x1F (also sent by Ctrl+/ on
-            // many terminals); Ctrl+Z works where the terminal forwards it in
-            // raw mode. Both pop the last pre-edit snapshot.
+            // legacy terminals); Ctrl+Z works where the terminal forwards it in
+            // raw mode. Under the Kitty keyboard protocol Ctrl+/ arrives as a
+            // distinct "/" codepoint rather than collapsing to 0x1F, so bind it
+            // too. All pop the last pre-edit snapshot.
             case ("_", true, false): undo()
+            case ("/", true, false): undo()
             case ("z", true, false): undo()
             // Newline-insert triggers. Ctrl+J is the raw LF byte
             // (0x0A); terminals emit it even without any keyboard

--- a/Sources/KWWKCli/KWWK.swift
+++ b/Sources/KWWKCli/KWWK.swift
@@ -19,7 +19,7 @@ public enum KWWK {
     /// no restart needed.
     ///
     /// `tools` controls which coding tools the agent is given. Default is
-    /// `.all` — read/write/edit/bash/grep/find/ls/task_status/wait_task.
+    /// `.standard` — read/write/edit/bash/grep/find/ls/task_status/wait_task.
     /// Pass `.readOnly` for a sandboxed reviewer-style agent. If `tools`
     /// contains `.tmux`, this CLI wrapper resolves `tmux` from `PATH` and
     /// passes the explicit executable path into the SDK.
@@ -30,7 +30,7 @@ public enum KWWK {
     /// `contextWindow`. Pass `nil` to disable.
     public static func runCodingTUI(
         cwd: String? = nil,
-        tools: CodingTools = .all,
+        tools: CodingTools = .standard,
         builtinSubagents: BuiltinSubagentSelection = .all,
         autoCompactThreshold: Double? = 0.75,
         thinkingLevel: ThinkingLevel = .medium,
@@ -95,7 +95,7 @@ public enum KWWK {
     public static func runHeadless(
         prompt: String,
         cwd: String? = nil,
-        tools: CodingTools = .all,
+        tools: CodingTools = .standard,
         builtinSubagents: BuiltinSubagentSelection = .all,
         thinkingLevel: ThinkingLevel = .medium,
         modelOverride: String? = nil,

--- a/Sources/KWWKCli/Keys.swift
+++ b/Sources/KWWKCli/Keys.swift
@@ -165,10 +165,16 @@ enum Keys {
         case 27: return "escape"
         case 32: return "space"
         case 127: return "backspace"
-        case 97...122:
-            return String(UnicodeScalar(code)!)
         case 65...90:
+            // Letters lower-case to a canonical name; the shift/ctrl flags
+            // carry the actual modifiers (see parseCSI).
             return String(UnicodeScalar(code)!).lowercased()
+        // Any other printable ASCII (digits + punctuation) decodes to its
+        // literal character. Whitelisting only letters dropped modified
+        // punctuation like Ctrl+_ / Ctrl+/ (undo) on kitty-protocol
+        // terminals kwwk opts into — decode from the codepoint instead.
+        case 0x21...0x7E:
+            return String(UnicodeScalar(code)!)
         default:
             return nil
         }

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -181,6 +181,47 @@ func loginFormTitle(for entry: LoginEntry) -> String {
     "Log in — " + (providerDescriptor(forStoreId: entry.id)?.formTitle ?? entry.id)
 }
 
+// MARK: - Terminal login callbacks
+
+/// The CLI's interactive implementation of `OAuthLogin.Callbacks`: progress
+/// to stderr, auth URL printed and handed to the system browser. The SDK no
+/// longer bakes these in (it must not print or spawn a browser on its own),
+/// so the terminal behavior lives here.
+func terminalLoginCallbacks() -> OAuthLogin.Callbacks {
+    OAuthLogin.Callbacks(
+        onAuthURL: { url in
+            FileHandle.standardError.write(Data("open in your browser:\n  \(url.absoluteString)\n".utf8))
+            Browser.open(url)
+        },
+        onProgress: { msg in
+            FileHandle.standardError.write(Data("\(msg)\n".utf8))
+        }
+    )
+}
+
+/// Best-effort URL opener. macOS uses `/usr/bin/open`; Linux tries
+/// `xdg-open`, else falls back to stderr so the user can click manually.
+enum Browser {
+    static func open(_ url: URL) {
+        #if os(macOS)
+        let opener = "/usr/bin/open"
+        #else
+        let opener = "/usr/bin/xdg-open"
+        #endif
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: opener)
+        process.arguments = [url.absoluteString]
+        do {
+            try process.run()
+        } catch {
+            FileHandle.standardError.write(Data(
+                "please open manually:\n  \(url.absoluteString)\n".utf8
+            ))
+        }
+    }
+}
+
 // MARK: - OAuth flow (TUI suspended)
 
 /// Browser-based OAuth login for `providerId`. Runs with the coding TUI
@@ -192,14 +233,15 @@ func runOAuthFlow(providerId: String) async throws {
     // Clear a line so the OAuth progress logs start fresh below the TUI.
     FileHandle.standardError.write(Data("starting \(providerId) login…  (Esc/Ctrl-C to cancel)\n".utf8))
 
+    let callbacks = terminalLoginCallbacks()
     let flow = Task {
         switch providerId {
         case "anthropic":
-            return try await OAuthLogin.loginAnthropic()
+            return try await OAuthLogin.loginAnthropic(callbacks: callbacks)
         case "openai-codex":
-            return try await OAuthLogin.loginOpenAICodex()
+            return try await OAuthLogin.loginOpenAICodex(callbacks: callbacks)
         case "github-copilot":
-            return try await OAuthLogin.loginGitHubCopilot()
+            return try await OAuthLogin.loginGitHubCopilot(callbacks: callbacks)
         default:
             throw LoginError.unknownProvider(providerId)
         }
@@ -250,7 +292,13 @@ func runOAuthFlow(providerId: String) async throws {
 /// `GitHubCopilotOAuthProvider.refresh`); we prefer that over the
 /// Individual default so policy POSTs hit the correct tier.
 private func runCopilotPolicyEnable() async {
-    let store = OAuthStore(url: OAuthStore.defaultURL())
+    let store: OAuthStore
+    do {
+        store = try OAuthStore(url: OAuthStore.defaultURL())
+    } catch {
+        print(Style.dimmed("  (skipped model policy enable: \(error.localizedDescription))"))
+        return
+    }
     let manager = OAuthManager(store: store)
     let sessionToken: String
     do {
@@ -336,7 +384,7 @@ private func persistCredentials(
     let saved = try await saveCredentials(
         credentials,
         providerId: providerId,
-        store: OAuthStore(url: OAuthStore.defaultURL())
+        store: try OAuthStore(url: OAuthStore.defaultURL())
     )
     print("")
     print(Style.prompt("✓ saved \(providerId) credentials"))

--- a/Sources/KWWKCli/SessionProviders.swift
+++ b/Sources/KWWKCli/SessionProviders.swift
@@ -2,7 +2,7 @@ import Foundation
 import KWWKAI
 
 /// One logged-in provider's session-scoped routing template. `/model` uses
-/// `template` to stamp correct wire routing (api / provider scope / baseUrl /
+/// `template` to stamp correct wire routing (api / provider scope / baseURL /
 /// headers) onto any catalog model the user switches to, and lists that
 /// provider's catalog under `catalogProvider` / `displayName`.
 struct ProviderSlot: Sendable {
@@ -15,7 +15,7 @@ struct ProviderSlot: Sendable {
     /// Human label shown as the group header in the `/model` picker.
     let displayName: String
     /// The default model built at registration time — carries the resolved
-    /// wire `api`, provider scope, session `baseUrl`, and headers that every
+    /// wire `api`, provider scope, session `baseURL`, and headers that every
     /// model under this provider must route through.
     let template: Model
 }
@@ -61,13 +61,13 @@ final class SessionProviders {
 /// on the next request — no agent rebuild. Static api-key providers have no
 /// entry; `resolve` returns nil and the provider falls back to its baked key.
 actor SessionAuthResolvers {
-    private var map: [String: @Sendable (Model, String?) async -> ResolvedProviderAuth?]
+    private var map: [String: @Sendable (Model, String?) async throws -> ResolvedProviderAuth?]
 
-    init(_ initial: [String: @Sendable (Model, String?) async -> ResolvedProviderAuth?] = [:]) {
+    init(_ initial: [String: @Sendable (Model, String?) async throws -> ResolvedProviderAuth?] = [:]) {
         self.map = initial
     }
 
-    func set(scope: String, _ resolver: @escaping @Sendable (Model, String?) async -> ResolvedProviderAuth?) {
+    func set(scope: String, _ resolver: @escaping @Sendable (Model, String?) async throws -> ResolvedProviderAuth?) {
         map[scope] = resolver
     }
 
@@ -75,15 +75,15 @@ actor SessionAuthResolvers {
         map.removeValue(forKey: scope)
     }
 
-    func resolve(_ model: Model, _ sessionId: String?) async -> ResolvedProviderAuth? {
+    func resolve(_ model: Model, _ sessionId: String?) async throws -> ResolvedProviderAuth? {
         guard let r = map[model.provider] else { return nil }
-        return await r(model, sessionId)
+        return try await r(model, sessionId)
     }
 
     /// One stable delegating closure to hand the agent. It closes over this
     /// actor, so later `set` / `remove` calls are visible without swapping the
     /// agent's `authResolver`.
-    nonisolated func delegatingResolver() -> @Sendable (Model, String?) async -> ResolvedProviderAuth? {
-        { model, sid in await self.resolve(model, sid) }
+    nonisolated func delegatingResolver() -> @Sendable (Model, String?) async throws -> ResolvedProviderAuth? {
+        { model, sid in try await self.resolve(model, sid) }
     }
 }

--- a/Sources/KWWKCli/SessionSlashCommands.swift
+++ b/Sources/KWWKCli/SessionSlashCommands.swift
@@ -78,7 +78,11 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
                 currentSessionId: recorderBox.sessionId,
                 onSelect: { info in
                     Task { @MainActor in
-                        let loaded = await sessionStore.resolveResume(.id(info.id), cwd: cwd)
+                        // `info.id` comes from the on-disk listing, so its
+                        // format is always valid; `try?` only guards the
+                        // (unreachable here) invalid-id throw.
+                        guard let loaded = try? await sessionStore.resolveResume(
+                            .id(info.id), cwd: cwd) else { return }
 
                         // Repoint persistence at the restored session.
                         recorderBox.unsubscribe()

--- a/Sources/KWWKCli/SlashCommand.swift
+++ b/Sources/KWWKCli/SlashCommand.swift
@@ -87,6 +87,12 @@ final class SlashContext {
     /// like the `/login` OAuth handoff), then restore the TUI and repaint.
     /// A no-op passthrough in headless / test contexts.
     let withSuspendedTUI: @MainActor (_ body: @escaping @MainActor () async -> Void) async -> Void
+    /// Mark the TUI busy for the duration of a manual `/compact`: shows the
+    /// compacting spinner and makes the Enter handler treat the round-trip as
+    /// busy, so a prompt submitted mid-compact queues (steers) instead of
+    /// starting a turn that the compactor would clobber when it overwrites
+    /// `agent.state.messages`. A no-op in headless / test contexts.
+    let setCompacting: @MainActor (_ active: Bool) -> Void
 
     init(
         agent: Agent,
@@ -101,7 +107,8 @@ final class SlashContext {
         sessionProviders: SessionProviders = SessionProviders(),
         authResolvers: SessionAuthResolvers? = nil,
         context1m: Bool = false,
-        withSuspendedTUI: @MainActor @escaping (_ body: @escaping @MainActor () async -> Void) async -> Void = { body in await body() }
+        withSuspendedTUI: @MainActor @escaping (_ body: @escaping @MainActor () async -> Void) async -> Void = { body in await body() },
+        setCompacting: @MainActor @escaping (_ active: Bool) -> Void = { _ in }
     ) {
         self.agent = agent
         self.modal = modal
@@ -116,6 +123,7 @@ final class SlashContext {
         self.authResolvers = authResolvers
         self.context1m = context1m
         self.withSuspendedTUI = withSuspendedTUI
+        self.setCompacting = setCompacting
     }
 
     /// Single-line convenience: one-off status messages (`/model switched

--- a/Sources/KWWKCli/StdinBuffer.swift
+++ b/Sources/KWWKCli/StdinBuffer.swift
@@ -6,11 +6,26 @@ import Foundation
 /// - Bracketed paste start/end sequences are emitted as single synthetic keys.
 /// - Standalone `ESC` waits briefly before flushing, in case an escape
 ///   sequence is in transit (handled by `flushOnTimeout`).
+///
+/// Consumed bytes are tracked with a read cursor (`readPos`) instead of being
+/// spliced off the front on every key, and the still-accumulating bracketed
+/// paste keeps a resumable end-scan cursor. Both keep large pastes linear:
+/// naïvely re-`removeFirst`-ing per key and rescanning the whole buffer for the
+/// paste terminator on every 64 KB chunk was O(n²) and froze the TUI.
 final class StdinBuffer: @unchecked Sendable {
     init() {}
 
     private let lock = NSLock()
     private var buffer: [UInt8] = []
+    /// Start of the unconsumed region. Advanced as sequences are emitted; the
+    /// consumed prefix is dropped by `compact()` once nothing is mid-flight.
+    private var readPos: Int = 0
+    /// While a bracketed-paste body is still arriving across `feed()` chunks,
+    /// the absolute buffer index from which the next end-terminator scan should
+    /// resume. `nil` when no paste is mid-flight. Persisting it stops each new
+    /// chunk from rescanning the whole (possibly multi-MB) accumulated paste
+    /// from the start.
+    private var pasteEndSearchFrom: Int?
 
     func feed(_ chunk: Data) -> [String] {
         var out: [String] = []
@@ -19,8 +34,9 @@ final class StdinBuffer: @unchecked Sendable {
             while let (consumed, sequence) = takeOne() {
                 if let sequence { out.append(sequence) }
                 if consumed == 0 { break }
-                buffer.removeFirst(consumed)
+                readPos += consumed
             }
+            compact()
         }
         return out
     }
@@ -33,57 +49,78 @@ final class StdinBuffer: @unchecked Sendable {
     /// Force-flush a lingering `ESC` that arrived without further bytes.
     func flushOnTimeout() -> [String] {
         lock.withLock {
-            guard let first = buffer.first, first == 0x1B else { return [] }
+            let avail = buffer.count - readPos
+            guard avail > 0, buffer[readPos] == 0x1B else { return [] }
             // A genuine double-Escape that never grew into a meta-CSI: flush
             // BOTH escapes so neither is swallowed nor stranded. If only one
             // were drained, the second 0x1B would linger with no pending timer
             // and later merge with an incoming arrow into a bogus meta-CSI.
             // A real meta-arrow would have completed via feed() by the time
             // this timeout fires.
-            if buffer.count == 2 && buffer[1] == 0x1B {
-                buffer.removeFirst(2)
+            if avail == 2 && buffer[readPos + 1] == 0x1B {
+                readPos += 2
+                compact()
                 return ["\u{1B}", "\u{1B}"]
             }
             // A lone ESC: flush it so the key isn't swallowed.
-            if buffer.count == 1 {
-                buffer.removeFirst()
+            if avail == 1 {
+                readPos += 1
+                compact()
                 return ["\u{1B}"]
             }
             return []
         }
     }
 
+    /// Drop the consumed prefix so the backing array can't grow without bound.
+    /// Rebases the paste-scan cursor (an absolute index) onto the shifted
+    /// buffer. Only shifts bytes when something was consumed; a mid-flight
+    /// paste consumes nothing, so this is a no-op until the paste lands.
+    private func compact() {
+        guard readPos > 0 else { return }
+        if readPos >= buffer.count {
+            buffer.removeAll(keepingCapacity: true)
+        } else {
+            buffer.removeFirst(readPos)
+        }
+        if let f = pasteEndSearchFrom { pasteEndSearchFrom = max(0, f - readPos) }
+        readPos = 0
+    }
+
     private func takeOne() -> (Int, String?)? {
-        guard !buffer.isEmpty else { return nil }
-        let first = buffer[0]
+        let p = readPos
+        let n = buffer.count
+        let avail = n - p
+        guard avail > 0 else { return nil }
+        let first = buffer[p]
 
         // Bracketed paste start: ESC [ 200 ~
-        if startsWith([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]) {
+        if matchesAt(p, [0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]) {
             if let endIdx = findBracketedPasteEnd() {
-                let bytes = Array(buffer[..<endIdx])
-                let consumed = endIdx
-                return (consumed, String(data: Data(bytes), encoding: .utf8))
+                let bytes = Array(buffer[p..<endIdx])
+                pasteEndSearchFrom = nil
+                return (endIdx - p, String(data: Data(bytes), encoding: .utf8))
             }
             return nil
         }
 
         // ESC sequences.
         if first == 0x1B {
-            if buffer.count == 1 { return nil } // wait for more
-            let second = buffer[1]
+            if avail == 1 { return nil } // wait for more
+            let second = buffer[p + 1]
             // Meta-prefixed CSI/SS3: `ESC ESC [ … ` or `ESC ESC O X`. macOS
             // terminals using "Option as Meta" encode Option+Arrow this way
             // (a leading ESC modifier in front of the normal arrow sequence).
             // Assemble the whole inner sequence so Keys.parse can mark it alt.
             if second == 0x1B {
-                if buffer.count < 3 { return nil } // wait — meta-CSI in transit
-                if buffer[2] == 0x5B || buffer[2] == 0x4F {
-                    var i = 3
-                    while i < buffer.count {
+                if avail < 3 { return nil } // wait — meta-CSI in transit
+                if buffer[p + 2] == 0x5B || buffer[p + 2] == 0x4F {
+                    var i = p + 3
+                    while i < n {
                         let b = buffer[i]
                         if b >= 0x40 && b <= 0x7E {
-                            let bytes = Array(buffer[..<(i + 1)])
-                            return (i + 1, String(data: Data(bytes), encoding: .utf8))
+                            let bytes = Array(buffer[p..<(i + 1)])
+                            return (i + 1 - p, String(data: Data(bytes), encoding: .utf8))
                         }
                         i += 1
                     }
@@ -95,43 +132,51 @@ final class StdinBuffer: @unchecked Sendable {
             }
             if second == 0x5B || second == 0x4F {
                 // CSI or SS3 — wait for a final byte (0x40...0x7E).
-                var i = 2
-                while i < buffer.count {
+                var i = p + 2
+                while i < n {
                     let b = buffer[i]
                     if (b >= 0x40 && b <= 0x7E) {
-                        let bytes = Array(buffer[..<(i + 1)])
-                        return (i + 1, String(data: Data(bytes), encoding: .utf8))
+                        let bytes = Array(buffer[p..<(i + 1)])
+                        return (i + 1 - p, String(data: Data(bytes), encoding: .utf8))
                     }
                     i += 1
                 }
                 return nil
             }
             // ESC + single byte (alt-prefixed)
-            let bytes = Array(buffer[..<2])
+            let bytes = Array(buffer[p..<(p + 2)])
             return (2, String(data: Data(bytes), encoding: .utf8))
         }
 
         // UTF-8 continuation
         let len = utf8Length(leadByte: first)
-        if buffer.count < len { return nil }
-        let bytes = Array(buffer[..<len])
+        if avail < len { return nil }
+        let bytes = Array(buffer[p..<(p + len)])
         return (len, String(data: Data(bytes), encoding: .utf8))
     }
 
-    private func startsWith(_ prefix: [UInt8]) -> Bool {
-        guard buffer.count >= prefix.count else { return false }
-        for i in 0..<prefix.count where buffer[i] != prefix[i] { return false }
+    /// True when `pattern` matches the bytes at absolute index `index`.
+    /// Compares in place — no per-position `Array` slice allocation.
+    private func matchesAt(_ index: Int, _ pattern: [UInt8]) -> Bool {
+        guard index >= 0, index + pattern.count <= buffer.count else { return false }
+        for k in 0..<pattern.count where buffer[index + k] != pattern[k] { return false }
         return true
     }
 
     private func findBracketedPasteEnd() -> Int? {
         let end: [UInt8] = [0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E]
-        if buffer.count < end.count { return nil }
-        for i in 0...(buffer.count - end.count) {
-            if Array(buffer[i..<(i + end.count)]) == end {
-                return i + end.count
-            }
+        // Body starts right after the 6-byte start marker at `readPos`.
+        let dataStart = readPos + 6
+        // Resume where the last scan stopped, backing up by `end.count - 1` so
+        // a terminator split across the previous chunk boundary is still found.
+        var i = max(dataStart, (pasteEndSearchFrom ?? dataStart) - (end.count - 1))
+        let last = buffer.count - end.count
+        while i <= last {
+            if matchesAt(i, end) { return i + end.count }
+            i += 1
         }
+        // Not found yet — record the resume point for the next chunk.
+        pasteEndSearchFrom = max(dataStart, buffer.count - (end.count - 1))
         return nil
     }
 

--- a/Sources/KWWKCli/TUI.swift
+++ b/Sources/KWWKCli/TUI.swift
@@ -34,6 +34,14 @@ final class TUI: @unchecked Sendable {
     private var clearOnShrink: Bool = true
     private var resizeUnsubscribe: (() -> Void)?
     private var _fullRedraws: Int = 0
+    /// Coalesces a burst of SIGWINCH events into a single authoritative
+    /// repaint. A window drag fires many resize events per second; replaying
+    /// the whole retained transcript (up to `maxCommittedLines`) on each step
+    /// is wasteful, so we debounce and repaint once the drag settles, using the
+    /// final terminal size. Cancelled + rescheduled on every resize event.
+    private var pendingResizeWork: DispatchWorkItem?
+    private var lastResizeRepaintAt = Date.distantPast
+    private static let resizeDebounceMs: Int = 60
     /// Optional decorative header (the welcome card) rendered fresh at the
     /// current width. Emitted once into scrollback on the first frame, and
     /// re-rendered at the top on every resize full-repaint so its fixed-width
@@ -89,6 +97,12 @@ final class TUI: @unchecked Sendable {
         }
         resizeUnsubscribe?()
         resizeUnsubscribe = nil
+        // Drop any debounced resize repaint so it can't fire into a
+        // torn-down / suspended terminal.
+        lock.withLock {
+            pendingResizeWork?.cancel()
+            pendingResizeWork = nil
+        }
         if wasStarted {
             let (cursorUpBy, cleared) = lock.withLock { (lastCursorUpBy, frameCleared) }
             var epilogue = TUI.enableAutowrap
@@ -201,18 +215,55 @@ final class TUI: @unchecked Sendable {
     private func handleResize() {
         let snapshotChildren: [Component] = lock.withLock { children }
         for child in snapshotChildren { child.invalidate() }
-        let inlineDirect = !TUI.resizeRepaintsInPlace()
-        if inlineDirect {
-            // Direct terminal: authoritative repaint that clears scrollback and
-            // replays the whole transcript so every line re-wraps to the new
-            // width — synchronously on every SIGWINCH, no throttle, so resize
-            // tracks the drag with zero latency. Synchronized output keeps it
-            // flicker-free even at drag rates.
-            fullRepaint()
-        } else {
+        // Leading edge + trailing coalesce: an isolated SIGWINCH repaints
+        // immediately (snappy single resizes), while a drag's burst collapses
+        // into one trailing repaint at the settled size instead of replaying
+        // the whole transcript per step. The escape-flush timer already
+        // establishes that the main queue is serviced, so a main-queue
+        // `asyncAfter` fires reliably for the trailing edge.
+        let immediate: Bool = lock.withLock {
+            guard pendingResizeWork == nil,
+                  Date().timeIntervalSince(lastResizeRepaintAt) >= Double(TUI.resizeDebounceMs) / 1000
+            else { return false }
+            lastResizeRepaintAt = Date()
+            return true
+        }
+        if immediate {
+            repaintForResize()
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in self?.performResizeRepaint() }
+        lock.withLock {
+            pendingResizeWork?.cancel()
+            pendingResizeWork = work
+        }
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(TUI.resizeDebounceMs),
+            execute: work
+        )
+    }
+
+    private func performResizeRepaint() {
+        let cancelled = lock.withLock { () -> Bool in
+            if pendingResizeWork == nil { return true }
+            pendingResizeWork = nil
+            lastResizeRepaintAt = Date()
+            return false
+        }
+        if cancelled { return }
+        repaintForResize()
+    }
+
+    private func repaintForResize() {
+        if TUI.resizeRepaintsInPlace() {
             // Multiplexer (tmux/screen/zellij): ED3 is hostile and the pane
             // reflows its own visible window, so snap + repaint it in place.
             multiplexerRepaint()
+        } else {
+            // Direct terminal: authoritative repaint that clears scrollback and
+            // replays the whole transcript so every line re-wraps to the new
+            // width. Synchronized output keeps it flicker-free.
+            fullRepaint()
         }
     }
 
@@ -374,6 +425,7 @@ final class TUI: @unchecked Sendable {
         let oldHeight: Int
         let prevCursorUpBy: Int
         let clearOnShrinkEnabled: Bool
+        let oldRendered: [String]
         var committed: [String]
 
         // Suppress all frame output while stopped/suspended (e.g. during a
@@ -390,6 +442,7 @@ final class TUI: @unchecked Sendable {
         oldHeight = lastFrameHeight
         prevCursorUpBy = lastCursorUpBy
         clearOnShrinkEnabled = clearOnShrink
+        oldRendered = lastRenderedLines
         committed = pendingCommits
         pendingCommits.removeAll()
         let emitHeaderNow = !headerEmitted && headerProvider != nil
@@ -421,6 +474,34 @@ final class TUI: @unchecked Sendable {
             rendered = Array(rendered.suffix(termHeight))
         }
 
+        // No-op suppression: the live zone is byte-for-byte what is already on
+        // screen and there is nothing new to commit. The stored previous frame
+        // is the source of truth, and the hardware cursor is already parked
+        // correctly, so skip the write (and the terminal's repaint) entirely.
+        if committed.isEmpty, !emitHeaderNow, rendered == oldRendered {
+            return
+        }
+
+        // Same-height fast path: no committed lines and the live zone still has
+        // the same number of rows. Rewrite only the rows that actually changed
+        // instead of clearing and redrawing the whole zone — the spinner tick /
+        // single-token cases touch one line but used to repaint all of them.
+        if committed.isEmpty, !emitHeaderNow, oldHeight > 0, rendered.count == oldHeight {
+            let (frame, newCursorUpBy) = renderInlineDiff(
+                rendered: rendered,
+                oldRendered: oldRendered,
+                prevCursorUpBy: prevCursorUpBy
+            )
+            lock.withLock {
+                lastRenderedLines = rendered
+                lastFrameHeight = rendered.count
+                lastCursorUpBy = newCursorUpBy
+                frameCleared = false
+            }
+            terminal.write(frame)
+            return
+        }
+
         let shrinking = rendered.count < oldHeight && clearOnShrinkEnabled
 
         let (frame, newCursorUpBy) = renderInline(
@@ -438,7 +519,56 @@ final class TUI: @unchecked Sendable {
             if shrinking { _fullRedraws += 1 }
         }
 
-        terminal.write(frame)
+        // Wrap the live-zone update in synchronized output (DEC 2026) so the
+        // rewind-clear-redraw is presented atomically — no partial-frame flicker
+        // even under rapid streaming ticks. Terminals lacking support ignore the
+        // private-mode toggles. (The resize repaints wrap themselves.)
+        terminal.write("\u{1B}[?2026h" + frame + "\u{1B}[?2026l")
+    }
+
+    /// Same-height incremental repaint: rewind to the top of the live zone and
+    /// rewrite only the rows whose text differs from `oldRendered`, then re-park
+    /// the cursor. Wrapped in synchronized output. Requires
+    /// `rendered.count == oldRendered.count > 0`.
+    private func renderInlineDiff(
+        rendered: [String],
+        oldRendered: [String],
+        prevCursorUpBy: Int
+    ) -> (String, cursorUpBy: Int) {
+        let height = rendered.count
+        var out = "\u{1B}[?2026h" + TUI.disableAutowrap
+        // Drop to the live-zone bottom (the cursor may be parked above it),
+        // then rewind to the top-left.
+        if prevCursorUpBy > 0 { out += "\u{1B}[\(prevCursorUpBy)B" }
+        out += "\r"
+        if height > 1 { out += "\u{1B}[\(height - 1)A" }
+
+        var cursorTarget: (rowFromTop: Int, col: Int)?
+        for i in 0..<height {
+            let (cleanLine, col) = TUI.extractCursor(rendered[i])
+            if let col, cursorTarget == nil { cursorTarget = (i, col) }
+            let (oldClean, _) = TUI.extractCursor(oldRendered[i])
+            if cleanLine != oldClean {
+                // Cursor is at column 0 of row i; clear + rewrite it.
+                out += "\r\u{1B}[2K" + cleanLine
+            }
+            // Advance to column 0 of the next row (CR handles a row we just
+            // wrote mid-line; the LF steps down).
+            if i < height - 1 { out += "\r\n" }
+        }
+
+        // Re-park the hardware cursor onto the focused row/column.
+        var upBy = 0
+        if let target = cursorTarget {
+            upBy = max(0, (height - 1) - target.rowFromTop)
+            if upBy > 0 { out += "\u{1B}[\(upBy)A" }
+            out += "\r"
+            if target.col > 0 { out += "\u{1B}[\(target.col)C" }
+        } else {
+            out += "\r"
+        }
+        out += TUI.enableAutowrap + "\u{1B}[?2026l"
+        return (out, upBy)
     }
 
     // MARK: - Inline rendering

--- a/Sources/KWWKCli/TUIRunner.swift
+++ b/Sources/KWWKCli/TUIRunner.swift
@@ -94,10 +94,16 @@ final class TUIRunner: @unchecked Sendable {
         try installStdin()
         await waitForExit()
         tearDown()
-        let code = lock.withLock { pendingExitCode } ?? 0
-        if code != 0 {
-            Foundation.exit(code)
-        }
+    }
+
+    /// The exit code requested by `exit(code:)` (or a SIGINT/SIGTERM handler),
+    /// or 0 if none. Read by the caller AFTER `run()` returns so it can perform
+    /// its own graceful shutdown (kill background tasks, close provider/tmux)
+    /// and then exit the process with this code. `run()` deliberately does NOT
+    /// call `Foundation.exit` itself — doing so skipped the caller's shutdown on
+    /// every signal-driven teardown, leaking background processes and sockets.
+    var exitCode: Int32 {
+        lock.withLock { pendingExitCode } ?? 0
     }
 
     /// Request a clean shutdown. Safe from signal handlers and keybinding

--- a/Sources/KWWKCli/TranscriptRenderer.swift
+++ b/Sources/KWWKCli/TranscriptRenderer.swift
@@ -54,6 +54,11 @@ final class TranscriptRenderer {
     /// boundary yet. It is flushed on newline boundaries while streaming and
     /// fully flushed on `messageEnd`.
     private var assistantSegmentBuffer: String = ""
+    /// Content-block index of the text block the last `.textDelta` extended.
+    /// While consecutive deltas grow the same block we append the delta
+    /// directly (O(delta)); only a block transition falls back to re-deriving
+    /// from the full snapshot. `nil` before the first text delta of a turn.
+    private var lastAssistantTextIndex: Int?
     /// Whether this assistant turn has already emitted any text/error marker
     /// into scrollback. Used to prepend the block's leading separator exactly
     /// once.
@@ -146,6 +151,7 @@ final class TranscriptRenderer {
                 assistantIngestedCharacters = 0
                 assistantSegmentBuffer = ""
                 assistantCommittedDuringTurn = false
+                lastAssistantTextIndex = nil
                 // New turn — drop any prior turn's thinking timings.
                 // Re-populated from `.thinkingStart` events below.
                 thinkingTimings.removeAll()
@@ -171,7 +177,23 @@ final class TranscriptRenderer {
             default:
                 break
             }
-            ingestAssistantText(assistant, flushAll: false)
+            // Fast path: while consecutive text deltas grow the same content
+            // block, append the delta straight into the segment buffer instead
+            // of re-deriving (and re-diffing) the whole accumulated snapshot on
+            // every event — the latter is O(n) per delta, O(n²) over a long
+            // message. A block transition (a new text block after a tool call)
+            // falls back to the snapshot path so the inter-block separator is
+            // inserted correctly, then re-syncs the ingested count.
+            if case .textDelta(let idx, let delta, _) = amEvent,
+               lastAssistantTextIndex == nil || lastAssistantTextIndex == idx {
+                lastAssistantTextIndex = idx
+                assistantSegmentBuffer += delta
+                assistantIngestedCharacters += delta.count
+                drainAssistantSegmentBuffer(flushAll: false)
+            } else {
+                if case .textDelta(let idx, _, _) = amEvent { lastAssistantTextIndex = idx }
+                ingestAssistantText(assistant, flushAll: false)
+            }
             recomputeLive()
 
         case .messageEnd(let message):
@@ -198,6 +220,7 @@ final class TranscriptRenderer {
                 assistantIngestedCharacters = 0
                 assistantSegmentBuffer = ""
                 assistantCommittedDuringTurn = false
+                lastAssistantTextIndex = nil
                 recomputeLive()
                 flushQueuedVerbose()
             case .toolResult, .user:
@@ -251,6 +274,7 @@ final class TranscriptRenderer {
             assistantIngestedCharacters = 0
             assistantSegmentBuffer = ""
             assistantCommittedDuringTurn = false
+            lastAssistantTextIndex = nil
             queuedVerboseLines.removeAll()
             recomputeLive()
 

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -26,7 +26,7 @@ import KWWKCli
 ///                        Requires the account to have long-context billing
 ///                        enabled. Ignored for non-Anthropic providers.
 ///   `--subagents <list>` — comma-separated built-in subagents to enable:
-///                        general, Explore, Plan, all, none.
+///                        general, explore, plan, all, none.
 ///   `--no-subagents`    — disable built-in CLI subagents.
 @main
 struct KwwkCLI {
@@ -91,7 +91,7 @@ struct KwwkCLI {
           --context-1m                opt into Anthropic 1M-context beta
                                       (long-context billing must be on)
           --subagents <list>          built-in subagents to enable:
-                                      general,Explore,Plan,all, or none
+                                      general,explore,plan,all, or none
           --no-subagents              disable built-in CLI subagents
           --continue                  resume the latest session for this
                                       directory (replays its transcript)

--- a/Tests/KWWKAITests/APIRegistryScopeTests.swift
+++ b/Tests/KWWKAITests/APIRegistryScopeTests.swift
@@ -49,6 +49,21 @@ struct APIRegistryScopeTests {
         #expect(stillFlat?.tag == "flat")
     }
 
+    @Test("a vendor-tagged flat provider refuses cross-vendor fallback")
+    func vendorTaggedFallbackIsGated() async {
+        let registry = APIRegistry()
+        // Flat Anthropic provider tagged to the `anthropic` vendor.
+        await registry.register(
+            TaggedProvider(api: "anthropic-messages", tag: "anthropic-flat"),
+            providerVendor: "anthropic"
+        )
+        // A same-vendor model resolves via the flat fallback.
+        let same = await registry.provider(scope: "anthropic", api: "anthropic-messages") as? TaggedProvider
+        #expect(same?.tag == "anthropic-flat")
+        // A foreign vendor sharing the wire must NOT route to Anthropic's key.
+        #expect(await registry.provider(scope: "github-copilot", api: "anthropic-messages") == nil)
+    }
+
     @Test("unregisterScope removes only that scope's entries")
     func unregisterScope() async {
         let registry = APIRegistry()

--- a/Tests/KWWKAITests/AWSSigV4Tests.swift
+++ b/Tests/KWWKAITests/AWSSigV4Tests.swift
@@ -67,9 +67,9 @@ struct AWSEventStreamTests {
             headers: [":event-type": "messageStart", ":content-type": "application/json"],
             payload: payload
         )
-        let bytes = AsyncThrowingStream<UInt8, Error> { cont in
+        let bytes = AsyncThrowingStream<Data, Error> { cont in
             Task {
-                for b in frame { cont.yield(b) }
+                cont.yield(frame)
                 cont.finish()
             }
         }
@@ -91,9 +91,12 @@ struct AWSEventStreamTests {
             headers: [":event-type": "messageStop"], payload: Data("{\"stopReason\":\"end_turn\"}".utf8)
         )
         let combined = one + two
-        let bytes = AsyncThrowingStream<UInt8, Error> { cont in
+        // Deliver the two frames split across chunk boundaries to exercise the
+        // parser's cross-chunk buffering.
+        let bytes = AsyncThrowingStream<Data, Error> { cont in
             Task {
-                for b in combined { cont.yield(b) }
+                cont.yield(combined.prefix(one.count + 3))
+                cont.yield(combined.suffix(from: one.count + 3))
                 cont.finish()
             }
         }
@@ -137,16 +140,16 @@ struct BedrockProviderTests {
         }
         func stream(
             url: URL, method: String, headers: [String: String], body requestBody: Data?
-        ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+        ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
             lastRequest = (url, method, headers, requestBody)
             let response = HTTPURLResponse(
                 url: url, statusCode: statusCode, httpVersion: "HTTP/1.1",
                 headerFields: ["content-type": "application/vnd.amazon.eventstream"]
             )!
-            let bytes = Array(body)
-            let stream = AsyncThrowingStream<UInt8, Error> { cont in
+            let bodyData = body
+            let stream = AsyncThrowingStream<Data, Error> { cont in
                 Task {
-                    for b in bytes { cont.yield(b) }
+                    cont.yield(bodyData)
                     cont.finish()
                 }
             }

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -23,7 +23,7 @@ final class StubSSEClient: HTTPClient, @unchecked Sendable {
         method: String,
         headers: [String: String],
         body requestBody: Data?
-    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         lock.withLock { lastRequest = (url, method, headers, requestBody) }
 
         let response = HTTPURLResponse(
@@ -33,12 +33,10 @@ final class StubSSEClient: HTTPClient, @unchecked Sendable {
             headerFields: ["content-type": "text/event-stream"]
         )!
 
-        let bodyBytes = Array(body.utf8)
-        let stream = AsyncThrowingStream<UInt8, Error> { cont in
+        let bodyData = Data(body.utf8)
+        let stream = AsyncThrowingStream<Data, Error> { cont in
             Task {
-                for byte in bodyBytes {
-                    cont.yield(byte)
-                }
+                cont.yield(bodyData)
                 cont.finish()
             }
         }
@@ -54,7 +52,7 @@ struct AnthropicProviderTests {
         name: "Claude Test",
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: false,
         input: [.text],
         contextWindow: 128_000,
@@ -409,7 +407,7 @@ struct AnthropicProviderTests {
         name: "Claude Reason",
         api: "anthropic-messages",
         provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: true,
         input: [.text],
         contextWindow: 200_000,

--- a/Tests/KWWKAITests/AzureCloudflareTests.swift
+++ b/Tests/KWWKAITests/AzureCloudflareTests.swift
@@ -153,7 +153,7 @@ struct AzureCloudflareTests {
             name: "gpt-4o-mini",
             api: "cloudflare-ai-gateway",
             provider: "cloudflare-ai-gateway",
-            baseUrl: "https://gateway.ai.cloudflare.com/v1/acct/gw/compat"
+            baseURL: "https://gateway.ai.cloudflare.com/v1/acct/gw/compat"
         )
         _ = provider.stream(
             model: model,
@@ -175,13 +175,13 @@ struct AzureCloudflareTests {
             accountId: "acctABC",
             client: client
         )
-        // model.baseUrl carries the literal placeholder; urlBuilder must expand it.
+        // model.baseURL carries the literal placeholder; urlBuilder must expand it.
         let model = Model(
             id: "@cf/x/y",
             name: "y",
             api: "cloudflare-workers-ai",
             provider: "cloudflare-workers-ai",
-            baseUrl: "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+            baseURL: "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1"
         )
         _ = provider.stream(
             model: model,

--- a/Tests/KWWKAITests/BedrockHardeningTests.swift
+++ b/Tests/KWWKAITests/BedrockHardeningTests.swift
@@ -59,28 +59,28 @@ struct BedrockRegionTests {
         // ARN wins over everything.
         #expect(BedrockRegion.resolve(
             modelId: "arn:aws:bedrock:eu-west-3:1:inference-profile/x",
-            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com",
             env: ["AWS_REGION": "us-west-2"]
         ) == "eu-west-3")
 
         // configuredRegion (env) wins over a standard endpoint host (pi order).
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+            baseURL: "https://bedrock-runtime.ap-south-1.amazonaws.com",
             env: ["AWS_REGION": "us-west-2"]
         ) == "us-west-2")
 
         // Env wins when no ARN / standard host.
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: "https://proxy.internal",
+            baseURL: "https://proxy.internal",
             env: ["AWS_DEFAULT_REGION": "sa-east-1"]
         ) == "sa-east-1")
 
         // us-east-1 when nothing pins a region.
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: nil,
+            baseURL: nil,
             env: [:]
         ) == "us-east-1")
     }
@@ -89,7 +89,7 @@ struct BedrockRegionTests {
     func envOutranksEndpoint() {
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+            baseURL: "https://bedrock-runtime.ap-south-1.amazonaws.com",
             env: ["AWS_REGION": "us-west-2"]
         ) == "us-west-2")
     }
@@ -98,13 +98,13 @@ struct BedrockRegionTests {
     func endpointOnlyWithoutConfigOrProfile() {
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+            baseURL: "https://bedrock-runtime.ap-south-1.amazonaws.com",
             env: [:]
         ) == "ap-south-1")
         // Ambient profile present -> endpoint host NOT used as override.
         #expect(BedrockRegion.resolve(
             modelId: "anthropic.claude",
-            baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+            baseURL: "https://bedrock-runtime.ap-south-1.amazonaws.com",
             env: ["AWS_PROFILE": "work"],
             profileRegion: "eu-central-1"
         ) == "eu-central-1")
@@ -245,15 +245,15 @@ struct BedrockCacheAndAuthTests {
         init(body: Data) { self.body = body }
         func stream(
             url: URL, method: String, headers: [String: String], body requestBody: Data?
-        ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+        ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
             lastRequest = (url, method, headers, requestBody)
             let response = HTTPURLResponse(
                 url: url, statusCode: 200, httpVersion: "HTTP/1.1",
                 headerFields: ["content-type": "application/vnd.amazon.eventstream"]
             )!
-            let bytes = Array(body)
-            let stream = AsyncThrowingStream<UInt8, Error> { cont in
-                Task { for b in bytes { cont.yield(b) }; cont.finish() }
+            let bodyData = body
+            let stream = AsyncThrowingStream<Data, Error> { cont in
+                Task { cont.yield(bodyData); cont.finish() }
             }
             return (response, stream)
         }

--- a/Tests/KWWKAITests/EnvAPIKeysTests.swift
+++ b/Tests/KWWKAITests/EnvAPIKeysTests.swift
@@ -4,12 +4,12 @@ import Testing
 
 @Suite("Env API keys")
 struct EnvAPIKeysTests {
-    @Test("default lookup uses an empty environment")
-    func defaultLookupIsEmpty() {
-        #expect(EnvAPIKeys.apiKey(for: "openai") == nil)
-        #expect(EnvAPIKeys.configuredProviders().isEmpty)
-        #expect(EnvAPIKeys.azure() == nil)
-        #expect(EnvAPIKeys.cloudflare() == nil)
+    @Test("an empty environment resolves nothing")
+    func emptyEnvironmentIsEmpty() {
+        #expect(EnvAPIKeys.apiKey(for: "openai", env: [:]) == nil)
+        #expect(EnvAPIKeys.configuredProviders(env: [:]).isEmpty)
+        #expect(EnvAPIKeys.azure(env: [:]) == nil)
+        #expect(EnvAPIKeys.cloudflare(env: [:]) == nil)
     }
 
     @Test("resolves provider keys from an injected environment")

--- a/Tests/KWWKAITests/FauxProviderTests.swift
+++ b/Tests/KWWKAITests/FauxProviderTests.swift
@@ -158,12 +158,21 @@ struct FauxProviderTests {
 
         let first = try await complete(model: registration.getModel(), context: context)
         let second = try await complete(model: registration.getModel(), context: context)
-        let exhausted = try await complete(model: registration.getModel(), context: context)
 
         #expect(first.content == [.text(TextContent(text: "first"))])
         #expect(second.content == [.text(TextContent(text: "second"))])
-        #expect(exhausted.stopReason == .error)
-        #expect(exhausted.errorMessage == "No more faux responses queued")
+
+        // The exhausted queue finishes the stream in an error state; complete()
+        // surfaces that as a thrown CompletionFailedError (carrying the error
+        // message) rather than an ordinary-looking message.
+        var thrown: CompletionFailedError?
+        do {
+            _ = try await complete(model: registration.getModel(), context: context)
+        } catch let error as CompletionFailedError {
+            thrown = error
+        }
+        #expect(thrown?.message.stopReason == .error)
+        #expect(thrown?.message.errorMessage == "No more faux responses queued")
         #expect(registration.getPendingResponseCount() == 0)
         #expect(registration.state.callCount == 3)
     }

--- a/Tests/KWWKAITests/GoogleGeminiTests.swift
+++ b/Tests/KWWKAITests/GoogleGeminiTests.swift
@@ -9,7 +9,7 @@ struct GoogleGeminiTests {
         name: "Gemini 2.5 Flash",
         api: "google-generative-ai",
         provider: "google",
-        baseUrl: "https://generativelanguage.googleapis.com",
+        baseURL: "https://generativelanguage.googleapis.com",
         reasoning: false,
         input: [.text, .image],
         contextWindow: 1_000_000,
@@ -217,7 +217,7 @@ struct GoogleGeminiTests {
 
     static func reasoningModel(_ id: String) -> Model {
         Model(id: id, name: id, api: "google-generative-ai", provider: "google",
-              baseUrl: "https://generativelanguage.googleapis.com", reasoning: true,
+              baseURL: "https://generativelanguage.googleapis.com", reasoning: true,
               input: [.text, .image], contextWindow: 1_000_000, maxTokens: 8192)
     }
 

--- a/Tests/KWWKAITests/LiveAnthropicStreamTest.swift
+++ b/Tests/KWWKAITests/LiveAnthropicStreamTest.swift
@@ -35,7 +35,7 @@ struct LiveAnthropicStreamTests {
             name: "claude-sonnet-4-5",
             api: "anthropic-messages",
             provider: "anthropic",
-            baseUrl: "https://api.anthropic.com",
+            baseURL: "https://api.anthropic.com",
             reasoning: true,
             input: [.text],
             contextWindow: 200_000,

--- a/Tests/KWWKAITests/LiveCodexStreamTest.swift
+++ b/Tests/KWWKAITests/LiveCodexStreamTest.swift
@@ -25,7 +25,7 @@ struct LiveCodexStreamTests {
         guard let entry = json["openai-codex"] as? [String: Any] else { return }
         _ = entry
 
-        let store = OAuthStore(url: OAuthStore.defaultURL())
+        let store = try OAuthStore(url: OAuthStore.defaultURL())
         let manager = OAuthManager(store: store)
         let accessToken = try await manager.apiKey(for: "openai-codex")
         let refreshed = await store.get("openai-codex")
@@ -97,7 +97,7 @@ struct LiveCodexStreamTests {
 
         // Refresh the access token so we have a fresh one before the
         // stream call. The manager also stashes the `accountId` JWT claim.
-        let store = OAuthStore(url: OAuthStore.defaultURL())
+        let store = try OAuthStore(url: OAuthStore.defaultURL())
         let manager = OAuthManager(store: store)
         let accessToken: String
         do {
@@ -123,7 +123,7 @@ struct LiveCodexStreamTests {
             name: "gpt-5.4",
             api: "chatgpt-codex",
             provider: "chatgpt-codex",
-            baseUrl: "https://chatgpt.com",
+            baseURL: "https://chatgpt.com",
             reasoning: true,
             input: [.text, .image],
             contextWindow: 272_000,

--- a/Tests/KWWKAITests/OAuthHardeningTests.swift
+++ b/Tests/KWWKAITests/OAuthHardeningTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import KWWKAI
+
+/// Covers the hardening added to `OAuth.swift`: corrupt-store detection,
+/// atomic 0600 persistence, deduplicated concurrent refreshes, and the
+/// throwing resolver's missing-vs-failed distinction.
+@Suite("OAuth hardening")
+struct OAuthHardeningTests {
+    private func tmpURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
+    }
+
+    @Test("missing store file is a normal fresh start, not an error")
+    func missingFileIsEmpty() async throws {
+        let store = try OAuthStore(url: tmpURL())
+        #expect(await store.all().isEmpty)
+    }
+
+    @Test("a corrupt store throws instead of silently starting empty")
+    func corruptStoreThrows() throws {
+        let tmp = tmpURL()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try Data("{ this is not json".utf8).write(to: tmp)
+        #expect(throws: OAuthError.self) {
+            _ = try OAuthStore(url: tmp)
+        }
+    }
+
+    @Test("persisted store file is created with 0600 permissions")
+    func storeFileIs0600() async throws {
+        let tmp = tmpURL()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = try OAuthStore(url: tmp)
+        try await store.set(
+            OAuthCredentials(access: "a", refresh: "r", expires: 10),
+            for: "x"
+        )
+        let attrs = try FileManager.default.attributesOfItem(atPath: tmp.path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600)
+    }
+
+    /// Refresh that suspends briefly so two concurrent callers overlap, and
+    /// counts how many times it actually ran.
+    final class SlowCountingProvider: OAuthProvider, @unchecked Sendable {
+        let id: String
+        let name = "slow"
+        private let lock = NSLock()
+        private var count = 0
+        var refreshCount: Int { lock.withLock { count } }
+        init(id: String) { self.id = id }
+        func refresh(_ c: OAuthCredentials, using client: HTTPClient) async throws -> OAuthCredentials {
+            lock.withLock { count += 1 }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            return OAuthCredentials(
+                access: "refreshed",
+                refresh: c.refresh,
+                expires: Int64(Date().timeIntervalSince1970 * 1000) + 600_000
+            )
+        }
+    }
+
+    @Test("concurrent apiKey() calls share one in-flight refresh")
+    func concurrentRefreshDeduped() async throws {
+        let tmp = tmpURL()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = try OAuthStore(url: tmp)
+        try await store.set(
+            OAuthCredentials(access: "expired", refresh: "r", expires: 0),
+            for: "x"
+        )
+        let provider = SlowCountingProvider(id: "x")
+        let manager = OAuthManager(store: store, providers: [provider])
+
+        async let first = manager.apiKey(for: "x")
+        async let second = manager.apiKey(for: "x")
+        let (a, b) = try await (first, second)
+        #expect(a == "refreshed")
+        #expect(b == "refreshed")
+        // Both callers must have joined the same refresh, not launched two.
+        #expect(provider.refreshCount == 1)
+    }
+
+    /// Provider whose refresh always fails, to check error propagation.
+    struct FailingRefreshProvider: OAuthProvider {
+        let id = "anthropic"
+        let name = "failing"
+        func refresh(_ c: OAuthCredentials, using client: HTTPClient) async throws -> OAuthCredentials {
+            throw OAuthError.refreshFailed("token revoked")
+        }
+    }
+
+    @Test("resolver returns nil for a provider with no stored credentials")
+    func resolverNilWhenMissing() async throws {
+        let store = try OAuthStore(url: tmpURL())
+        let manager = OAuthManager(store: store, providers: [FailingRefreshProvider()])
+        let resolver = manager.resolver()
+        let model = Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
+        #expect(try await resolver(model, nil) == nil)
+    }
+
+    @Test("resolver propagates a refresh failure instead of degrading to nil")
+    func resolverPropagatesRefreshFailure() async throws {
+        let tmp = tmpURL()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = try OAuthStore(url: tmp)
+        try await store.set(
+            OAuthCredentials(access: "expired", refresh: "r", expires: 0),
+            for: "anthropic"
+        )
+        let manager = OAuthManager(store: store, providers: [FailingRefreshProvider()])
+        let resolver = manager.resolver()
+        let model = Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
+        await #expect(throws: OAuthError.self) {
+            _ = try await resolver(model, nil)
+        }
+    }
+}

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -102,8 +102,7 @@ struct OAuthLoginShapeTests {
             clientID: "test-client",
             callbacks: OAuthLogin.Callbacks(
                 onAuthURL: { _ in },
-                onProgress: { _ in },
-                onPrompt: { _ in "" }
+                onProgress: { _ in }
             ),
             client: client
         )
@@ -127,17 +126,17 @@ final class SequentialStubClient: HTTPClient, @unchecked Sendable {
 
     func stream(
         url: URL, method: String, headers: [String: String], body: Data?
-    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         recorded.append((url, method, headers, body))
         let next = queue.removeFirst()
         let response = HTTPURLResponse(
             url: url, statusCode: next.status, httpVersion: "HTTP/1.1",
             headerFields: ["content-type": "application/json"]
         )!
-        let bytes = Array(next.body.utf8)
-        let stream = AsyncThrowingStream<UInt8, Error> { cont in
+        let bodyData = Data(next.body.utf8)
+        let stream = AsyncThrowingStream<Data, Error> { cont in
             Task {
-                for b in bytes { cont.yield(b) }
+                cont.yield(bodyData)
                 cont.finish()
             }
         }

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -20,16 +20,16 @@ final class StubResponseClient: HTTPClient, @unchecked Sendable {
 
     func stream(
         url: URL, method: String, headers: [String: String], body: Data?
-    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<UInt8, Error>) {
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         lock.withLock { lastRequest = (url, method, headers, body) }
         let response = HTTPURLResponse(
             url: url, statusCode: responseStatus, httpVersion: "HTTP/1.1",
             headerFields: ["content-type": "application/json"]
         )!
-        let bytes = Array(responseBody)
-        let stream = AsyncThrowingStream<UInt8, Error> { cont in
+        let bodyData = responseBody
+        let stream = AsyncThrowingStream<Data, Error> { cont in
             Task {
-                for b in bytes { cont.yield(b) }
+                cont.yield(bodyData)
                 cont.finish()
             }
         }
@@ -58,14 +58,14 @@ struct OAuthStoreTests {
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let a = OAuthStore(url: tmp)
+        let a = try OAuthStore(url: tmp)
         try await a.set(
             OAuthCredentials(access: "A", refresh: "R", expires: 10, extras: ["projectId": .string("p-1")]),
             for: "test"
         )
 
         // Re-open from disk.
-        let b = OAuthStore(url: tmp)
+        let b = try OAuthStore(url: tmp)
         let loaded = await b.get("test")
         #expect(loaded?.access == "A")
         #expect(loaded?.refresh == "R")
@@ -87,7 +87,7 @@ struct OAuthStoreTests {
         """
         try Data(raw.utf8).write(to: tmp)
 
-        let store = OAuthStore(url: tmp)
+        let store = try OAuthStore(url: tmp)
         #expect(await store.get("a")?.extras == [:])
         #expect(await store.get("b")?.extras["x"] == .string("y"))
     }
@@ -226,7 +226,7 @@ struct OAuthManagerTests {
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let store = OAuthStore(url: tmp)
+        let store = try OAuthStore(url: tmp)
         try await store.set(
             OAuthCredentials(access: "expired", refresh: "r", expires: 0),
             for: "x"
@@ -244,8 +244,8 @@ struct OAuthManagerTests {
         #expect(provider.refreshCount == 1)
     }
 
-    @Test("throws when no credentials are stored") func missingCreds() async {
-        let store = OAuthStore(url: FileManager.default.temporaryDirectory
+    @Test("throws when no credentials are stored") func missingCreds() async throws {
+        let store = try OAuthStore(url: FileManager.default.temporaryDirectory
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json"))
         let manager = OAuthManager(store: store, providers: [AnthropicOAuthProvider()])
         await #expect(throws: Error.self) {
@@ -258,7 +258,7 @@ struct OAuthManagerTests {
             .appendingPathComponent("kw-oauth-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let store = OAuthStore(url: tmp)
+        let store = try OAuthStore(url: tmp)
         try await store.set(
             OAuthCredentials(access: "static", refresh: "r", expires: Int64.max / 2),
             for: "anthropic"
@@ -266,11 +266,11 @@ struct OAuthManagerTests {
         let manager = OAuthManager(store: store, providers: [AnthropicOAuthProvider()])
         let resolver = manager.resolver()
         let model = Model(id: "claude", api: "anthropic-messages", provider: "anthropic")
-        let auth = await resolver(model, nil)
+        let auth = try await resolver(model, nil)
         #expect(auth?.token == "static")
         #expect(auth?.scheme == .bearer)
         let unknown = Model(id: "unknown", api: "unknown", provider: "unknown-xyz")
-        #expect(await resolver(unknown, nil) == nil)
+        #expect(try await resolver(unknown, nil) == nil)
     }
 
     @Test("resolver() includes GitHub Copilot endpoint as baseURL") func resolverPreservesCopilotEndpoint() async throws {
@@ -279,7 +279,7 @@ struct OAuthManagerTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let endpoint = "https://api.business.githubcopilot.com"
-        let store = OAuthStore(url: tmp)
+        let store = try OAuthStore(url: tmp)
         try await store.set(
             OAuthCredentials(
                 access: "session-token",
@@ -293,7 +293,7 @@ struct OAuthManagerTests {
         let resolver = manager.resolver()
         let model = Model(id: "gpt-4.1", api: "openai-completions", provider: "github-copilot")
 
-        let auth = await resolver(model, nil)
+        let auth = try await resolver(model, nil)
         #expect(auth?.token == "session-token")
         #expect(auth?.scheme == .bearer)
         #expect(auth?.baseURL == endpoint)

--- a/Tests/KWWKAITests/OpenAICompletionsTests.swift
+++ b/Tests/KWWKAITests/OpenAICompletionsTests.swift
@@ -9,7 +9,7 @@ struct OpenAICompletionsTests {
         name: "GPT-4o Mini",
         api: "openai-completions",
         provider: "openai",
-        baseUrl: "https://api.openai.com",
+        baseURL: "https://api.openai.com",
         reasoning: false,
         input: [.text],
         contextWindow: 128_000,
@@ -210,7 +210,7 @@ struct OpenAICompletionsTests {
         #expect(json["prompt_cache_retention"] as? String == "24h")
 
         var proxy = Self.model
-        proxy.baseUrl = "https://proxy.example.com"
+        proxy.baseURL = "https://proxy.example.com"
         var compat = ModelCompat()
         compat.supportsLongCacheRetention = false
         proxy.compat = compat
@@ -230,7 +230,7 @@ struct OpenAICompletionsTests {
     @Test("session affinity headers honor cache retention and caller overrides")
     func sessionAffinityHeaders() async throws {
         var model = Self.model
-        model.baseUrl = "https://proxy.example.com"
+        model.baseURL = "https://proxy.example.com"
         model.headers = ["x-model-header": "model"]
         var compat = ModelCompat()
         compat.sendSessionAffinityHeaders = true
@@ -309,7 +309,7 @@ struct OpenAICompletionsTests {
     func anthropicCacheControlCompat() async throws {
         var model = Self.model
         model.provider = "openrouter"
-        model.baseUrl = "https://openrouter.ai/api"
+        model.baseURL = "https://openrouter.ai/api"
         var compat = ModelCompat()
         compat.cacheControlFormat = "anthropic"
         model.compat = compat
@@ -344,7 +344,7 @@ struct OpenAICompletionsTests {
     func anthropicCacheExcludesNativeCache() async throws {
         var model = Self.model
         model.provider = "openrouter"
-        model.baseUrl = "https://openrouter.ai/api"
+        model.baseURL = "https://openrouter.ai/api"
         var compat = ModelCompat()
         compat.cacheControlFormat = "anthropic"
         compat.supportsLongCacheRetention = true
@@ -405,7 +405,7 @@ struct OpenAICompletionsTests {
     @Test("forwards tool-result images as a following user message (vision model)")
     func toolResultImageForwarding() async throws {
         let visionModel = Model(id: "gpt-4o", name: "GPT-4o", api: "openai-completions",
-            provider: "openai", baseUrl: "https://api.openai.com", reasoning: false,
+            provider: "openai", baseURL: "https://api.openai.com", reasoning: false,
             input: [.text, .image], contextWindow: 128_000, maxTokens: 4096)
         let client = StubSSEClient(body: Self.textSSE)
         let provider = OpenAICompletionsProvider(client: client, defaultAPIKey: "sk-test")

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -9,7 +9,7 @@ struct OpenAIResponsesTests {
         name: "GPT-5",
         api: "openai-responses",
         provider: "openai",
-        baseUrl: "https://api.openai.com",
+        baseURL: "https://api.openai.com",
         reasoning: true,
         input: [.text, .image],
         contextWindow: 200_000,

--- a/Tests/KWWKAITests/ProviderAttributionTests.swift
+++ b/Tests/KWWKAITests/ProviderAttributionTests.swift
@@ -36,7 +36,7 @@ struct ProviderAttributionTests {
     func openRouterByBaseUrl() {
         let h = ProviderAttribution.attributionHeaders(
             provider: "custom",
-            baseUrl: "https://openrouter.ai/api/v1"
+            baseURL: "https://openrouter.ai/api/v1"
         )
         #expect(h?["HTTP-Referer"] == "https://kwwk.dev")
     }
@@ -47,7 +47,7 @@ struct ProviderAttributionTests {
         #expect(byId?["X-BILLING-INVOKE-ORIGIN"] == "kwwk")
         let byHost = ProviderAttribution.attributionHeaders(
             provider: "x",
-            baseUrl: "https://integrate.api.nvidia.com/v1"
+            baseURL: "https://integrate.api.nvidia.com/v1"
         )
         #expect(byHost?["X-BILLING-INVOKE-ORIGIN"] == "kwwk")
     }
@@ -77,7 +77,7 @@ struct ProviderAttributionTests {
             id: "x",
             api: "openai-completions",
             provider: "openrouter",
-            baseUrl: "https://openrouter.ai/api/v1"
+            baseURL: "https://openrouter.ai/api/v1"
         )
         let merged = ProviderAttribution.mergedHeaders(
             for: model,

--- a/Tests/KWWKAITests/ProviderVariantsTests.swift
+++ b/Tests/KWWKAITests/ProviderVariantsTests.swift
@@ -80,7 +80,7 @@ struct ProviderVariantsTests {
             name: "claude",
             api: "anthropic-messages",
             provider: "anthropic",
-            baseUrl: "https://api.anthropic.com"
+            baseURL: "https://api.anthropic.com"
         )
         _ = provider.stream(
             model: model,
@@ -143,7 +143,7 @@ struct ProviderVariantsTests {
             name: "claude",
             api: "github-copilot-chat",
             provider: "github-copilot",
-            baseUrl: "https://api.githubcopilot.com"
+            baseURL: "https://api.githubcopilot.com"
         )
 
         // Agent flow: last message is tool result → x-initiator=agent.
@@ -183,7 +183,7 @@ struct ProviderVariantsTests {
             name: "m",
             api: "github-copilot-chat",
             provider: "github-copilot",
-            baseUrl: "https://api.githubcopilot.com"
+            baseURL: "https://api.githubcopilot.com"
         )
         _ = provider.stream(
             model: model,

--- a/Tests/KWWKAITests/ReasoningEncoderTests.swift
+++ b/Tests/KWWKAITests/ReasoningEncoderTests.swift
@@ -22,11 +22,11 @@ struct ReasoningEncoderTests {
 
     """
 
-    private func reasoningModel(provider: String, baseUrl: String, compat: ModelCompat? = nil,
+    private func reasoningModel(provider: String, baseURL: String, compat: ModelCompat? = nil,
                                 thinkingLevelMap: [String: String?]? = nil) -> Model {
         Model(
             id: "m", name: "m", api: "openai-completions", provider: provider,
-            baseUrl: baseUrl, reasoning: true, input: [.text],
+            baseURL: baseURL, reasoning: true, input: [.text],
             contextWindow: 128_000, maxTokens: 4096,
             compat: compat, thinkingLevelMap: thinkingLevelMap
         )
@@ -44,7 +44,7 @@ struct ReasoningEncoderTests {
 
     @Test("openai default emits flat reasoning_effort")
     func openaiDefault() throws {
-        let b = try body(reasoningModel(provider: "openai", baseUrl: "https://api.openai.com"), .high)
+        let b = try body(reasoningModel(provider: "openai", baseURL: "https://api.openai.com"), .high)
         #expect(b["reasoning_effort"] as? String == "high")
         #expect(b["reasoning"] == nil)
         #expect(b["thinking"] == nil)
@@ -52,7 +52,7 @@ struct ReasoningEncoderTests {
 
     @Test("openrouter (detected from baseUrl) emits nested reasoning.effort")
     func openrouterNested() throws {
-        let b = try body(reasoningModel(provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1"), .medium)
+        let b = try body(reasoningModel(provider: "openrouter", baseURL: "https://openrouter.ai/api/v1"), .medium)
         let reasoning = b["reasoning"] as? [String: Any]
         #expect(reasoning?["effort"] as? String == "medium")
         #expect(b["reasoning_effort"] == nil)
@@ -60,14 +60,14 @@ struct ReasoningEncoderTests {
 
     @Test("deepseek emits thinking{type:enabled} + reasoning_effort")
     func deepseekFormat() throws {
-        let b = try body(reasoningModel(provider: "deepseek", baseUrl: "https://api.deepseek.com"), .high)
+        let b = try body(reasoningModel(provider: "deepseek", baseURL: "https://api.deepseek.com"), .high)
         let thinking = b["thinking"] as? [String: Any]
         #expect(thinking?["type"] as? String == "enabled")
     }
 
     @Test("zai emits thinking + tool_stream via compat")
     func zaiFormat() throws {
-        let model = reasoningModel(provider: "zai", baseUrl: "https://api.z.ai/api/coding/paas/v4",
+        let model = reasoningModel(provider: "zai", baseURL: "https://api.z.ai/api/coding/paas/v4",
                                    compat: { var c = ModelCompat(); c.zaiToolStream = true; c.supportsReasoningEffort = true; return c }())
         let b = try OpenAICompletionsProvider.encodeBodyDict(
             model: model,
@@ -83,7 +83,7 @@ struct ReasoningEncoderTests {
     @Test("thinkingLevelMap remaps the wire effort value")
     func levelMapRemap() throws {
         // xhigh maps to "max"; request xhigh -> reasoning_effort "max".
-        let model = reasoningModel(provider: "openai", baseUrl: "https://api.openai.com",
+        let model = reasoningModel(provider: "openai", baseURL: "https://api.openai.com",
                                    thinkingLevelMap: ["xhigh": "max"])
         let b = try body(model, .xhigh)
         #expect(b["reasoning_effort"] as? String == "max")
@@ -92,7 +92,7 @@ struct ReasoningEncoderTests {
     @Test("non-reasoning model emits no reasoning fields")
     func nonReasoning() throws {
         let model = Model(id: "m", name: "m", api: "openai-completions", provider: "openai",
-                          baseUrl: "https://api.openai.com", reasoning: false)
+                          baseURL: "https://api.openai.com", reasoning: false)
         let b = try OpenAICompletionsProvider.encodeBodyDict(
             model: model, context: Context(messages: [.user(UserMessage(text: "hi"))]),
             options: StreamOptions(reasoning: .high))
@@ -108,7 +108,7 @@ struct ReasoningEncoderTests {
         let provider = AnthropicProvider(client: client, defaultAPIKey: "k")
         var compat = ModelCompat(); compat.forceAdaptiveThinking = true
         let model = Model(id: "claude-opus-4-6", name: "Opus", api: "anthropic-messages",
-                          provider: "anthropic", baseUrl: "https://api.anthropic.com",
+                          provider: "anthropic", baseURL: "https://api.anthropic.com",
                           reasoning: true, input: [.text], contextWindow: 200_000, maxTokens: 8192,
                           compat: compat, thinkingLevelMap: ["xhigh": "max"])
         _ = provider.stream(model: model,
@@ -130,7 +130,7 @@ struct ReasoningEncoderTests {
         let client = StubSSEClient(body: Self.geminiSSE)
         let provider = GoogleGeminiProvider(client: client, defaultAPIKey: "k")
         let model = Model(id: "gemini-3-pro-preview", name: "G3", api: "google-generative-ai",
-                          provider: "google", baseUrl: "https://generativelanguage.googleapis.com",
+                          provider: "google", baseURL: "https://generativelanguage.googleapis.com",
                           reasoning: true, input: [.text], contextWindow: 1_000_000, maxTokens: 8192)
         _ = provider.stream(model: model,
                             context: Context(messages: [.user(UserMessage(text: "hi"))]),

--- a/Tests/KWWKAITests/TransportHardeningTests.swift
+++ b/Tests/KWWKAITests/TransportHardeningTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import KWWKAI
 

--- a/Tests/KWWKAITests/TransportHardeningTests.swift
+++ b/Tests/KWWKAITests/TransportHardeningTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+
+// A stub HTTPClient that returns a fixed status + body, delivered as one or
+// more `Data` chunks (chunk-based streaming, matching the production contract).
+private final class ChunkStubClient: HTTPClient, @unchecked Sendable {
+    let chunks: [Data]
+    let statusCode: Int
+    init(body: Data, statusCode: Int = 200, splitInto: Int = 1) {
+        self.statusCode = statusCode
+        if splitInto <= 1 || body.isEmpty {
+            self.chunks = [body]
+        } else {
+            let size = max(1, body.count / splitInto)
+            var out: [Data] = []
+            var i = 0
+            while i < body.count {
+                let end = min(i + size, body.count)
+                out.append(body.subdata(in: i..<end))
+                i = end
+            }
+            self.chunks = out
+        }
+    }
+
+    convenience init(text: String, statusCode: Int = 200) {
+        self.init(body: Data(text.utf8), statusCode: statusCode)
+    }
+
+    func stream(
+        url: URL, method: String, headers: [String: String], body: Data?
+    ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
+        let response = HTTPURLResponse(
+            url: url, statusCode: statusCode, httpVersion: "HTTP/1.1",
+            headerFields: ["content-type": "text/event-stream"]
+        )!
+        let chunks = self.chunks
+        let stream = AsyncThrowingStream<Data, Error> { cont in
+            Task {
+                for c in chunks { cont.yield(c) }
+                cont.finish()
+            }
+        }
+        return (response, stream)
+    }
+}
+
+@Suite("SSEParser UTF-8 boundary buffering")
+struct SSEParserBoundaryTests {
+    @Test("multi-byte character split across ingest calls is not dropped")
+    func splitMultibyte() {
+        let parser = SSEParser()
+        // "café" — the é is 2 bytes (0xC3 0xA9). Split the line between them.
+        let full = Data("data: café\n\n".utf8)
+        let splitAt = full.firstIndex(of: 0xA9)! // second byte of é
+        parser.ingest(bytes: full.subdata(in: 0..<splitAt))
+        parser.ingest(bytes: full.subdata(in: splitAt..<full.count))
+        let messages = parser.drain()
+        #expect(messages.count == 1)
+        #expect(messages.first?.data == "café")
+    }
+
+    @Test("decodeUTF8Prefix keeps an incomplete trailing sequence")
+    func decodePrefix() {
+        // "aé" with the last byte of é chopped off.
+        var data = Data("a".utf8)
+        data.append(0xC3) // lead byte of é, incomplete
+        let (decoded, remaining) = SSEParser.decodeUTF8Prefix(data)
+        #expect(decoded == "a")
+        #expect(remaining == Data([0xC3]))
+    }
+}
+
+@Suite("parseSSE chunk consumption")
+struct ParseSSEChunkTests {
+    @Test("parses SSE messages from Data chunks split mid-line")
+    func chunkedParse() async throws {
+        let sse = "event: message\ndata: {\"n\":1}\n\ndata: {\"n\":2}\n\n"
+        let body = Data(sse.utf8)
+        let bytes = AsyncThrowingStream<Data, Error> { cont in
+            Task {
+                // Split so a line boundary falls inside a chunk.
+                cont.yield(body.subdata(in: 0..<10))
+                cont.yield(body.subdata(in: 10..<body.count))
+                cont.finish()
+            }
+        }
+        var datas: [String] = []
+        for try await msg in parseSSE(bytes: bytes) {
+            datas.append(msg.data)
+        }
+        #expect(datas == ["{\"n\":1}", "{\"n\":2}"])
+    }
+}
+
+@Suite("AssistantMessageStream producer/consumer split")
+struct AssistantMessageStreamSplitTests {
+    @Test("makeStream feeds events and settles a result via the continuation")
+    func makeStreamBasic() async {
+        let (stream, continuation) = AssistantMessageStream.makeStream()
+        let msg = fauxAssistantMessage("hi")
+        continuation.push(.start(partial: msg))
+        continuation.push(.done(reason: .stop, message: msg))
+        continuation.end(msg)
+
+        var types: [String] = []
+        for await event in stream { types.append(event.type) }
+        let result = await stream.result()
+        #expect(types == ["start", "done"])
+        #expect(result.stopReason == .stop)
+    }
+
+    @Test("cancelling a consumer task ends iteration promptly without a producer")
+    func cancellationEndsIteration() async {
+        // The stream is never pushed to nor ended. Without cancellation-aware
+        // iteration this would hang forever.
+        let (stream, _) = AssistantMessageStream.makeStream()
+        let task = Task<Int, Never> {
+            var count = 0
+            for await _ in stream { count += 1 }
+            return count
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+        let count = await task.value
+        #expect(count == 0)
+    }
+}
+
+@Suite("Anthropic terminal-state hardening")
+struct AnthropicTerminalTests {
+    static let model = Model(
+        id: "claude-test", name: "Claude Test",
+        api: "anthropic-messages", provider: "anthropic",
+        baseURL: "https://api.anthropic.com",
+        reasoning: false, input: [.text],
+        contextWindow: 128_000, maxTokens: 1024
+    )
+
+    @Test("stream closing without message_stop is surfaced as an error")
+    func prematureEOF() async {
+        let sse = """
+        event: message_start
+        data: {"type":"message_start","message":{"id":"m","role":"assistant","content":[],"model":"claude-test","usage":{"input_tokens":1,"output_tokens":0}}}
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+
+
+        """
+        let provider = AnthropicProvider(client: ChunkStubClient(text: sse), defaultAPIKey: "k")
+        let s = provider.stream(model: Self.model, context: Context(messages: [.user(UserMessage(text: "hi"))]), options: nil)
+        var terminal: AssistantMessage?
+        for await event in s {
+            if case .error(_, let err) = event { terminal = err }
+        }
+        let result = await s.result()
+        #expect(terminal?.stopReason == .error)
+        #expect(result.stopReason == .error)
+        #expect((result.errorMessage ?? "").contains("message_stop"))
+    }
+
+    @Test("refusal stop_reason is surfaced as an error, not a clean stop")
+    func refusal() async {
+        let sse = """
+        event: message_start
+        data: {"type":"message_start","message":{"id":"m","role":"assistant","content":[],"model":"claude-test","usage":{"input_tokens":1,"output_tokens":0}}}
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"No"}}
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0}
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":1}}
+
+        event: message_stop
+        data: {"type":"message_stop"}
+
+
+        """
+        let provider = AnthropicProvider(client: ChunkStubClient(text: sse), defaultAPIKey: "k")
+        let s = provider.stream(model: Self.model, context: Context(messages: [.user(UserMessage(text: "hi"))]), options: nil)
+        var sawError = false
+        for await event in s {
+            if case .error(_, let err) = event, err.stopReason == .error { sawError = true }
+        }
+        let result = await s.result()
+        #expect(sawError)
+        #expect(result.stopReason == .error)
+    }
+}
+
+@Suite("OpenAI Responses incomplete handling")
+struct OpenAIResponsesIncompleteTests {
+    static let model = Model(
+        id: "gpt-5-test", name: "GPT-5 Test",
+        api: "openai-responses", provider: "openai",
+        baseURL: "https://api.openai.com",
+        reasoning: true, input: [.text],
+        contextWindow: 128_000, maxTokens: 1024
+    )
+
+    @Test("response.incomplete finishes as length-truncated, not a clean stop")
+    func incomplete() async {
+        let sse = """
+        data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}
+
+        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}
+
+        data: {"type":"response.content_part.added","output_index":0,"part":{"type":"output_text"}}
+
+        data: {"type":"response.output_text.delta","output_index":0,"delta":"partial answer"}
+
+        data: {"type":"response.incomplete","response":{"id":"resp_1","status":"incomplete","usage":{"input_tokens":3,"output_tokens":2}}}
+
+
+        """
+        let provider = OpenAIResponsesProvider(client: ChunkStubClient(text: sse), webSocketClient: nil, defaultAPIKey: "k")
+        let s = provider.stream(model: Self.model, context: Context(messages: [.user(UserMessage(text: "hi"))]), options: nil)
+        for await _ in s {}
+        let result = await s.result()
+        #expect(result.stopReason == .length)
+        if case .text(let t)? = result.content.first {
+            #expect(t.text == "partial answer")
+        } else {
+            Issue.record("expected streamed text content")
+        }
+    }
+}
+
+@Suite("Bedrock reasoning signature capture")
+struct BedrockSignatureTests {
+    static let model = Model(
+        id: "anthropic.claude-sonnet-4-20250514-v1:0", name: "claude",
+        api: "bedrock-converse-stream", provider: "amazon-bedrock",
+        contextWindow: 200_000, maxTokens: 8192
+    )
+
+    private static func frame(_ type: String, _ payload: String) -> Data {
+        encodeAWSEventFrame(
+            headers: [":event-type": type, ":message-type": "event"],
+            payload: Data(payload.utf8)
+        )
+    }
+
+    @Test("reasoningContent.signature delta is captured onto the thinking block")
+    func capturesSignature() async {
+        var body = Data()
+        body.append(Self.frame("messageStart", "{\"role\":\"assistant\"}"))
+        body.append(Self.frame("contentBlockDelta", "{\"contentBlockIndex\":0,\"delta\":{\"reasoningContent\":{\"text\":\"thinking\"}}}"))
+        body.append(Self.frame("contentBlockDelta", "{\"contentBlockIndex\":0,\"delta\":{\"reasoningContent\":{\"signature\":\"SIG123\"}}}"))
+        body.append(Self.frame("contentBlockStop", "{\"contentBlockIndex\":0}"))
+        body.append(Self.frame("messageStop", "{\"stopReason\":\"end_turn\"}"))
+
+        let provider = BedrockProvider(
+            client: ChunkStubClient(body: body),
+            region: "us-east-1",
+            resolveProfileFiles: false,
+            credentialsProvider: { AWSSigV4.Credentials(accessKeyId: "k", secretAccessKey: "s") }
+        )
+        let s = provider.stream(model: Self.model, context: Context(messages: [.user(UserMessage(text: "hi"))]), options: nil)
+        for await _ in s {}
+        let result = await s.result()
+        if case .thinking(let th)? = result.content.first {
+            #expect(th.thinking == "thinking")
+            #expect(th.thinkingSignature == "SIG123")
+        } else {
+            Issue.record("expected a thinking block with a captured signature")
+        }
+    }
+}

--- a/Tests/KWWKAgentTests/AgentContextCompactorTests.swift
+++ b/Tests/KWWKAgentTests/AgentContextCompactorTests.swift
@@ -204,8 +204,8 @@ struct AgentContextCompactorTests {
             ),
             streamFn: { model, context, options in
                 await capture.record(context: context, sessionId: options?.sessionId)
-                let stream = AssistantMessageStream()
-                stream.end(AssistantMessage(
+                let (stream, continuation) = AssistantMessageStream.makeStream()
+                continuation.end(AssistantMessage(
                     content: [.text(TextContent(text: "custom stream summary"))],
                     api: model.api,
                     provider: model.provider,

--- a/Tests/KWWKAgentTests/AgentHardeningTests.swift
+++ b/Tests/KWWKAgentTests/AgentHardeningTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+/// Covers the Agent-core review findings: ergonomic steer/followUp overloads
+/// and exactly-one-turnStart-per-run.
+@Suite("Agent hardening")
+struct AgentHardeningTests {
+
+    private actor Counter {
+        var count = 0
+        func bump() { count += 1 }
+    }
+
+    // M15: steer/followUp gained String and UserMessage conveniences so callers
+    // don't have to wrap in `.user(...)`.
+    @Test("steer/followUp accept String and UserMessage without .user wrapping")
+    func steerConveniencesEnqueue() async {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let agent = Agent(initialState: AgentInitialState(model: registration.getModel()))
+        agent.steer("plain text")
+        agent.steer(UserMessage(text: "typed message"))
+        #expect(agent.queuedSteeringCount() == 2)
+
+        let queued = agent.queuedSteeringMessages()
+        if case .user(let first) = queued.first {
+            #expect(first.content.contains { block in
+                if case .text(let t) = block { return t.text == "plain text" }
+                return false
+            })
+        } else {
+            Issue.record("expected a user message at the front of the steering queue")
+        }
+    }
+
+    // Finding #8 / L12: run() pre-emits turnStart and previously entered the
+    // loop with firstTurn:false, so every run emitted two turnStart events.
+    @Test("a single-turn run emits exactly one turnStart")
+    func oneTurnStartPerRun() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let agent = Agent(initialState: AgentInitialState(model: registration.getModel()))
+        let counter = Counter()
+        let unsubscribe = agent.subscribe { event, _ in
+            if case .turnStart = event { await counter.bump() }
+        }
+        defer { unsubscribe() }
+
+        try await agent.prompt("hello")
+        #expect(await counter.count == 1)
+    }
+}

--- a/Tests/KWWKAgentTests/AgentTests.swift
+++ b/Tests/KWWKAgentTests/AgentTests.swift
@@ -123,13 +123,13 @@ struct AgentInitTests {
         let registration = await registerFauxProvider()
         defer { registration.unregister() }
 
-        let agent = await makeCodingAgent(CodingAgentConfig(
+        let agent = try await makeCodingAgent(CodingAgentConfig(
             model: registration.getModel(),
             cwd: FileManager.default.temporaryDirectory.path,
             tools: [],
             sessionId: "stable-session",
             bashEnvironment: [:]
-        ))
+        )).agent
 
         #expect(agent.sessionId == "stable-session")
         #expect(agent.autoCompact?.threshold == 0.75)
@@ -154,21 +154,21 @@ struct AgentInitTests {
         """.write(to: skillDir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let defaultAgent = await makeCodingAgent(CodingAgentConfig(
+        let defaultAgent = try await makeCodingAgent(CodingAgentConfig(
             model: registration.getModel(),
             cwd: root.path,
             tools: [],
             bashEnvironment: [:]
-        ))
+        )).agent
         #expect(!defaultAgent.state.systemPrompt.contains("<name>greeter</name>"))
 
-        let configuredAgent = await makeCodingAgent(CodingAgentConfig(
+        let configuredAgent = try await makeCodingAgent(CodingAgentConfig(
             model: registration.getModel(),
             cwd: root.path,
             tools: [],
             skillDirectories: [skillsRoot.path],
             bashEnvironment: [:]
-        ))
+        )).agent
         #expect(configuredAgent.state.systemPrompt.contains("<name>greeter</name>"))
     }
 }
@@ -480,7 +480,7 @@ struct AgentIntegrationTests {
         let streamed = await capture.streamed
         #expect(resolved?.model.id == registration.getModel().id)
         #expect(resolved?.sessionId == "session-auth")
-        #expect(streamed?.model.baseUrl == "https://proxy.example")
+        #expect(streamed?.model.baseURL == "https://proxy.example")
         #expect(streamed?.options?.apiKey == "resolved-token")
         #expect(streamed?.options?.sessionId == "session-auth")
         #expect(streamed?.options?.resolvedAuth?.scheme == .bearer)

--- a/Tests/KWWKAgentTests/BackgroundStallCompletionTests.swift
+++ b/Tests/KWWKAgentTests/BackgroundStallCompletionTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+/// A stall notification is a non-terminal heads-up: it must NOT suppress the
+/// task's eventual completion notification. Regression guard for the bug where
+/// the shared `notified` flag let a stall swallow the completion the tool
+/// documents ("you will be notified on completion").
+@Suite("Stall does not suppress completion", .serialized)
+struct BackgroundStallCompletionTests {
+    /// Lets the test release the runner once the stall has been observed.
+    final class Gate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var open = false
+        var isOpen: Bool { lock.withLock { open } }
+        func openGate() { lock.withLock { open = true } }
+    }
+
+    @Test("a stuck-then-finished task yields both a stall and a completion")
+    func stallThenComplete() async {
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let stallInterval: UInt64 = ProcessInfo.processInfo.environment["CI"] != nil ? 2 : 1
+        await manager.setStallTiming(intervalSeconds: stallInterval, thresholdSeconds: 0.05)
+
+        let received = Received()
+        _ = await manager.onNotification { n in await received.add(n) }
+
+        let gate = Gate()
+        struct StuckThenDoneRunner: BackgroundTaskRunner {
+            let spec = BackgroundTaskSpec(kind: "test", label: "stuck", description: nil, hardTimeoutSeconds: 60)
+            let gate: Gate
+            func run(
+                taskId: String,
+                outputFile: URL,
+                cancellation: CancellationHandle,
+                onDone: @escaping @Sendable (BackgroundTaskOutcome) -> Void
+            ) {
+                let gate = self.gate
+                Task.detached {
+                    // Prompt-shaped tail that never grows → looks stalled.
+                    _ = try? "waiting...\nContinue?".data(using: .utf8)?.write(to: outputFile)
+                    while !gate.isOpen && !cancellation.isCancelled {
+                        try? await Task.sleep(nanoseconds: 30_000_000)
+                    }
+                    onDone(BackgroundTaskOutcome(success: true, summary: "exit 0"))
+                }
+            }
+        }
+        let (taskId, _) = await manager.spawn(runner: StuckThenDoneRunner(gate: gate), sessionId: "s1")
+
+        // 1) Stall fires first.
+        let stalled = await awaitUntil(8000) {
+            await received.all().contains { $0.taskId == taskId && $0.stalled }
+        }
+        #expect(stalled)
+
+        // 2) Release the runner; the completion must still be delivered.
+        gate.openGate()
+        let completed = await awaitUntil(8000) {
+            await received.all().contains { $0.taskId == taskId && !$0.stalled && $0.status == .completed }
+        }
+        #expect(completed)
+    }
+}

--- a/Tests/KWWKAgentTests/BashOutputBoundingTests.swift
+++ b/Tests/KWWKAgentTests/BashOutputBoundingTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+/// The default (no-manager) bash path used to read its pipes only after
+/// `waitUntilExit`, deadlocking on any command whose output exceeded the
+/// ~64KB pipe buffer. These tests drive far more than that through both
+/// stdout and stderr; a regression would hang (child blocked in write(2),
+/// parent in wait) instead of completing.
+@Suite("Bash output draining + bounding")
+struct BashOutputBoundingTests {
+    @Test("large stdout does not deadlock and is tail-bounded")
+    func largeStdout() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
+        let result = try await tool.execute(
+            "call-1",
+            ["command": .string("seq 1 100000")],
+            nil, nil
+        )
+        let text = textOutput(result)
+        // Completed (didn't hang), tail preserved, and bounded well under the
+        // raw ~600KB the command emitted.
+        #expect(text.hasSuffix("100000"))
+        #expect(text.hasPrefix("[output truncated:"))
+        #expect(text.utf8.count < 200_000)
+    }
+
+    @Test("large stderr does not deadlock")
+    func largeStderr() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tool = createBashTool(
+            cwd: dir.path,
+            options: BashToolOptions(environment: testBashEnvironment)
+        )
+        // Exit 0 with everything on stderr; the body is the stderr stream.
+        let result = try await tool.execute(
+            "call-2",
+            ["command": .string("seq 1 100000 1>&2")],
+            nil, nil
+        )
+        let text = textOutput(result)
+        #expect(text.hasSuffix("100000"))
+    }
+}

--- a/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
+++ b/Tests/KWWKAgentTests/BuiltinSubagentDefinitionTests.swift
@@ -11,14 +11,14 @@ struct BuiltinSubagentDefinitionTests {
         #expect(general.tools == nil)
         #expect(general.prompt.contains("general-purpose coding agent"))
 
-        let explore = SubagentDefinition.explore(tools: .all)
-        #expect(explore.name == "Explore")
+        let explore = SubagentDefinition.explore(tools: .standard)
+        #expect(explore.name == "explore")
         #expect(explore.tools == .readOnly)
         #expect(explore.prompt.contains("read-only code exploration"))
         #expect(explore.prompt.contains("Do not edit"))
 
-        let plan = SubagentDefinition.plan(tools: .all)
-        #expect(plan.name == "Plan")
+        let plan = SubagentDefinition.plan(tools: .standard)
+        #expect(plan.name == "plan")
         #expect(plan.tools == .readOnly)
         #expect(plan.prompt.contains("read-only implementation planner"))
     }
@@ -29,14 +29,14 @@ struct BuiltinSubagentDefinitionTests {
             for: .readOnly,
             selection: [.general, .explore]
         )
-        #expect(readOnly.map(\.name) == ["general", "Explore"])
+        #expect(readOnly.map(\.name) == ["general", "explore"])
         #expect(readOnly.first { $0.name == "general" }?.tools == nil)
 
         let selected = SubagentDefinition.builtins(
-            for: .all,
+            for: .standard,
             selection: [.plan]
         )
-        #expect(selected.map(\.name) == ["Plan"])
+        #expect(selected.map(\.name) == ["plan"])
     }
 
     @Test("builtin selection parses CLI names")
@@ -52,12 +52,12 @@ struct BuiltinSubagentDefinitionTests {
         let base = CodingAgentConfig(
             model: .init(id: "m", name: "m", api: "a", provider: "p"),
             cwd: "/tmp",
-            tools: .all,
+            tools: .standard,
             bashEnvironment: testBashEnvironment
         )
 
         let configured = base.withBuiltinSubagents(.general.union(.plan))
-        #expect(configured.subagents.map { $0.name } == ["general", "Plan"])
+        #expect(configured.subagents.map { $0.name } == ["general", "plan"])
         #expect(base.subagents.isEmpty)
     }
 }

--- a/Tests/KWWKAgentTests/SessionHardeningTests.swift
+++ b/Tests/KWWKAgentTests/SessionHardeningTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+/// Covers the session-persistence review findings: ensureCreated must not
+/// truncate a resumed transcript, load must surface (not swallow) an
+/// undecodable entry, listing must count without decoding message bodies, and
+/// transcripts land 0600 in a 0700 directory.
+@Suite("Session hardening")
+struct SessionHardeningTests {
+
+    private func tempStore() -> (SessionStore, URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwsess-hardening-\(UUID().uuidString)")
+        return (SessionStore(directory: dir), dir)
+    }
+
+    private func userMsg(_ text: String) -> Message { .user(UserMessage(text: text)) }
+    private func assistantMsg(_ text: String) -> Message {
+        .assistant(AssistantMessage(
+            content: [.text(TextContent(text: text))],
+            api: "anthropic", provider: "anthropic", model: "claude-test"
+        ))
+    }
+
+    // H9: the recorder's ensureCreated used to unconditionally overwrite the
+    // file, wiping a resumed transcript to a header-only stub.
+    @Test("ensureCreated after resume preserves the persisted transcript")
+    func ensureCreatedNeverTruncates() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "resume-preserve"
+        try await store.append(id: id, cwd: "/w", message: userMsg("a"),
+                               model: "m1", provider: "p1")
+        try await store.append(id: id, cwd: "/w", message: assistantMsg("b"))
+
+        // Simulate a resuming SDK caller who (wrongly) calls ensureCreated on a
+        // recorder seeded with the already-persisted count.
+        let recorder = SessionRecorder(
+            store: store, sessionId: id, cwd: "/w",
+            model: "m1", provider: "p1", persistedCount: 2
+        )
+        await recorder.ensureCreated()
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages.count == 2)
+    }
+
+    @Test("createIfMissing creates a fresh file but leaves an existing one intact")
+    func createIfMissingIsIdempotent() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "if-missing"
+        try await store.createIfMissing(id: id, cwd: "/w")
+        try await store.append(id: id, cwd: "/w", message: userMsg("only"))
+        // Second call must be a no-op, not an overwrite.
+        try await store.createIfMissing(id: id, cwd: "/w")
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages.count == 1)
+    }
+
+    // M24: a mid-file entry that fails to decode must throw with a line number
+    // rather than silently dropping messages out of the conversation.
+    @Test("load throws on an undecodable mid-file entry")
+    func loadThrowsOnCorruptEntry() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "corrupt-mid"
+        try await store.append(id: id, cwd: "/w", message: userMsg("good"))
+        // Header = line 1, the good message = line 2. Append a line 3 whose
+        // `message` is a string, not a Message object → decode fails.
+        let url = dir.appendingPathComponent("\(id).jsonl")
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seekToEnd()
+        handle.write(Data(#"{"message":"not-an-object","timestamp":1,"type":"message"}"# .utf8))
+        handle.write(Data("\n".utf8))
+        try handle.close()
+
+        var caught: SessionStore.SessionStoreError?
+        do {
+            _ = try await store.load(id: id)
+        } catch let error as SessionStore.SessionStoreError {
+            caught = error
+        }
+        #expect(caught == .undecodableEntry(path: url.path, line: 3))
+    }
+
+    // M25: listing counts message lines and reads the latest meta without
+    // decoding the (potentially huge) message bodies.
+    @Test("listing counts messages and picks up meta without full decode")
+    func listingCountsCheaply() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "count-me"
+        try await store.append(id: id, cwd: "/w", message: userMsg("one"),
+                               model: "m1", provider: "p1")
+        try await store.append(id: id, cwd: "/w", message: assistantMsg("two"))
+        try await store.append(id: id, cwd: "/w", message: userMsg("three"))
+        try await store.setTitle(id: id, cwd: "/w", title: "My Session")
+
+        let infos = await store.list()
+        let info = try #require(infos.first { $0.id == id })
+        #expect(info.messageCount == 3)
+        #expect(info.title == "My Session")
+        #expect(info.model == "m1")
+    }
+
+    // L18: transcripts carry the full conversation + tool output, so they get
+    // the same 0600 file / 0700 dir treatment as background task logs.
+    @Test("session file is 0600 inside a 0700 directory")
+    func transcriptPermissionsLockedDown() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "locked"
+        try await store.create(id: id, cwd: "/w")
+
+        let fm = FileManager.default
+        let dirMode = try #require(
+            (try fm.attributesOfItem(atPath: dir.path)[.posixPermissions]) as? Int)
+        let fileMode = try #require(
+            (try fm.attributesOfItem(atPath: dir.appendingPathComponent("\(id).jsonl").path)[.posixPermissions]) as? Int)
+        #expect(dirMode == 0o700)
+        #expect(fileMode == 0o600)
+    }
+}

--- a/Tests/KWWKAgentTests/SessionResumeTests.swift
+++ b/Tests/KWWKAgentTests/SessionResumeTests.swift
@@ -12,19 +12,27 @@ struct SessionResumeTests {
     }
 
     @Test("pickInteractive resolves to a fresh session at the agent layer")
-    func pickInteractiveFallsBackFresh() async {
+    func pickInteractiveFallsBackFresh() async throws {
         let store = SessionStore(directory: tempDir())
-        let r = await store.resolveResume(.pickInteractive, cwd: "/x", freshId: "FIX")
+        let r = try await store.resolveResume(.pickInteractive, cwd: "/x", freshId: "FIX")
         #expect(r.sessionId == "FIX")
         #expect(r.resumed == false)
     }
 
     @Test("none resolves to a fresh session")
-    func noneFresh() async {
+    func noneFresh() async throws {
         let store = SessionStore(directory: tempDir())
-        let r = await store.resolveResume(.none, cwd: "/x", freshId: "FIX")
+        let r = try await store.resolveResume(.none, cwd: "/x", freshId: "FIX")
         #expect(r.sessionId == "FIX")
         #expect(r.resumed == false)
+    }
+
+    @Test("an invalid-format explicit id throws instead of minting a random session")
+    func invalidIdThrows() async {
+        let store = SessionStore(directory: tempDir())
+        await #expect(throws: SessionStore.SessionStoreError.invalidId("has spaces")) {
+            _ = try await store.resolveResume(.id("has spaces"), cwd: "/x", freshId: "FIX")
+        }
     }
 
     @Test("the four resume cases are distinct")

--- a/Tests/KWWKAgentTests/SessionStoreTests.swift
+++ b/Tests/KWWKAgentTests/SessionStoreTests.swift
@@ -167,7 +167,7 @@ struct SessionStoreTests {
         let raw = #"{"type":"session","version":999,"id":"sess-corrupt","cwd":"/w","createdAt":1}"# + "\n"
         try raw.data(using: .utf8)!.write(to: file)
 
-        let resolved = await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh-session")
+        let resolved = try await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh-session")
         #expect(!resolved.resumed)
         #expect(resolved.sessionId == "fresh-session")
         #expect((try? String(contentsOf: file, encoding: .utf8)) == raw)
@@ -345,7 +345,7 @@ struct SessionStoreTests {
                                model: "m1", provider: "p1")
         try await store.append(id: "s1", cwd: "/proj", message: assistantMsg("world"))
 
-        let resolved = await store.resolveResume(.latestForCwd, cwd: "/proj")
+        let resolved = try await store.resolveResume(.latestForCwd, cwd: "/proj")
         #expect(resolved.resumed)
         #expect(resolved.sessionId == "s1")
         #expect(resolved.messages.count == 2)
@@ -358,7 +358,7 @@ struct SessionStoreTests {
         let (store, dir) = tempStore()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        let resolved = await store.resolveResume(.none, cwd: "/proj", freshId: "fresh-1")
+        let resolved = try await store.resolveResume(.none, cwd: "/proj", freshId: "fresh-1")
         #expect(!resolved.resumed)
         #expect(resolved.sessionId == "fresh-1")
         #expect(resolved.messages.isEmpty)
@@ -483,7 +483,7 @@ struct SessionStoreTests {
         #expect(loaded.transcriptMessages.count > loaded.messages.count)
         #expect(loaded.persistedContextCount == 1)
 
-        let resolved = await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh")
+        let resolved = try await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh")
         #expect(resolved.resumed)
         #expect(resolved.messages == loaded.messages)
         #expect(resolved.persistedCount == loaded.persistedContextCount)

--- a/Tests/KWWKAgentTests/SubagentToolTests.swift
+++ b/Tests/KWWKAgentTests/SubagentToolTests.swift
@@ -12,21 +12,21 @@ struct SubagentToolTests {
         let cwd = makeTempDir()
         defer { try? FileManager.default.removeItem(at: cwd) }
 
-        let withoutSubagents = await makeCodingAgent(CodingAgentConfig(
+        let withoutSubagents = try await makeCodingAgent(CodingAgentConfig(
             model: faux.getModel(),
             cwd: cwd.path,
             tools: .readOnly,
             bashEnvironment: [:]
-        ))
+        )).agent
         #expect(!withoutSubagents.state.tools.contains { $0.name == "agent" })
 
-        let withSubagents = await makeCodingAgent(CodingAgentConfig(
+        let withSubagents = try await makeCodingAgent(CodingAgentConfig(
             model: faux.getModel(),
             cwd: cwd.path,
             tools: .readOnly,
             subagents: [minimalSubagent()],
             bashEnvironment: [:]
-        ))
+        )).agent
         #expect(withSubagents.state.tools.contains { $0.name == "agent" })
     }
 
@@ -426,7 +426,7 @@ struct SubagentToolTests {
         ])
         let tool = createAgentTool(
             cwd: FileManager.default.currentDirectoryPath,
-            subagents: [minimalSubagent(tools: .all)],
+            subagents: [minimalSubagent(tools: .standard)],
             parentModel: faux.getModel(),
             parentTools: .readOnly,
             bashEnvironment: testBashEnvironment

--- a/Tests/KWWKAgentTests/TmuxToolTests.swift
+++ b/Tests/KWWKAgentTests/TmuxToolTests.swift
@@ -17,9 +17,22 @@ private func resolvedTmuxPath() -> String? {
     return nil
 }
 
+/// Explicit environment for the tmux server in integration tests. tmux itself
+/// (socket under TMPDIR, config under HOME, terminal type) needs more than bare
+/// PATH, so pass a small curated slice of the host env rather than the whole
+/// thing — exercising the new required-environment contract realistically.
+private func tmuxTestEnvironment() -> [String: String] {
+    let host = ProcessInfo.processInfo.environment
+    var env = testBashEnvironment
+    for key in ["HOME", "TMPDIR", "TERM", "USER"] {
+        if let value = host[key] { env[key] = value }
+    }
+    return env
+}
+
 private func tmuxAvailable() async -> Bool {
     guard let tmuxPath = resolvedTmuxPath() else { return false }
-    return await TmuxSessionManager(tmuxPath: tmuxPath).isAvailable
+    return await TmuxSessionManager(tmuxPath: tmuxPath, environment: tmuxTestEnvironment()).isAvailable
 }
 
 private func makeSessionManager() -> TmuxSessionManager {
@@ -28,6 +41,7 @@ private func makeSessionManager() -> TmuxSessionManager {
     let id = UUID().uuidString.prefix(8)
     return TmuxSessionManager(
         tmuxPath: resolvedTmuxPath()!,
+        environment: tmuxTestEnvironment(),
         socketName: "kw-test-\(id)",
         sessionName: "t\(id)"
     )
@@ -89,7 +103,7 @@ struct TmuxSessionManagerTests {
 
     @Test("methods throw .unavailable when tmux is not on PATH")
     func unavailableRaises() async {
-        let manager = TmuxSessionManager(tmuxPath: "/definitely-not-real/tmux-absent")
+        let manager = TmuxSessionManager(tmuxPath: "/definitely-not-real/tmux-absent", environment: testBashEnvironment)
         await #expect(throws: TmuxError.self) {
             _ = try await manager.startPane(command: "echo hi")
         }
@@ -139,7 +153,7 @@ struct TmuxToolTests {
     @Test("createTmuxTool returns nil when tmux is unavailable")
     func gatedByAvailability() async {
         // Simulate by passing a manager with a bogus path.
-        let bogus = TmuxSessionManager(tmuxPath: "/definitely-not-a-real-path/tmux-nope")
+        let bogus = TmuxSessionManager(tmuxPath: "/definitely-not-a-real-path/tmux-nope", environment: testBashEnvironment)
         let tool = await createTmuxTool(
             manager: bogus,
             cwd: FileManager.default.currentDirectoryPath

--- a/Tests/KWWKAgentTests/ToolHardeningTests.swift
+++ b/Tests/KWWKAgentTests/ToolHardeningTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+@testable import KWWKAgent
+
+// Regression coverage for the file-tool / builder hardening pass.
+// Shared helpers (`makeTempDir`, `write`, `textOutput`) live in ReadToolTests.
+
+@Suite("Edit/Write preserve symlinks")
+struct SymlinkWriteTests {
+    @Test("edit writes through a symlink and leaves the link intact")
+    func editWritesThroughSymlink() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = dir.appendingPathComponent("target.txt")
+        try write("hello world", to: target)
+        let link = dir.appendingPathComponent("link.txt")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let tool = createEditTool(cwd: dir.path)
+        let edits: JSONValue = .array([
+            .object(["oldText": .string("world"), "newText": .string("swift")])
+        ])
+        _ = try await tool.execute(
+            "call-edit-symlink",
+            .object(["path": .string(link.path), "edits": edits]),
+            nil, nil
+        )
+
+        // The link is still a symlink pointing at the same target...
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: link.path)
+        #expect(destination == target.path)
+        // ...and the edit landed on the real target file, not a detached copy.
+        #expect(try String(contentsOf: target, encoding: .utf8) == "hello swift")
+    }
+
+    @Test("write writes through a symlink and leaves the link intact")
+    func writeWritesThroughSymlink() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = dir.appendingPathComponent("target.txt")
+        try write("original", to: target)
+        let link = dir.appendingPathComponent("link.txt")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let tool = createWriteTool(cwd: dir.path)
+        _ = try await tool.execute(
+            "call-write-symlink",
+            ["path": .string(link.path), "content": .string("replaced")],
+            nil, nil
+        )
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: link.path)
+        #expect(destination == target.path)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "replaced")
+    }
+
+    @Test("write preserves an existing file's inode")
+    func writePreservesInode() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("keep-inode.txt")
+        try write("before", to: file)
+        let before = try FileManager.default.attributesOfItem(atPath: file.path)[.systemFileNumber] as? Int
+
+        let tool = createWriteTool(cwd: dir.path)
+        _ = try await tool.execute(
+            "call-inode",
+            ["path": .string(file.path), "content": .string("after")],
+            nil, nil
+        )
+
+        let after = try FileManager.default.attributesOfItem(atPath: file.path)[.systemFileNumber] as? Int
+        #expect(before != nil)
+        #expect(before == after)
+        #expect(try String(contentsOf: file, encoding: .utf8) == "after")
+    }
+}
+
+@Suite("Grep filtering and context")
+struct GrepHardeningTests {
+    @Test("glob filters candidate files and pruned dirs are skipped")
+    func globAndPruning() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("needle here", to: dir.appendingPathComponent("a.swift"))
+        try write("needle there", to: dir.appendingPathComponent("b.txt"))
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("sub"), withIntermediateDirectories: true)
+        try write("needle nested", to: dir.appendingPathComponent("sub/c.swift"))
+        // A match inside .git must be pruned even though it is a plain text file.
+        let git = dir.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: git, withIntermediateDirectories: true)
+        try write("needle in git config", to: git.appendingPathComponent("config"))
+
+        let tool = createGrepTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-grep-glob",
+            ["pattern": .string("needle"), "path": .string(dir.path), "glob": .string("*.swift")],
+            nil, nil
+        )
+        let output = textOutput(result)
+        #expect(output.contains("a.swift"))
+        #expect(output.contains("c.swift"))
+        #expect(!output.contains("b.txt"))
+        #expect(!output.contains("config"))
+    }
+
+    @Test("context parameter emits surrounding lines")
+    func contextLines() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("ctx.txt")
+        try write("line before\nMATCH here\nline after", to: file)
+
+        let tool = createGrepTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-grep-ctx",
+            ["pattern": .string("MATCH"), "path": .string(file.path), "context": 1],
+            nil, nil
+        )
+        let output = textOutput(result)
+        #expect(output.contains("line before"))
+        #expect(output.contains("MATCH here"))
+        #expect(output.contains("line after"))
+        // The match line uses `:`, context lines use `-`.
+        #expect(output.contains("\(file.path):2:MATCH here"))
+        #expect(output.contains("\(file.path)-1-line before"))
+        #expect(output.contains("\(file.path)-3-line after"))
+    }
+
+    @Test("binary files are skipped")
+    func skipsBinary() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("needle text", to: dir.appendingPathComponent("text.txt"))
+        // A file containing a NUL byte next to the pattern bytes.
+        var binary = Data("needle".utf8)
+        binary.append(0)
+        binary.append(Data("binary".utf8))
+        try binary.write(to: dir.appendingPathComponent("blob.bin"))
+
+        let tool = createGrepTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-grep-bin",
+            ["pattern": .string("needle"), "path": .string(dir.path)],
+            nil, nil
+        )
+        let output = textOutput(result)
+        #expect(output.contains("text.txt"))
+        #expect(!output.contains("blob.bin"))
+    }
+}
+
+@Suite("Glob translation")
+struct GlobHardeningTests {
+    @Test("bracket characters are matched literally, not as a character class")
+    func bracketsAreLiteral() {
+        #expect(Glob.matches(path: "file[1].txt", pattern: "file[1].txt"))
+        #expect(!Glob.matches(path: "file1.txt", pattern: "file[1].txt"))
+    }
+
+    @Test("expand prunes VCS and dependency directories")
+    func expandPrunes() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write("x", to: dir.appendingPathComponent("keep.swift"))
+        for pruned in [".git", "node_modules"] {
+            let sub = dir.appendingPathComponent(pruned)
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            try write("x", to: sub.appendingPathComponent("ignored.swift"))
+        }
+        let matches = Glob.expand(root: dir.path, pattern: "**/*.swift")
+        #expect(matches.contains { $0.hasSuffix("keep.swift") })
+        #expect(!matches.contains { $0.contains("/.git/") })
+        #expect(!matches.contains { $0.contains("/node_modules/") })
+    }
+}
+
+@Suite("Coding agent tmux configuration")
+struct TmuxConfigValidationTests {
+    private func model() -> Model {
+        Model(id: "m", name: "m", api: "a", provider: "p")
+    }
+
+    @Test("tmux on the agent's tools without a manager throws at build time")
+    func agentToolsTmuxThrows() async throws {
+        await #expect(throws: CodingAgentConfigError.self) {
+            _ = try await makeCodingAgent(CodingAgentConfig(
+                model: model(),
+                cwd: "/tmp",
+                tools: .allIncludingTmux,
+                bashEnvironment: [:]
+            ))
+        }
+    }
+
+    @Test("tmux on a subagent's tools without a manager throws at build time")
+    func subagentTmuxThrows() async throws {
+        let sub = SubagentDefinition(
+            name: "pty",
+            description: "d",
+            prompt: "p",
+            tools: [.read, .tmux]
+        )
+        await #expect(throws: CodingAgentConfigError.self) {
+            _ = try await makeCodingAgent(CodingAgentConfig(
+                model: model(),
+                cwd: "/tmp",
+                tools: .readOnly,
+                subagents: [sub],
+                bashEnvironment: [:]
+            ))
+        }
+    }
+}

--- a/Tests/KWWKAgentTests/TruncateTailTests.swift
+++ b/Tests/KWWKAgentTests/TruncateTailTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+
+@Suite("Truncate.truncateTail")
+struct TruncateTailTests {
+    @Test("short content passes through untouched")
+    func passthrough() {
+        let r = Truncate.truncateTail("a\nb\nc")
+        #expect(!r.truncated)
+        #expect(r.content == "a\nb\nc")
+        #expect(r.outputLines == 3)
+    }
+
+    @Test("keeps the last lines when the line budget is exceeded")
+    func lineBudget() {
+        let content = (1...100).map { "line \($0)" }.joined(separator: "\n")
+        let r = Truncate.truncateTail(content, maxLines: 10, maxBytes: 1_000_000)
+        #expect(r.truncated)
+        #expect(r.truncatedBy == "lines")
+        #expect(r.outputLines == 10)
+        // Tail is kept: last line survives, earliest lines are dropped.
+        #expect(r.content.hasSuffix("line 100"))
+        #expect(!r.content.contains("line 1\n"))
+        #expect(r.content.hasPrefix("line 91"))
+    }
+
+    @Test("keeps the last bytes when the byte budget is exceeded")
+    func byteBudget() {
+        let content = (1...100).map { "line \($0)" }.joined(separator: "\n")
+        let r = Truncate.truncateTail(content, maxLines: 10_000, maxBytes: 20)
+        #expect(r.truncated)
+        #expect(r.truncatedBy == "bytes")
+        #expect(r.outputBytes <= 20)
+        #expect(r.content.hasSuffix("line 100"))
+    }
+
+    @Test("boundBashOutput prepends a notice only when truncated")
+    func boundNotice() {
+        #expect(boundBashOutput("hello") == "hello")
+        let big = (1...5000).map { "row \($0)" }.joined(separator: "\n")
+        let bounded = boundBashOutput(big)
+        #expect(bounded.hasPrefix("[output truncated:"))
+        #expect(bounded.hasSuffix("row 5000"))
+    }
+}

--- a/Tests/KWWKCliTests/BuiltinSubagentsTests.swift
+++ b/Tests/KWWKCliTests/BuiltinSubagentsTests.swift
@@ -8,25 +8,25 @@ struct BuiltinSubagentsTests {
     func readOnlyBuiltins() {
         let agents = defaultCLISubagents(for: .readOnly)
         let names = agents.map(\.name)
-        #expect(names == ["general", "Explore", "Plan"])
+        #expect(names == ["general", "explore", "plan"])
         #expect(agents.first { $0.name == "general" }?.tools == nil)
-        #expect(agents.first { $0.name == "Explore" }?.tools == .readOnly)
-        #expect(agents.first { $0.name == "Plan" }?.tools == .readOnly)
+        #expect(agents.first { $0.name == "explore" }?.tools == .readOnly)
+        #expect(agents.first { $0.name == "plan" }?.tools == .readOnly)
     }
 
     @Test("bash-enabled CLI tools keep the same default subagent set")
     func bashBuiltins() {
-        let agents = defaultCLISubagents(for: .all)
+        let agents = defaultCLISubagents(for: .standard)
         let names = agents.map(\.name)
-        #expect(names == ["general", "Explore", "Plan"])
+        #expect(names == ["general", "explore", "plan"])
         #expect(agents.first { $0.name == "general" }?.tools == nil)
     }
 
     @Test("CLI subagent selection can disable or narrow builtins")
     func selectedBuiltins() {
-        #expect(defaultCLISubagents(for: .all, selection: .none).isEmpty)
+        #expect(defaultCLISubagents(for: .standard, selection: .none).isEmpty)
 
-        let agents = defaultCLISubagents(for: .all, selection: [.general, .plan])
-        #expect(agents.map(\.name) == ["general", "Plan"])
+        let agents = defaultCLISubagents(for: .standard, selection: [.general, .plan])
+        #expect(agents.map(\.name) == ["general", "plan"])
     }
 }

--- a/Tests/KWWKCliTests/LoginLogoutModalTests.swift
+++ b/Tests/KWWKCliTests/LoginLogoutModalTests.swift
@@ -244,7 +244,7 @@ struct LoginLogoutModalTests {
         // The active slot, model, and resolver are untouched.
         #expect(ctx.sessionProviders.slot(forStoreId: "anthropic") != nil)
         #expect(ctx.agent.state.model.id == "claude")
-        #expect(await authResolvers.resolve(incumbent, nil)?.token == "live-token")
+        #expect(try await authResolvers.resolve(incumbent, nil)?.token == "live-token")
     }
 
     @MainActor
@@ -368,7 +368,7 @@ struct LoginLogoutModalTests {
             let (ctx, harness) = await makeContext(authResolvers: authResolvers)
             let template = Model(
                 id: "z-ai/glm-5.2", api: "openai-completions", provider: "openrouter",
-                baseUrl: "https://openrouter.ai/api/v1"
+                baseURL: "https://openrouter.ai/api/v1"
             )
             ctx.sessionProviders.upsert(ProviderSlot(
                 storeId: "openrouter", catalogProvider: "openrouter",
@@ -400,7 +400,7 @@ struct LoginLogoutModalTests {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("kwwk-login-modal-\(UUID().uuidString.prefix(8))")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+        return try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
     }
 
     /// SlashContext wired to a recording modal host + notifier. The faux

--- a/Tests/KWWKCliTests/ModelSelectorModalTests.swift
+++ b/Tests/KWWKCliTests/ModelSelectorModalTests.swift
@@ -10,7 +10,7 @@ private func model(_ id: String, provider: String = "anthropic") -> Model {
         name: id,
         api: "anthropic-messages",
         provider: provider,
-        baseUrl: "https://api.anthropic.com",
+        baseURL: "https://api.anthropic.com",
         reasoning: false,
         input: [.text],
         contextWindow: 0,

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -14,7 +14,7 @@ struct MultiProviderAuthTests {
             .appendingPathComponent("kwwk-multilogin-\(UUID().uuidString.prefix(8))")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent("oauth.json")
-        let store = OAuthStore(url: url)
+        let store = try OAuthStore(url: url)
 
         try await store.set(OAuthCredentials(access: "a", refresh: "ra", expires: .max), for: "anthropic")
         try await store.set(OAuthCredentials(access: "c", refresh: "rc", expires: .max), for: "openai-codex")
@@ -22,7 +22,7 @@ struct MultiProviderAuthTests {
         #expect(all.keys.sorted() == ["anthropic", "openai-codex"])
 
         // Re-persist through a fresh store instance to confirm it round-trips.
-        let reopened = OAuthStore(url: url)
+        let reopened = try OAuthStore(url: url)
         #expect(await reopened.get("anthropic")?.access == "a")
         #expect(await reopened.get("openai-codex")?.access == "c")
     }
@@ -72,7 +72,7 @@ struct MultiProviderAuthTests {
             let dir = FileManager.default.temporaryDirectory
                 .appendingPathComponent("kwwk-openrouter-\(UUID().uuidString.prefix(8))")
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            let store = OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+            let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
             try await store.set(OAuthCredentials(
                 access: "sk-or-test", refresh: "", expires: .max,
                 extras: ["defaultModel": .string("z-ai/glm-5.2")]
@@ -84,7 +84,7 @@ struct MultiProviderAuthTests {
             #expect(resolved?.model.id == "z-ai/glm-5.2")
             #expect(resolved?.model.provider == "openrouter")
             #expect(resolved?.model.api == "openai-completions")
-            #expect(resolved?.model.baseUrl == "https://openrouter.ai/api/v1")
+            #expect(resolved?.model.baseURL == "https://openrouter.ai/api/v1")
             // Catalog metadata — including the OpenRouter reasoning format the
             // completions encoder needs — rides along. Compare against the live
             // catalog entry (not a pinned number) so a catalog regeneration
@@ -106,7 +106,7 @@ struct MultiProviderAuthTests {
             let dir = FileManager.default.temporaryDirectory
                 .appendingPathComponent("kwwk-openrouter-\(UUID().uuidString.prefix(8))")
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            let store = OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+            let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
             // No defaultModel stored → sensible default.
             try await store.set(OAuthCredentials(
                 access: "sk-or-test", refresh: "", expires: .max
@@ -123,7 +123,7 @@ struct MultiProviderAuthTests {
                 modelOverride: "somelab/brand-new-model", context1m: false
             )
             #expect(custom?.model.id == "somelab/brand-new-model")
-            #expect(custom?.model.baseUrl == "https://openrouter.ai/api/v1")
+            #expect(custom?.model.baseURL == "https://openrouter.ai/api/v1")
             #expect(custom?.model.compat?.thinkingFormat == "openrouter")
             await APIRegistry.shared.unregisterScope("openrouter")
         }
@@ -132,7 +132,7 @@ struct MultiProviderAuthTests {
     // MARK: - Unified resolver dispatch
 
     @Test("SessionAuthResolvers dispatches by model.provider and supports mid-session add/remove")
-    func resolverDispatch() async {
+    func resolverDispatch() async throws {
         let resolvers = SessionAuthResolvers()
         await resolvers.set(scope: "anthropic") { _, _ in
             ResolvedProviderAuth(token: "anthropic-token", scheme: .bearer)
@@ -145,22 +145,22 @@ struct MultiProviderAuthTests {
         let codexModel = Model(id: "gpt", api: "chatgpt-codex", provider: "chatgpt-codex")
         let staticModel = Model(id: "k", api: "openai-responses", provider: "openai")
 
-        #expect(await resolvers.resolve(anthropicModel, nil)?.token == "anthropic-token")
-        #expect(await resolvers.resolve(codexModel, nil)?.token == "codex-token")
+        #expect(try await resolvers.resolve(anthropicModel, nil)?.token == "anthropic-token")
+        #expect(try await resolvers.resolve(codexModel, nil)?.token == "codex-token")
         // A static (api-key) provider has no resolver → nil → baked key used.
-        #expect(await resolvers.resolve(staticModel, nil) == nil)
+        #expect(try await resolvers.resolve(staticModel, nil) == nil)
 
         // The stable delegating closure sees a provider added later (`/login`).
         let delegate = resolvers.delegatingResolver()
-        #expect(await delegate(staticModel, nil) == nil)
+        #expect(try await delegate(staticModel, nil) == nil)
         await resolvers.set(scope: "openai") { _, _ in
             ResolvedProviderAuth(token: "openai-token", scheme: .bearer)
         }
-        #expect(await delegate(staticModel, nil)?.token == "openai-token")
+        #expect(try await delegate(staticModel, nil)?.token == "openai-token")
 
         // Removal (`/logout`) drops it again.
         await resolvers.remove(scope: "openai")
-        #expect(await delegate(staticModel, nil) == nil)
+        #expect(try await delegate(staticModel, nil) == nil)
     }
 
     // MARK: - SessionProviders bookkeeping
@@ -199,32 +199,32 @@ struct MultiProviderAuthTests {
         // Codex `maxTokens == 0` sentinel.
         let codexTemplate = Model(
             id: "gpt-5.5", api: "chatgpt-codex", provider: "chatgpt-codex",
-            baseUrl: "https://chatgpt.com", maxTokens: 0
+            baseURL: "https://chatgpt.com", maxTokens: 0
         )
         let picked = Model(
             id: "gpt-5.5-codex", api: "openai-responses", provider: "openai-codex",
-            baseUrl: "https://api.openai.com", maxTokens: 128_000
+            baseURL: "https://api.openai.com", maxTokens: 128_000
         )
         let routed = adoptFields(from: codexTemplate, into: picked)
         #expect(routed.id == "gpt-5.5-codex")
         #expect(routed.provider == "chatgpt-codex")
         #expect(routed.api == "chatgpt-codex")
-        #expect(routed.baseUrl == "https://chatgpt.com")
+        #expect(routed.baseURL == "https://chatgpt.com")
         #expect(routed.maxTokens == 0)
 
-        // Same-provider switch (Copilot enterprise) keeps the session baseUrl.
+        // Same-provider switch (Copilot enterprise) keeps the session baseURL.
         let copilotTemplate = Model(
             id: "gpt-5.5", api: "openai-responses", provider: "github-copilot",
-            baseUrl: "https://api.business.githubcopilot.com"
+            baseURL: "https://api.business.githubcopilot.com"
         )
         let copilotPick = Model(
             id: "claude-opus-4-8", api: "anthropic-messages", provider: "github-copilot",
-            baseUrl: "https://api.individual.githubcopilot.com"
+            baseURL: "https://api.individual.githubcopilot.com"
         )
         let copilotRouted = adoptFields(from: copilotTemplate, into: copilotPick)
         #expect(copilotRouted.provider == "github-copilot")
         #expect(copilotRouted.api == "anthropic-messages")
-        #expect(copilotRouted.baseUrl == "https://api.business.githubcopilot.com")
+        #expect(copilotRouted.baseURL == "https://api.business.githubcopilot.com")
     }
 
     @Test("adoptFields keeps per-model compat + thinkingLevelMap")
@@ -233,11 +233,11 @@ struct MultiProviderAuthTests {
         compat.thinkingFormat = "openrouter"
         let template = Model(
             id: "anthropic/claude-sonnet-5", api: "openai-completions",
-            provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1"
+            provider: "openrouter", baseURL: "https://openrouter.ai/api/v1"
         )
         let picked = Model(
             id: "z-ai/glm-5.2", api: "openai-completions",
-            provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1",
+            provider: "openrouter", baseURL: "https://openrouter.ai/api/v1",
             compat: compat, thinkingLevelMap: ["xhigh": "xhigh"]
         )
         let routed = adoptFields(from: template, into: picked)

--- a/Tests/KWWKCliTests/ReviewFixesTests.swift
+++ b/Tests/KWWKCliTests/ReviewFixesTests.swift
@@ -31,7 +31,7 @@ struct AdoptFieldsMaxTokensTests {
             name: id,
             api: api,
             provider: provider,
-            baseUrl: "https://example",
+            baseURL: "https://example",
             reasoning: false,
             input: [.text],
             contextWindow: 0,
@@ -63,10 +63,10 @@ struct AdoptFieldsMaxTokensTests {
 @Suite("adoptFields session routing")
 struct AdoptFieldsSessionRoutingTests {
     private func model(
-        id: String, api: String, provider: String, baseUrl: String, maxTokens: Int = 4096
+        id: String, api: String, provider: String, baseURL: String, maxTokens: Int = 4096
     ) -> Model {
         Model(
-            id: id, name: id, api: api, provider: provider, baseUrl: baseUrl,
+            id: id, name: id, api: api, provider: provider, baseURL: baseURL,
             reasoning: false, input: [.text], contextWindow: 0, maxTokens: maxTokens
         )
     }
@@ -74,24 +74,24 @@ struct AdoptFieldsSessionRoutingTests {
     @Test("same-provider swap keeps the session's baseUrl")
     func sameProviderPreservesBaseUrl() {
         // Mimics the real bug: user logs in with anthropic-api-key using a
-        // custom baseUrl (e.g. a corporate proxy). `/model` switching to
+        // custom baseURL (e.g. a corporate proxy). `/model` switching to
         // another Claude model from the catalog must not drop that host
         // in favor of the catalog's `https://api.anthropic.com`.
         let current = model(
             id: "claude-sonnet-4-5-20250929",
             api: "anthropic-messages",
             provider: "anthropic",
-            baseUrl: "https://proxy.example.com"
+            baseURL: "https://proxy.example.com"
         )
         let picked = model(
             id: "claude-haiku-4-5",
             api: "anthropic-messages",
             provider: "anthropic",
-            baseUrl: "https://api.anthropic.com"
+            baseURL: "https://api.anthropic.com"
         )
         let result = adoptFields(from: current, into: picked)
         #expect(result.id == "claude-haiku-4-5")
-        #expect(result.baseUrl == "https://proxy.example.com",
+        #expect(result.baseURL == "https://proxy.example.com",
                 "session baseUrl must survive same-provider /model swap")
     }
 
@@ -101,23 +101,23 @@ struct AdoptFieldsSessionRoutingTests {
         // proxy endpoint onto the initial model. Switching from a
         // completions-wire model (gpt-4.1) to an anthropic-messages-wire
         // model (claude-sonnet-4.5) must carry picked.api through, but
-        // keep the enterprise baseUrl.
+        // keep the enterprise baseURL.
         let current = model(
             id: "gpt-4.1",
             api: "openai-completions",
             provider: "github-copilot",
-            baseUrl: "https://api.business.githubcopilot.com"
+            baseURL: "https://api.business.githubcopilot.com"
         )
         let picked = model(
             id: "claude-sonnet-4.5",
             api: "anthropic-messages",
             provider: "github-copilot",
-            baseUrl: "https://api.individual.githubcopilot.com"
+            baseURL: "https://api.individual.githubcopilot.com"
         )
         let result = adoptFields(from: current, into: picked)
         #expect(result.api == "anthropic-messages",
                 "picked's wire format must be used — routing by api key")
-        #expect(result.baseUrl == "https://api.business.githubcopilot.com",
+        #expect(result.baseURL == "https://api.business.githubcopilot.com",
                 "session (enterprise) baseUrl must survive the cross-wire swap")
     }
 }

--- a/Tests/KWWKCliTests/TUIClusterFixTests.swift
+++ b/Tests/KWWKCliTests/TUIClusterFixTests.swift
@@ -1,0 +1,125 @@
+import Testing
+import Foundation
+@testable import KWWKCli
+
+/// Covers the TUI/perf review-fix cluster: grapheme-aware widths, Kitty CSI-u
+/// punctuation decoding, and linear bracketed-paste accumulation.
+@Suite("TUI cluster fixes")
+struct TUIClusterFixTests {
+
+    // MARK: - Width table (finding 5)
+
+    @Test("ZWJ emoji sequence is one 2-column glyph")
+    func zwjFamilyWidth() {
+        // 👨‍👩‍👧 = man ZWJ woman ZWJ girl — a single rendered glyph.
+        let family = "👨‍👩‍👧"
+        #expect(ANSI.graphemeWidth(Character(family)) == 2)
+        #expect(ANSI.visibleWidth(family) == 2)
+    }
+
+    @Test("skin-tone modifier composes onto its base (width 2, not 4)")
+    func skinToneWidth() {
+        let thumbs = "👍🏽"
+        #expect(ANSI.graphemeWidth(Character(thumbs)) == 2)
+        #expect(ANSI.visibleWidth(thumbs) == 2)
+    }
+
+    @Test("regional-indicator flag is one 2-column glyph")
+    func flagWidth() {
+        let us = "🇺🇸"
+        #expect(ANSI.graphemeWidth(Character(us)) == 2)
+        #expect(ANSI.visibleWidth(us) == 2)
+        // Two flags side by side = 4 columns.
+        #expect(ANSI.visibleWidth("🇺🇸🇬🇧") == 4)
+    }
+
+    @Test("modern Extended-A pictographs (U+1FA70–1FAFF) are width 2")
+    func extendedAEmojiWidth() {
+        #expect(ANSI.columnWidth(of: 0x1FA79) == 2) // adhesive bandage
+        #expect(ANSI.columnWidth(of: 0x1FAB4) == 2) // potted plant
+        #expect(ANSI.graphemeWidth("🩹") == 2)
+    }
+
+    @Test("plain ASCII and CJK widths are unchanged")
+    func baselineWidths() {
+        #expect(ANSI.visibleWidth("hello") == 5)
+        #expect(ANSI.visibleWidth("你好") == 4)
+        #expect(ANSI.graphemeWidth("a") == 1)
+        #expect(ANSI.graphemeWidth("中") == 2)
+    }
+
+    // MARK: - Kitty CSI-u punctuation (finding 9)
+
+    @Test("Ctrl+/ decodes to name \"/\" with ctrl on kitty terminals")
+    func kittyCtrlSlash() {
+        // CSI 47 ; 5 u  →  '/' (0x2F) with ctrl (mod 5 = 1 + ctrl).
+        let ev = Keys.parse("\u{1B}[47;5u")
+        #expect(ev?.name == "/")
+        #expect(ev?.ctrl == true)
+    }
+
+    @Test("Ctrl+_ decodes to name \"_\" with ctrl on kitty terminals")
+    func kittyCtrlUnderscore() {
+        let ev = Keys.parse("\u{1B}[95;5u")
+        #expect(ev?.name == "_")
+        #expect(ev?.ctrl == true)
+    }
+
+    @Test("kitty letters still lower-case with modifiers preserved")
+    func kittyLetterStillWorks() {
+        // CSI 97 ; 5 u = Ctrl+a
+        let ev = Keys.parse("\u{1B}[97;5u")
+        #expect(ev?.name == "a")
+        #expect(ev?.ctrl == true)
+    }
+
+    // MARK: - Bracketed paste accumulation (finding 2)
+
+    @Test("bracketed paste split across chunks yields one sequence")
+    func pasteAcrossChunks() {
+        let buf = StdinBuffer()
+        // Start marker + first half, no terminator yet.
+        var out = buf.feed("\u{1B}[200~hello ")
+        #expect(out.isEmpty)
+        // Rest of the body + terminator arrives in a later chunk.
+        out = buf.feed("world\u{1B}[201~")
+        #expect(out.count == 1)
+        #expect(out.first == "\u{1B}[200~hello world\u{1B}[201~")
+    }
+
+    @Test("large paste accumulates intact regardless of chunk boundaries")
+    func largePasteReassembles() {
+        let buf = StdinBuffer()
+        let body = String(repeating: "x", count: 200_000)
+        let full = "\u{1B}[200~" + body + "\u{1B}[201~"
+        let bytes = Array(full.utf8)
+        // Feed in many 4 KB chunks, mimicking stdin reads.
+        var out: [String] = []
+        var i = 0
+        while i < bytes.count {
+            let end = min(i + 4096, bytes.count)
+            out += buf.feed(Data(bytes[i..<end]))
+            i = end
+        }
+        #expect(out.count == 1)
+        #expect(out.first == full)
+    }
+
+    @Test("ordinary keystrokes still split correctly after the cursor rewrite")
+    func plainKeysStillSplit() {
+        let buf = StdinBuffer()
+        let out = buf.feed("abc")
+        #expect(out == ["a", "b", "c"])
+        // A CSI arrow arrives whole.
+        #expect(buf.feed("\u{1B}[A") == ["\u{1B}[A"])
+    }
+
+    @Test("terminator straddling a chunk boundary is still found")
+    func terminatorStraddlesBoundary() {
+        let buf = StdinBuffer()
+        #expect(buf.feed("\u{1B}[200~data\u{1B}[20").isEmpty)
+        let out = buf.feed("1~")
+        #expect(out.count == 1)
+        #expect(out.first == "\u{1B}[200~data\u{1B}[201~")
+    }
+}

--- a/Tests/KWWKCliTests/TUIRenderTests.swift
+++ b/Tests/KWWKCliTests/TUIRenderTests.swift
@@ -562,10 +562,14 @@ struct TUIInlineResizeReflowTests {
         // still drop back down by 2 (CSI 2 B) before rewinding to the top.
         let terminal = VirtualTerminal(width: 40, height: 10)
         let tui = TUI(terminal: terminal)
-        tui.addChild(TestLinesComponent([CURSOR_MARKER + "input", "border", "state"]))
+        let comp = TestLinesComponent([CURSOR_MARKER + "input", "border", "state"])
+        tui.addChild(comp)
         tui.start()
         await terminal.waitForRender()
 
+        // Change a row so the frame isn't suppressed as a no-op — an
+        // identical frame is (correctly) skipped entirely these days.
+        comp.lines = [CURSOR_MARKER + "input", "border", "state ✳"]
         terminal.clearWrites()
         tui.requestRender()
         await terminal.waitForRender()


### PR DESCRIPTION
## Summary

A full multi-dimension review of the SDK + CLI (7 parallel review dimensions, every finding adversarially verified — full report in `Docs/holistic-review-2026-07-06.md`) confirmed 69 issues. This PR fixes all of them, guided by one philosophy: **no defensive programming** — errors throw and propagate, dead options are deleted rather than guarded, configuration fails fast, invalid states become unrepresentable.

## Highlights by area

### KWWKAI transport/streaming
- One long-lived `URLSession` per `HTTPClient` (TCP/TLS reuse); body streams deliver `Data` chunks instead of single bytes (~1000× less stream overhead)
- Cancellation aborts the in-flight request immediately — even during a silent stream gap; `AssistantMessageStream` honors task cancellation and splits producer/consumer via `makeStream()`
- Honest terminal states: Anthropic `refusal`/premature EOF → error, OpenAI Responses `response.incomplete` → `.length`, Bedrock captures thinking signatures, encrypted reasoning is captured and replayed
- Tool-call JSON parses once at block end (was O(n²) per delta); SSE parser buffers split UTF-8; Gemini/Bedrock include HTTP error bodies

### OAuth/registry
- Concurrent token refreshes dedupe through one in-flight task per provider — fixes intermittent logouts from rotated refresh tokens
- Corrupt `oauth.json` throws instead of being silently overwritten; created 0600 atomically; resolver distinguishes "no credentials" (nil) from "refresh failed" (throws)
- Registry never falls back across vendors (no API-key leakage to a foreign baseURL); interactive login callbacks moved from the SDK into the CLI

### Agent runtime
- Bash/tmux pipes drain concurrently with the wait — no more deadlock past the 64KB pipe buffer; commands run in their own process group and are signalled as a group; foreground output is tail-truncated
- tmux requires an explicit environment (host env, including API keys, no longer leaks into panes); `.tmux` without a manager throws at `makeCodingAgent` time instead of `preconditionFailure` at tool-call time
- Edit/Write write in place — symlinks, hard links, inodes, and permissions survive; grep/find prune `.git`/`node_modules`, honor `glob`/`context`, compile patterns once
- `SessionRecorder` never truncates an existing session file; invalid resume ids and undecodable entries throw; session files 0600/dir 0700; `sessionId` is immutable; `makeCodingAgent` returns `CodingAgent` exposing the auto-continue `detachBackground` handle

### CLI/TUI
- `/compact` runs under the busy gate with progress — a prompt submitted mid-compact no longer gets its turn clobbered
- Ctrl-C follows the pi/omp two-stage convention (cancel stream / clear input, then exit); SIGINT/SIGTERM run the full graceful shutdown
- Row-level live-zone diffing under DEC 2026 synchronized output; no-op frames skipped; SIGWINCH repaints coalesce (leading + trailing); paste is O(n)
- Grapheme-cluster widths (ZWJ sequences, skin tones, U+1FA70 emoji) keep the prompt box and IME cursor aligned; `--resume` uses the same arrow-key picker as `/resume`; startup refreshes only the active provider's token

## Breaking API changes (pre-1.0)

- `makeCodingAgent` is now `async throws` and returns `CodingAgent` (use `.agent`)
- Auth-resolver closures are `async throws`
- `HTTPClient` stream element `UInt8` → `Data`; `URLSessionHTTPClient` is a class
- `OAuthStore(url:)` throws; `EnvAPIKeys` requires an explicit env snapshot
- `SessionStore.resolveResume` throws; `Agent.sessionId` is `let`
- `Model.baseUrl` → `Model.baseURL` (wire/persisted key stays `"baseUrl"` via CodingKeys)
- Removed: `CodingTools.all`, `ReadToolOptions.autoResizeImages`, `OAuthLogin.Callbacks` interactive defaults

## Test plan

- 882 tests in 155 suites pass (10 new test files covering the fixed behaviors: pipe-deadlock regression, refresh-race dedup, no-truncate resume, 0600 perms, UTF-8 boundary, grapheme widths, large-paste reassembly, …)
- Release build clean
- TUI smoke-tested in tmux: welcome screen, emoji/CJK input alignment, two-stage Ctrl-C exit, `--resume` arrow picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYhQCEBBoDYimbjy6V5ThY