### PR TITLE
Add typed filtering to the /model selector

### DIFF
--- a/Sources/KWWKCli/ListSelectorModal.swift
+++ b/Sources/KWWKCli/ListSelectorModal.swift
@@ -84,20 +84,20 @@ final class ModalListCore {
         self.scroll = 0
     }
 
-    /// Render the full modal surface. `header`, when present, is one extra
-    /// chrome line between the title and the list (e.g. a provider tab bar)
-    /// and is charged against the `maxRows` budget so windowing never
-    /// overflows.
-    func render(title: String, header: String? = nil, maxRows: Int) -> [String] {
+    /// Render the full modal surface. `headerLines`, when present, are extra
+    /// chrome lines between the title and the list (e.g. a provider tab bar
+    /// or a filter line) and are charged against the `maxRows` budget so
+    /// windowing never overflows.
+    func render(title: String, headerLines: [String] = [], maxRows: Int) -> [String] {
         // Cosmetic blank spacers (above the list and above the footer) are
         // dropped on short terminals so the render stays within `maxRows` —
-        // title + header + body + footer is the irreducible minimum.
-        let headerRows = header == nil ? 0 : 1
+        // title + headers + body + footer is the irreducible minimum.
+        let headerRows = headerLines.count
         let roomy = maxRows >= 9 + headerRows
         var out: [String] = []
         if roomy { out.append("") }
         out.append(Style.header("  \(title)"))
-        if let header { out.append(header) }
+        out.append(contentsOf: headerLines)
         guard !rows.isEmpty else {
             if roomy { out.append("") }
             out.append(Style.dimmed("  \(emptyMessage)"))

--- a/Sources/KWWKCli/Modal.swift
+++ b/Sources/KWWKCli/Modal.swift
@@ -97,7 +97,13 @@ final class ModalHost {
         active?.confirm()
         if isOpen { redraw() }
     }
-    func routeCancel() { guard isOpen else { return }; active?.cancel() }
+    /// Cancel may close the modal or mutate it in place (e.g. Esc clearing
+    /// the model selector's filter query) — repaint only when still open.
+    func routeCancel() {
+        guard isOpen else { return }
+        active?.cancel()
+        if isOpen { redraw() }
+    }
     func routeTab() { guard isOpen else { return }; active?.tab(); redraw() }
     func routeLeft() { guard isOpen else { return }; active?.left(); redraw() }
     func routeRight() { guard isOpen else { return }; active?.right(); redraw() }

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -10,6 +10,10 @@ import KWWKAI
 /// "All" plus one tab per provider — and Tab / ←→ filter the list to a
 /// single provider. With a single provider the tab bar is omitted and the
 /// render is identical to the ungrouped selector.
+///
+/// Typing filters the list by model id (case-insensitive substring),
+/// composed with the active provider tab. Backspace edits the query; Esc
+/// clears a non-empty query first and only closes the modal once empty.
 @MainActor
 final class ModelSelectorModal: Modal {
     private let title: String
@@ -32,7 +36,10 @@ final class ModelSelectorModal: Modal {
     private let tabs: [String]
     /// Index into `tabs`; 0 is "All".
     private var activeTab = 0
-    /// Indices into `models` currently listed (filtered by the active tab).
+    /// Typed filter query, matched case-insensitively against model ids.
+    private var query = ""
+    /// Indices into `models` currently listed (filtered by the active tab
+    /// and the typed query).
     private var visible: [Int]
     private let core: ModalListCore
 
@@ -96,18 +103,26 @@ final class ModelSelectorModal: Modal {
         }
     }
 
-    /// Re-derive the visible rows for `activeTab`. The active model's row
-    /// stays selected when it is visible under the tab; otherwise selection
-    /// falls back to the first row. Scroll resets with the new row set.
-    private func applyTabFilter() {
-        let indices: [Int]
+    /// Re-derive the visible rows for `activeTab` + `query` (intersection).
+    /// The active model's row stays selected when it is visible under the
+    /// filters; otherwise selection falls back to the first row. Scroll
+    /// resets with the new row set.
+    private func applyFilters() {
+        var indices: [Int]
         if activeTab == 0 {
             indices = Array(models.indices)
         } else {
             let label = tabs[activeTab]
             indices = models.indices.filter { groupLabels?[$0] == label }
         }
+        if !query.isEmpty {
+            let q = query.lowercased()
+            indices = indices.filter { models[$0].id.lowercased().contains(q) }
+        }
         visible = indices
+        core.emptyMessage = query.isEmpty
+            ? "(no models available for this provider)"
+            : "(no models match \"\(query)\")"
         let selected = activeModelIndex.flatMap { indices.firstIndex(of: $0) } ?? 0
         core.setRows(rows(for: indices), selectedIndex: selected)
     }
@@ -115,7 +130,7 @@ final class ModelSelectorModal: Modal {
     private func moveTab(_ delta: Int) {
         guard tabs.count > 1 else { return }
         activeTab = (activeTab + delta + tabs.count) % tabs.count
-        applyTabFilter()
+        applyFilters()
     }
 
     // MARK: - Modal
@@ -131,12 +146,72 @@ final class ModelSelectorModal: Modal {
         onSelect(models[visible[core.selectedIndex]])
     }
 
+    /// Esc clears a non-empty filter query first; a second Esc (or Esc with
+    /// no query) closes the modal.
     func cancel() {
+        guard query.isEmpty else {
+            query = ""
+            applyFilters()
+            return
+        }
         onCancel()
     }
 
+    /// Typed input edits the filter query: printable characters append,
+    /// backspace deletes, pasted text is unwrapped, and everything else is
+    /// swallowed so keystrokes never leak into the prompt box while the
+    /// selector is open. Enter / Esc / Tab / arrows are keybound upstream
+    /// and never reach here.
+    func handleText(_ data: String) -> Bool {
+        var text = data
+        if text.hasPrefix("\u{1B}[200~") && text.hasSuffix("\u{1B}[201~") {
+            text.removeFirst("\u{1B}[200~".count)
+            text.removeLast("\u{1B}[201~".count)
+        }
+        if text == "\u{7F}" || text == "\u{08}" {
+            if !query.isEmpty {
+                query.removeLast()
+                applyFilters()
+            }
+            return true
+        }
+        if text.hasPrefix("\u{1B}") {
+            return true // unrecognized escape sequence — swallow it
+        }
+        var appended = ""
+        for ch in text {
+            if ch == "\n" || ch == "\r" || ch == "\t" { continue }
+            if let ascii = ch.asciiValue, ascii < 0x20 { continue }
+            appended.append(ch)
+        }
+        if !appended.isEmpty {
+            query.append(appended)
+            applyFilters()
+        }
+        return true
+    }
+
     func render(maxRows: Int) -> [String] {
-        core.render(title: title, header: tabBarLine(), maxRows: maxRows)
+        var headers = [tabBarLine(), filterLine(maxRows: maxRows)].compactMap { $0 }
+        // Irreducible chrome is title + footer + one body row; when the
+        // header lines would push the render past maxRows, drop the tab bar
+        // first — an active filter query must stay visible.
+        while headers.count > 1, maxRows < 3 + headers.count {
+            headers.removeFirst()
+        }
+        return core.render(title: title, headerLines: headers, maxRows: maxRows)
+    }
+
+    /// One-line filter status: a dim typing hint while the query is empty
+    /// (dropped on short terminals — it's cosmetic), the highlighted query
+    /// with a match count once the user has typed.
+    private func filterLine(maxRows: Int) -> String? {
+        guard !query.isEmpty else {
+            guard maxRows >= 9 else { return nil }
+            return "  " + Style.dimmed("type to filter by model id")
+        }
+        return "  " + Style.dimmed("filter: ") + Theme.accentText(query, bold: true)
+            + Style.dimmed("   \(visible.count) match\(visible.count == 1 ? "" : "es")   Esc: clear")
     }
 
     /// One-line provider tab bar (nil when a single provider makes it noise).

--- a/Tests/KWWKCliTests/ModelSelectorModalTests.swift
+++ b/Tests/KWWKCliTests/ModelSelectorModalTests.swift
@@ -95,9 +95,11 @@ struct ModelSelectorModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        let lines = modal.render(maxRows: 40)
+        let lines = modal.render(maxRows: 40).map(strip)
         // Current (`b`) should get the pre-selection + "· current" tag.
-        let bLine = lines.first(where: { $0.contains("b") && !$0.contains("Pick one") })
+        // Match the row body ("b  b" = id + name detail) so chrome lines
+        // that merely contain the letter b (e.g. the filter hint) don't win.
+        let bLine = lines.first(where: { $0.contains("b  b") && !$0.contains("Pick one") })
         #expect(bLine?.contains("current") == true)
         #expect(bLine?.contains("❯") == true)
     }
@@ -295,6 +297,120 @@ struct ModelSelectorModalTests {
                 modal.down()
             }
         }
+    }
+
+    // MARK: - Typed filter
+
+    @MainActor
+    @Test("typing filters the list by model id, case-insensitively")
+    func typedFilter() {
+        let models = [model("opus-4"), model("sonnet-4"), model("haiku-4")]
+        let picked = Ref<String?>(nil)
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: models,
+            currentModelId: "opus-4",
+            onSelect: { picked.value = $0.id },
+            onCancel: {}
+        )
+        #expect(modal.handleText("SON") == true)
+        let lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("sonnet-4") }))
+        #expect(!lines.contains(where: { $0.contains("opus-4") }))
+        #expect(lines.contains(where: { $0.contains("filter: SON") }))
+        modal.confirm()
+        #expect(picked.value == "sonnet-4")
+    }
+
+    @MainActor
+    @Test("backspace edits the query; no-match shows a message; confirm is a no-op")
+    func filterBackspaceAndNoMatch() {
+        let models = [model("opus-4"), model("sonnet-4")]
+        let picked = Ref<String?>(nil)
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: models,
+            currentModelId: nil,
+            onSelect: { picked.value = $0.id },
+            onCancel: {}
+        )
+        _ = modal.handleText("zzz")
+        var lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("no models match \"zzz\"") }))
+        modal.confirm()
+        #expect(picked.value == nil)
+
+        // Backspace down to "z" — still no match; then to empty — full list.
+        _ = modal.handleText("\u{7F}")
+        _ = modal.handleText("\u{7F}")
+        _ = modal.handleText("\u{7F}")
+        lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("opus-4") }))
+        #expect(lines.contains(where: { $0.contains("sonnet-4") }))
+    }
+
+    @MainActor
+    @Test("Esc clears a non-empty query first, then closes")
+    func escClearsQueryThenCloses() {
+        let cancelled = Ref<Bool>(false)
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: [model("opus-4"), model("sonnet-4")],
+            currentModelId: nil,
+            onSelect: { _ in },
+            onCancel: { cancelled.value = true }
+        )
+        _ = modal.handleText("opus")
+        modal.cancel()
+        #expect(cancelled.value == false)
+        let lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("sonnet-4") })) // filter cleared
+        modal.cancel()
+        #expect(cancelled.value == true)
+    }
+
+    @MainActor
+    @Test("query composes with the provider tab filter")
+    func filterComposesWithTabs() {
+        let (models, groups) = multiProviderFixture()
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: models,
+            currentModelId: "opus-4",
+            groupLabels: groups,
+            currentIndex: 0,
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        _ = modal.handleText("sonnet")
+        modal.tab() // → Anthropic
+        var lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("sonnet-4") }))
+        #expect(!lines.contains(where: { $0.contains("opus-4") }))
+        #expect(lines.filter { $0.contains("sonnet-4") }.count == 1)
+        modal.tab() // → OpenAI: its own sonnet-4 copy
+        lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("sonnet-4") }))
+        #expect(!lines.contains(where: { $0.contains("gpt-5") }))
+    }
+
+    @MainActor
+    @Test("pasted text is unwrapped and escape sequences are swallowed")
+    func pasteAndEscapes() {
+        let models = [model("opus-4"), model("sonnet-4")]
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: models,
+            currentModelId: nil,
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        #expect(modal.handleText("\u{1B}[200~son\u{1B}[201~") == true)
+        #expect(modal.handleText("\u{1B}[1;5C") == true) // swallowed, not typed
+        let lines = modal.render(maxRows: 40).map(strip)
+        #expect(lines.contains(where: { $0.contains("filter: son") }))
+        #expect(lines.contains(where: { $0.contains("sonnet-4") }))
+        #expect(!lines.contains(where: { $0.contains("opus-4") }))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Typing in the `/model` selector now filters the list by model id (case-insensitive substring), composed with the existing provider tab filter (Tab / ←→).
- Backspace edits the query, bracketed paste is unwrapped, and Esc clears a non-empty query first — a second Esc closes the modal. While the selector is open, keystrokes no longer fall through to the prompt box.
- `ModalListCore.render` now takes multiple header lines so the tab bar and filter line share the height budget; on short terminals the typing hint is dropped and the filter line wins over the tab bar. `ModalHost.routeCancel` repaints when a cancel mutates the modal in place.

## Test plan
- [x] 5 new `ModelSelectorModalTests` cover typed filtering, backspace / no-match, two-stage Esc, composition with provider tabs, and paste / escape-sequence handling
- [x] Full suite passes (882 tests), verified on this branch alone in a clean worktree

Made with [Cursor](https://cursor.com)