### PR TITLE
Split visual history from model context; fold read-only tools; coalesce stream renders

### DIFF
--- a/Sources/KWWKAgent/FindTool.swift
+++ b/Sources/KWWKAgent/FindTool.swift
@@ -32,7 +32,12 @@ public func createFindTool(cwd: String, options: FindToolOptions = .init()) -> A
     return AgentTool(
         name: "find",
         label: "find",
-        description: "Find files matching a glob pattern.",
+        description: """
+        Find files matching a glob pattern. A pattern without a slash matches the file \
+        name at any depth, so `*.swift` finds every Swift file in the tree. Use a slash \
+        to scope it: `Sources/*.swift` matches only that directory's top level, and \
+        `Sources/**/*.swift` recurses under it.
+        """,
         parameters: parameters,
         execute: { _, args, cancellation, _ in
             try cancellation?.throwIfCancelled()

--- a/Sources/KWWKAgent/Glob.swift
+++ b/Sources/KWWKAgent/Glob.swift
@@ -1,8 +1,11 @@
 import Foundation
 
 /// Directory names pruned during recursive tool walks (find, grep). Mirrors
-/// pi's fd/ripgrep defaults, which skip VCS metadata and dependency trees.
-let ignoredWalkDirectoryNames: Set<String> = [".git", ".hg", ".svn", "node_modules"]
+/// pi's fd/ripgrep defaults, which skip VCS metadata and dependency/build
+/// trees. `.build` matters especially now that a slashless `find` pattern
+/// recurses the whole tree — without it `find "*.swift"` drowns in SwiftPM's
+/// vendored checkouts and generated sources.
+let ignoredWalkDirectoryNames: Set<String> = [".git", ".hg", ".svn", "node_modules", ".build"]
 
 public enum Glob {
 
@@ -53,22 +56,50 @@ public enum Glob {
         return out
     }
 
+    /// Canonicalize a directory path with a real filesystem resolve. The
+    /// `FileManager` enumerator yields fully-resolved paths (on macOS a
+    /// `/var/…` root surfaces as `/private/var/…` because `/var` is a
+    /// firmlink that neither `resolvingSymlinksInPath` nor
+    /// `standardizedFileURL` traverse — only `realpath` does). Any walk that
+    /// slices enumerated paths relative to its root must measure the prefix
+    /// against this canonical form. Returns the input unchanged when it
+    /// doesn't resolve (nonexistent path) — the enumerator then yields
+    /// nothing anyway.
+    public static func canonicalDirectoryPath(_ path: String) -> String {
+        guard let resolved = realpath(path, nil) else { return path }
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+
     /// Walk `root` recursively and return absolute file paths matching `pattern`.
     /// The pattern is compiled once, and well-known VCS/dependency directories
     /// are pruned during the walk.
+    ///
+    /// Matching mirrors the grep tool's `--glob` semantics (and fd/ripgrep/omp):
+    /// a pattern **without** a slash filters on the basename at any depth, so
+    /// `*.swift` finds every Swift file in the tree — not just top-level ones.
+    /// A pattern **with** a slash matches the path relative to `root`, so
+    /// `Sources/*.swift` scopes to that directory and `**/*.swift` recurses
+    /// explicitly.
     public static func expand(root: String, pattern: String, limit: Int? = nil) -> [String] {
         guard let regex = try? NSRegularExpression(pattern: patternToRegex(pattern)) else {
             return []
         }
+        let matchesRelative = pattern.contains("/")
         let fm = FileManager.default
+        // Canonicalize the root before enumerating so the relative-path
+        // prefix below strips the right number of leading characters (see
+        // `canonicalDirectoryPath`) — otherwise a slash-anchored pattern like
+        // `src/*.swift` under a firmlinked root matches nothing.
+        let base = canonicalDirectoryPath(root)
         guard let enumerator = fm.enumerator(
-            at: URL(fileURLWithPath: root),
+            at: URL(fileURLWithPath: base),
             includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
         ) else {
             return []
         }
         var results: [String] = []
-        let prefix = root.hasSuffix("/") ? root.count : root.count + 1
+        let prefix = base.hasSuffix("/") ? base.count : base.count + 1
         for case let url as URL in enumerator {
             let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
             if values?.isDirectory == true {
@@ -78,9 +109,15 @@ public enum Glob {
                 continue
             }
             guard values?.isRegularFile == true else { continue }
-            var relative = url.path
-            if relative.count > prefix { relative = String(relative.dropFirst(prefix)) }
-            if matches(path: relative, compiled: regex) {
+            let candidate: String
+            if matchesRelative {
+                var relative = url.path
+                if relative.count > prefix { relative = String(relative.dropFirst(prefix)) }
+                candidate = relative
+            } else {
+                candidate = url.lastPathComponent
+            }
+            if matches(path: candidate, compiled: regex) {
                 results.append(url.path)
                 if let limit, results.count >= limit { break }
             }

--- a/Sources/KWWKAgent/GrepTool.swift
+++ b/Sources/KWWKAgent/GrepTool.swift
@@ -117,8 +117,13 @@ public struct LocalGrepOperations: GrepOperations {
 
     private func collectFiles(at rootURL: URL, glob: String?) -> [URL] {
         let fm = FileManager.default
+        // Canonicalize the root before enumerating so a slash-anchored glob's
+        // relative-path prefix strips the right number of leading characters
+        // (see `Glob.canonicalDirectoryPath` — the enumerator yields
+        // firmlink-resolved paths that `standardizedFileURL` doesn't produce).
+        let rootPath = Glob.canonicalDirectoryPath(rootURL.path)
         guard let enumerator = fm.enumerator(
-            at: rootURL,
+            at: URL(fileURLWithPath: rootPath),
             includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
         ) else {
             return []
@@ -129,7 +134,6 @@ public struct LocalGrepOperations: GrepOperations {
         // to the search root.
         let globRegex = glob.flatMap { try? NSRegularExpression(pattern: Glob.patternToRegex($0)) }
         let globMatchesRelative = glob?.contains("/") ?? false
-        let rootPath = rootURL.standardizedFileURL.path
         var out: [URL] = []
         for case let url as URL in enumerator {
             let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])

--- a/Sources/KWWKAgent/SessionRecorder.swift
+++ b/Sources/KWWKAgent/SessionRecorder.swift
@@ -71,7 +71,8 @@ public final class SessionRecorder: @unchecked Sendable {
                 if case .compacted(let messagesCompacted, _) = outcome {
                     await self.recordCompaction(
                         messages: agent.state.messages,
-                        messagesCompacted: messagesCompacted
+                        messagesCompacted: messagesCompacted,
+                        reason: .compact
                     )
                 }
             default:
@@ -125,7 +126,8 @@ public final class SessionRecorder: @unchecked Sendable {
         messages replacementMessages: [Message],
         messagesCompacted: Int,
         tokensBefore: Int? = nil,
-        contextWindow: Int? = nil
+        contextWindow: Int? = nil,
+        reason: SessionStore.CompactionReason
     ) async {
         let work: Task<Void, Never> = lock.withLock {
             let usage = pendingCompactionUsage
@@ -150,6 +152,7 @@ public final class SessionRecorder: @unchecked Sendable {
                     messagesCompacted: messagesCompacted,
                     tokensBefore: tokensBefore ?? usage?.tokens,
                     contextWindow: contextWindow ?? usage?.window,
+                    reason: reason,
                     model: model,
                     provider: provider
                 )

--- a/Sources/KWWKAgent/SessionResume.swift
+++ b/Sources/KWWKAgent/SessionResume.swift
@@ -30,6 +30,9 @@ public enum SessionResume: Sendable, Hashable {
 public struct ResolvedResume: Sendable {
     public var sessionId: String
     public var messages: [Message]
+    /// Visual-recap transcript (`LoadedSession.displayMessages`): the full
+    /// on-screen history, truncated by rewinds but not by context compaction.
+    public var displayMessages: [Message]
     public var model: String?
     public var thinkingLevel: String?
     /// Number of projected context messages already represented on disk for
@@ -41,6 +44,7 @@ public struct ResolvedResume: Sendable {
     public init(
         sessionId: String,
         messages: [Message] = [],
+        displayMessages: [Message]? = nil,
         model: String? = nil,
         thinkingLevel: String? = nil,
         persistedCount: Int = 0,
@@ -48,6 +52,7 @@ public struct ResolvedResume: Sendable {
     ) {
         self.sessionId = sessionId
         self.messages = messages
+        self.displayMessages = displayMessages ?? messages
         self.model = model
         self.thinkingLevel = thinkingLevel
         self.persistedCount = persistedCount
@@ -85,6 +90,7 @@ extension SessionStore {
             return ResolvedResume(
                 sessionId: loaded.header.id,
                 messages: loaded.messages,
+                displayMessages: loaded.displayMessages,
                 model: loaded.model,
                 thinkingLevel: loaded.thinkingLevel,
                 persistedCount: loaded.persistedContextCount,
@@ -100,6 +106,7 @@ extension SessionStore {
                 return ResolvedResume(
                     sessionId: loaded.header.id,
                     messages: loaded.messages,
+                    displayMessages: loaded.displayMessages,
                     model: loaded.model,
                     thinkingLevel: loaded.thinkingLevel,
                     persistedCount: loaded.persistedContextCount,

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -91,25 +91,38 @@ public actor SessionStore {
     /// Append-only marker written when the live agent context is compacted.
     /// `replacementMessages` is the model-facing context that should replace
     /// prior projected messages when the session is resumed.
+    /// Why a projection-replacement entry was written. `.compact` = context
+    /// compaction (auto or `/compact`): only the model-facing context shrinks;
+    /// the visual transcript is unaffected. `.rewind` = the user cut the
+    /// conversation at a prompt: the visual transcript truncates too.
+    public enum CompactionReason: String, Codable, Sendable {
+        case compact
+        case rewind
+    }
+
     public struct Compaction: Codable, Sendable, Hashable {
         public var replacementMessages: [Message]
         public var messagesCompacted: Int
         public var firstKeptMessageIndex: Int?
         public var tokensBefore: Int?
         public var contextWindow: Int?
+        /// Nil when decoding pre-`CompactionReason` session files.
+        public var reason: CompactionReason?
 
         public init(
             replacementMessages: [Message],
             messagesCompacted: Int,
             firstKeptMessageIndex: Int? = nil,
             tokensBefore: Int? = nil,
-            contextWindow: Int? = nil
+            contextWindow: Int? = nil,
+            reason: CompactionReason?
         ) {
             self.replacementMessages = replacementMessages
             self.messagesCompacted = messagesCompacted
             self.firstKeptMessageIndex = firstKeptMessageIndex
             self.tokensBefore = tokensBefore
             self.contextWindow = contextWindow
+            self.reason = reason
         }
     }
 
@@ -123,7 +136,7 @@ public actor SessionStore {
         private enum CodingKeys: String, CodingKey {
             case type, timestamp, message, model, provider, thinkingLevel, title
             case replacementMessages, messagesCompacted, firstKeptMessageIndex
-            case tokensBefore, contextWindow
+            case tokensBefore, contextWindow, reason
         }
         private enum Kind: String, Codable { case message, meta, compaction }
 
@@ -151,7 +164,9 @@ public actor SessionStore {
                         firstKeptMessageIndex: try c.decodeIfPresent(
                             Int.self, forKey: .firstKeptMessageIndex),
                         tokensBefore: try c.decodeIfPresent(Int.self, forKey: .tokensBefore),
-                        contextWindow: try c.decodeIfPresent(Int.self, forKey: .contextWindow)
+                        contextWindow: try c.decodeIfPresent(Int.self, forKey: .contextWindow),
+                        reason: try c.decodeIfPresent(
+                            CompactionReason.self, forKey: .reason)
                     )
                 )
             }
@@ -180,6 +195,7 @@ public actor SessionStore {
                     compaction.firstKeptMessageIndex, forKey: .firstKeptMessageIndex)
                 try c.encodeIfPresent(compaction.tokensBefore, forKey: .tokensBefore)
                 try c.encodeIfPresent(compaction.contextWindow, forKey: .contextWindow)
+                try c.encodeIfPresent(compaction.reason, forKey: .reason)
             }
         }
     }
@@ -189,8 +205,11 @@ public actor SessionStore {
         public var header: Header
         /// Model-facing context after replaying any compaction markers.
         public var messages: [Message]
-        /// Raw transcript message entries, excluding compaction replacements.
-        public var transcriptMessages: [Message]
+        /// What the user actually saw, replayed for visual recaps: every raw
+        /// message, truncated by rewind markers but NOT by context compaction
+        /// (compaction shrinks the model-facing context, not the on-screen
+        /// history).
+        public var displayMessages: [Message]
         /// Number of messages in `messages` already represented on disk.
         public var persistedContextCount: Int
         /// Latest model id seen (from the header or a later `meta` entry).
@@ -205,7 +224,7 @@ public actor SessionStore {
         public init(
             header: Header,
             messages: [Message],
-            transcriptMessages: [Message]? = nil,
+            displayMessages: [Message]? = nil,
             persistedContextCount: Int? = nil,
             model: String?,
             provider: String?,
@@ -214,7 +233,7 @@ public actor SessionStore {
         ) {
             self.header = header
             self.messages = messages
-            self.transcriptMessages = transcriptMessages ?? messages
+            self.displayMessages = displayMessages ?? messages
             self.persistedContextCount = persistedContextCount ?? messages.count
             self.model = model
             self.provider = provider
@@ -428,6 +447,7 @@ public actor SessionStore {
         firstKeptMessageIndex: Int? = nil,
         tokensBefore: Int? = nil,
         contextWindow: Int? = nil,
+        reason: CompactionReason,
         model: String? = nil,
         provider: String? = nil
     ) throws {
@@ -444,7 +464,8 @@ public actor SessionStore {
                     messagesCompacted: messagesCompacted,
                     firstKeptMessageIndex: firstKeptMessageIndex,
                     tokensBefore: tokensBefore,
-                    contextWindow: contextWindow
+                    contextWindow: contextWindow,
+                    reason: reason
                 )
             ))
     }
@@ -482,7 +503,7 @@ public actor SessionStore {
         let header = try parseHeader(String(first), path: url.path)
 
         var messages: [Message] = []
-        var transcriptMessages: [Message] = []
+        var displayMessages: [Message] = []
         var model = header.model
         var provider = header.provider
         var thinkingLevel: String?
@@ -505,8 +526,8 @@ public actor SessionStore {
             }
             switch entry {
             case .message(_, let message):
-                transcriptMessages.append(message)
                 messages.append(message)
+                displayMessages.append(message)
             case .meta(_, let m, let p, let t, let ti):
                 if let m { model = m }
                 if let p { provider = p }
@@ -514,13 +535,31 @@ public actor SessionStore {
                 if let ti { title = ti }
             case .compaction(_, let compaction):
                 messages = compaction.replacementMessages
+                switch compaction.reason {
+                case .compact:
+                    // Context compaction shrinks the model-facing context
+                    // only; the on-screen history is untouched.
+                    break
+                case .rewind:
+                    // Rewind cut the conversation at a prompt: drop the same
+                    // tail from the visual history that was cut from the
+                    // model context. The kept prefix cannot simply replace
+                    // the display — after a compaction it starts with a
+                    // summary message the display never contained.
+                    displayMessages = Array(
+                        displayMessages.dropLast(compaction.messagesCompacted))
+                case nil:
+                    // Legacy entries predate the reason split and truncated
+                    // both the model and the display context.
+                    displayMessages = compaction.replacementMessages
+                }
             }
         }
 
         return LoadedSession(
             header: header,
             messages: messages,
-            transcriptMessages: transcriptMessages,
+            displayMessages: displayMessages,
             persistedContextCount: messages.count,
             model: model,
             provider: provider,

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -75,11 +75,6 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
         handler: handleCopyCommand
     ))
     registry.register(SlashCommand(
-        name: "dump",
-        description: "Copy the full transcript to the clipboard",
-        handler: handleDumpCommand
-    ))
-    registry.register(SlashCommand(
         name: "rename",
         description: "Set a title for the current session",
         handler: handleRenameCommand
@@ -933,7 +928,7 @@ private func handleHotkeysCommand(_ ctx: SlashContext, _ args: String) async {
     ctx.notifyBlock(lines)
 }
 
-// MARK: - /copy, /dump
+// MARK: - /copy
 
 /// `/copy` — put the last assistant reply on the clipboard (plain text, ANSI
 /// stripped). Defers omp's interactive selector; the no-arg default covers the
@@ -946,20 +941,6 @@ private func handleCopyCommand(_ ctx: SlashContext, _ args: String) async {
     }
     let outcome = ClipboardWriter.copy(text)
     ctx.notify(Style.dimmed("  /copy: copied last reply (\(text.count) chars)\(clipboardVia(outcome))"))
-}
-
-/// `/dump` — put the whole transcript on the clipboard as plain text.
-@MainActor
-private func handleDumpCommand(_ ctx: SlashContext, _ args: String) async {
-    let rendered = TranscriptSnapshot.render(ctx.agent.state.messages, width: 100)
-    let plain = rendered.map { ANSI.stripEscapes($0) }.joined(separator: "\n")
-    let trimmed = plain.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-        ctx.notify(Style.dimmed("  /dump: transcript is empty"))
-        return
-    }
-    let outcome = ClipboardWriter.copy(trimmed)
-    ctx.notify(Style.dimmed("  /dump: copied transcript (\(trimmed.count) chars)\(clipboardVia(outcome))"))
 }
 
 /// Trailing " · via OSC 52" note when the write didn't go through the native

--- a/Sources/KWWKCli/Clipboard.swift
+++ b/Sources/KWWKCli/Clipboard.swift
@@ -98,7 +98,7 @@ enum ClipboardImageReader {
 /// Write text to the system clipboard. On macOS this drives `NSPasteboard`;
 /// everywhere else (and over SSH where there's no local pasteboard) it falls
 /// back to the OSC 52 terminal escape, which asks the *outer* terminal
-/// emulator to set its own clipboard. Backs `/copy` and `/dump`.
+/// emulator to set its own clipboard. Backs `/copy`.
 enum ClipboardWriter {
 
     /// Result of a write so callers can tailor the confirmation message.

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -174,10 +174,16 @@ func runCodingTUIInternal(
         WelcomeScreen.render(welcomeHeader.snapshot(), width: width) + [""]
     }
     if resolvedResume.resumed {
-        runner.tui.commit([
-            Theme.faintText("  ↻ resumed session \(sessionId.prefix(8)) · \(resolvedResume.messages.count) messages"),
+        // Replay the restored session's visual history into scrollback (the
+        // same recap `/resume` paints), then the trailing session note.
+        var recap = TranscriptSnapshot.render(
+            resolvedResume.displayMessages, width: runner.terminal.width)
+        recap.append(contentsOf: [
+            "",
+            Theme.faintText("  ↻ resumed session \(sessionId.prefix(8)) · \(resolvedResume.displayMessages.count) messages"),
             "",
         ])
+        runner.tui.commit(recap)
     }
 
     runner.tui.addChild(frame)
@@ -409,6 +415,10 @@ func runCodingTUIInternal(
     // every event, so `/thinking show|hide` (which only mutates agent
     // state) takes effect on the next turn without extra plumbing.
     renderer.setThinkingDisplay(agent.state.thinkingDisplay)
+    let streamCoalescer = RenderCoalescer {
+        updateFrameStatus()
+        runner.tui.requestRender()
+    }
     _ = agent.subscribe { event, _ in
         await MainActor.run {
             renderer.setThinkingDisplay(agent.state.thinkingDisplay)
@@ -419,7 +429,15 @@ func runCodingTUIInternal(
             if !modal.isOpen {
                 recomputeTranscript()
             }
-            _ = flushCommits()
+            let flushedCommits = flushCommits()
+            // A pure token delta that settled nothing only mutates the live
+            // tail — render it on the coalesced ~30fps cadence rather than
+            // synchronously per delta. Anything that reached scrollback (or
+            // any non-delta event) keeps the immediate render below.
+            if isPureStreamDelta(event) && !flushedCommits {
+                streamCoalescer.schedule()
+                return
+            }
             switch event {
             case .agentStart:
                 break
@@ -608,6 +626,7 @@ func runCodingTUIInternal(
             agent: agent,
             modal: modal,
             frame: frame,
+            sessionStore: sessionStore,
             recorderBox: recorderBox,
             retry: retry,
             attachments: attachments,
@@ -700,7 +719,8 @@ func runCodingTUIInternal(
         recordCompaction: { messagesCompacted in
             await recorderBox.recorder.recordCompaction(
                 messages: agent.state.messages,
-                messagesCompacted: messagesCompacted
+                messagesCompacted: messagesCompacted,
+                reason: .compact
             )
         },
         setSessionTitle: { title in
@@ -1121,6 +1141,13 @@ func runCodingTUIInternal(
             try? await Task.sleep(nanoseconds: 90_000_000)
             guard agent.state.isStreaming || frameStatus.isAutoCompacting || frameStatus.mode.isActive else { continue }
             frame.tick()
+            // Advance the collapsed `[thinking Ns…]` elapsed counter between
+            // provider deltas — liveLines is cached state, so it must be
+            // re-derived here for the label to tick.
+            if renderer.hasActiveThinking && !modal.isOpen {
+                renderer.tickLive()
+                recomputeTranscript()
+            }
             updateFrameStatus()
             runner.tui.requestRender()
         }

--- a/Sources/KWWKCli/RenderCoalescer.swift
+++ b/Sources/KWWKCli/RenderCoalescer.swift
@@ -1,0 +1,44 @@
+import Foundation
+import KWWKAI
+import KWWKAgent
+
+/// Coalesces the render storm of token streaming. Every `.textDelta` /
+/// `.thinkingDelta` used to trigger a synchronous terminal render; with the
+/// live tail visible each delta now changes `liveLines`, so per-delta
+/// rendering would repaint the live zone at provider speed. Pure stream
+/// deltas instead call `schedule()`, which flushes at most once per
+/// interval (~30fps). Everything else — commits, tool events, turn
+/// boundaries — still renders immediately via its existing path.
+@MainActor
+final class RenderCoalescer {
+    private var scheduled = false
+    private let intervalNs: UInt64
+    private let flush: @MainActor () -> Void
+
+    init(intervalMs: UInt64 = 33, flush: @escaping @MainActor () -> Void) {
+        self.intervalNs = intervalMs * 1_000_000
+        self.flush = flush
+    }
+
+    func schedule() {
+        guard !scheduled else { return }
+        scheduled = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: intervalNs)
+            scheduled = false
+            flush()
+        }
+    }
+}
+
+/// True for events that only extend streaming text/thinking — the ones
+/// safe to render on the coalesced cadence instead of immediately.
+func isPureStreamDelta(_ event: AgentEvent) -> Bool {
+    guard case .messageUpdate(_, let amEvent) = event else { return false }
+    switch amEvent {
+    case .textDelta, .thinkingDelta:
+        return true
+    default:
+        return false
+    }
+}

--- a/Sources/KWWKCli/RewindSelector.swift
+++ b/Sources/KWWKCli/RewindSelector.swift
@@ -63,6 +63,7 @@ func openRewindSelector(
     agent: Agent,
     modal: ModalHost,
     frame: CodingFrame,
+    sessionStore: SessionStore,
     recorderBox: RecorderBox,
     retry: TurnRetryState,
     attachments: AttachmentStore,
@@ -171,13 +172,35 @@ func openRewindSelector(
                 recomputeTranscript()
                 updateFrameStatus()
 
+                // Persist the cut as a projection replacement (the same store
+                // entry compaction uses): it resets the recorder's baseline so
+                // post-rewind turns flush from the new count, and a later
+                // /resume loads the kept prefix instead of replaying the
+                // dropped tail — the JSONL store is append-only, so the tail
+                // can't be deleted, only superseded. Persisted BEFORE the
+                // repaint so the recap below can read the updated visual
+                // history back from the store.
+                await recorderBox.recorder.recordCompaction(
+                    messages: kept,
+                    messagesCompacted: removed,
+                    reason: .rewind
+                )
+
                 // omp's branch treatment: clear the screen (and scrollback,
-                // where the terminal allows) and re-render the kept prefix as
-                // the whole transcript — the dropped tail vanishes from view
-                // instead of piling a recap under the stale conversation. The
-                // welcome header is re-emitted on top by the repaint; a
+                // where the terminal allows) and re-render the surviving
+                // transcript — the dropped tail vanishes from view instead of
+                // piling a recap under the stale conversation. The recap
+                // replays the store's visual history (displayMessages), NOT
+                // `kept`: after a context compaction the model context starts
+                // with a `<previous-session-summary>` message the user never
+                // saw, and everything the compaction summarized away is still
+                // part of the on-screen history. Falls back to the kept model
+                // prefix only when the session file can't be read back.
+                // The welcome header is re-emitted on top by the repaint; a
                 // trailing note keeps the cut visible after the clear.
-                var snapshot = TranscriptSnapshot.render(kept, width: terminalWidth())
+                let display = (try? await sessionStore.load(id: recorderBox.sessionId))?
+                    .displayMessages ?? kept
+                var snapshot = TranscriptSnapshot.render(display, width: terminalWidth())
                 snapshot.append(contentsOf: [
                     "",
                     Theme.accentText(
@@ -187,19 +210,6 @@ func openRewindSelector(
                 ])
                 replaceTranscript(snapshot)
                 requestRender()
-
-                // Persist the cut as a projection replacement (the same store
-                // entry compaction uses): it resets the recorder's baseline so
-                // post-rewind turns flush from the new count, and a later
-                // /resume loads the kept prefix instead of replaying the
-                // dropped tail — the JSONL store is append-only, so the tail
-                // can't be deleted, only superseded. Only the disk write is
-                // deferred; the recorder's append chain keeps it ordered ahead
-                // of any later turn's flush.
-                await recorderBox.recorder.recordCompaction(
-                    messages: kept,
-                    messagesCompacted: removed
-                )
             }
         },
         onCancel: { modal.close() }

--- a/Sources/KWWKCli/SessionSlashCommands.swift
+++ b/Sources/KWWKCli/SessionSlashCommands.swift
@@ -136,10 +136,12 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
                         // (and scrollback, where the terminal allows) and
                         // re-render the restored transcript in place of the
                         // outgoing one; a trailing note names the session.
-                        var snapshot = TranscriptSnapshot.render(loaded.messages, width: terminalWidth())
+                        // The recap replays the full visual history
+                        // (displayMessages), not the compacted model context.
+                        var snapshot = TranscriptSnapshot.render(loaded.displayMessages, width: terminalWidth())
                         snapshot.append(contentsOf: [
                             "",
-                            Theme.accentText("↻ resumed session \(info.id.prefix(8)) · \(loaded.messages.count) messages", bold: false),
+                            Theme.accentText("↻ resumed session \(info.id.prefix(8)) · \(loaded.displayMessages.count) messages", bold: false),
                         ])
                         replaceTranscript(snapshot)
                         requestRender()

--- a/Sources/KWWKCli/TranscriptRenderer.swift
+++ b/Sources/KWWKCli/TranscriptRenderer.swift
@@ -11,10 +11,12 @@ import KWWKAgent
 ///   terminal's native scrollback and stay there forever). CodingTUI
 ///   drains this on every agent event and passes it to `tui.commit(_:)`.
 ///
-/// * `liveLines` — the mutable in-progress tail: running tool headers
-///   + their result previews. Assistant text is not retained here; it is
-///   committed append-only at stable segment boundaries so the terminal's
-///   native autowrap handles long lines.
+/// * `liveLines` — the mutable in-progress tail: the read-only fold group,
+///   running tool headers + result previews, open-thinking labels, and the
+///   unsettled trailing segment of assistant text (streamed token-by-token).
+///   Stable text segments are committed append-only at hard-line boundaries
+///   so the terminal's native autowrap handles long lines; only the trailing
+///   partial stays live until it settles.
 ///
 /// Settlement points:
 ///   - `messageStart(.user)` → commit the user prompt row + a blank
@@ -37,10 +39,11 @@ final class TranscriptRenderer {
     /// Drained by CodingTUI via `drainCommits()` on every agent event.
     private var pendingCommits: [String] = []
 
-    /// The current in-progress tail. Assistant text is deliberately not
-    /// retained here: stable text segments are committed append-only so the
-    /// terminal can handle native autowrap. The live tail is for mutable tool
-    /// slots and transient status only.
+    /// The current in-progress tail: mutable tool slots, open-thinking
+    /// labels, and the unsettled assistant-text tail streamed token-by-token.
+    /// Stable text segments (up to a hard newline) are still committed
+    /// append-only so the terminal owns native autowrap; only the trailing
+    /// partial segment lives here until it settles.
     private(set) var liveLines: [String] = []
 
     /// True while an assistant message is mid-stream.
@@ -81,7 +84,30 @@ final class TranscriptRenderer {
         let args: JSONValue
         var partial: AgentToolResult?
         var resolution: [String]?   // nil = running
+        /// Set when this slot resolved as a foldable read-only call: the
+        /// tool name + compact one-line summary that joins the current
+        /// fold run instead of committing its own block.
+        var foldEntry: FoldEntry?
     }
+
+    private struct FoldEntry {
+        let name: String
+        let summary: String
+    }
+
+    /// Read-only tools whose successful results fold to a one-line summary
+    /// instead of a content preview (omp keeps read/grep/glob visually
+    /// light; edit/write/bash keep their full blocks). Errors never fold.
+    private static let foldedTools: Set<String> = ["read", "grep", "find", "ls"]
+
+    /// Consecutive resolved read-only calls (read/grep/find/ls), held back
+    /// from scrollback so they commit as one group — a per-tool-count header
+    /// (`read 2 files, grep 1 time`) over a dimmed tree, the same structure
+    /// for one call or many. The run is sealed by any other content entering
+    /// scrollback — assistant text, a non-folded tool block, a user message —
+    /// so a burst of file/search calls reads
+    /// as one calm block instead of N green-bulleted rows.
+    private var foldRun: [FoldEntry] = []
 
     /// How to surface thinking blocks. Mirrored from `agent.state` via
     /// `setThinkingDisplay` so the UI can honor the user's `/thinking
@@ -89,10 +115,28 @@ final class TranscriptRenderer {
     /// Agent.
     private var thinkingDisplay: ThinkingDisplay = .collapsed
 
+    /// Minimum reasoning time before a **collapsed** thinking block is shown
+    /// at all. Short thinks stay fully hidden — no live label, no committed
+    /// row, no group seal — so a quick think between two tool calls doesn't
+    /// chop the fold group into fragments. Expanded mode ignores this (the
+    /// user opted into seeing every reasoning step). Stored so tests can
+    /// lower it without waiting on the wall clock.
+    var collapsedThinkingMinSeconds: Double = 3.0
+
     /// Start/end timestamps per thinking content-block index for the
     /// current streaming turn. `end == nil` while the block is still
     /// receiving deltas. Reset on every `messageStart`.
     private var thinkingTimings: [Int: (start: DispatchTime, end: DispatchTime?)] = [:]
+
+    /// Streaming thinking text per content-block index, accumulated from
+    /// `.thinkingDelta` and shown live (expanded mode) while the block is
+    /// open. Cleared when the block commits.
+    private var thinkingBuffers: [Int: String] = [:]
+
+    /// Thinking blocks whose settled form has already been committed to
+    /// scrollback — guards against double-commit when `messageEnd` sweeps
+    /// up blocks that never saw an explicit `thinkingEnd`.
+    private var thinkingCommitted: Set<Int> = []
 
     /// Terminal width used to render full-width blocks (the user-message bar).
     /// Updated by CodingTUI on init + resize. Committed lines are otherwise
@@ -152,9 +196,11 @@ final class TranscriptRenderer {
                 assistantSegmentBuffer = ""
                 assistantCommittedDuringTurn = false
                 lastAssistantTextIndex = nil
-                // New turn — drop any prior turn's thinking timings.
+                // New turn — drop any prior turn's thinking state.
                 // Re-populated from `.thinkingStart` events below.
                 thinkingTimings.removeAll()
+                thinkingBuffers.removeAll()
+                thinkingCommitted.removeAll()
                 recomputeLive()
             case .toolResult:
                 break
@@ -169,11 +215,14 @@ final class TranscriptRenderer {
                 if thinkingTimings[idx] == nil {
                     thinkingTimings[idx] = (start: DispatchTime.now(), end: nil)
                 }
-            case .thinkingEnd(let idx, _, _):
+            case .thinkingDelta(let idx, let delta, _):
+                thinkingBuffers[idx, default: ""] += delta
+            case .thinkingEnd(let idx, let content, _):
                 if var t = thinkingTimings[idx] {
                     t.end = DispatchTime.now()
                     thinkingTimings[idx] = t
                 }
+                commitThinkingBlock(idx, content: content)
             default:
                 break
             }
@@ -206,6 +255,13 @@ final class TranscriptRenderer {
                     thinkingTimings[idx] = (start: t.start, end: DispatchTime.now())
                 }
                 ingestAssistantText(a, flushAll: true)
+                // Commit blocks the sweep just sealed: an abort mid-thought
+                // still leaves a settled `[thought for Ns]` row (with
+                // whatever streamed, in expanded mode) instead of the block
+                // silently vanishing from the transcript.
+                for idx in thinkingTimings.keys.sorted() where !thinkingCommitted.contains(idx) {
+                    commitThinkingBlock(idx, content: thinkingBuffers[idx] ?? "")
+                }
                 var tail: [String] = []
                 if a.stopReason == .aborted {
                     tail.append(Style.dimmed("⋯ aborted"))
@@ -239,16 +295,21 @@ final class TranscriptRenderer {
         case .toolExecutionEnd(let id, _, let result, let isError):
             guard let idx = toolSlots.firstIndex(where: { $0.id == id }) else { break }
             let slot = toolSlots[idx]
-            let header = Style.tool("● \(slot.name)(\(formatArgs(slot.args)))")
-            // Leading blank, no trailing — uniform "every scrollback block
-            // opens with a separator row, never closes with one" rule.
-            var finalLines = ["", header]
-            finalLines.append(contentsOf: formatToolResult(result, isError: isError))
-            toolSlots[idx].resolution = finalLines
+            if !isError, let summary = foldedSummary(name: slot.name, args: slot.args, result: result) {
+                toolSlots[idx].foldEntry = FoldEntry(name: slot.name, summary: summary)
+            } else {
+                let header = Style.tool("● \(slot.name)(\(formatArgs(slot.args)))")
+                // Leading blank, no trailing — uniform "every scrollback block
+                // opens with a separator row, never closes with one" rule.
+                var finalLines = ["", header]
+                finalLines.append(contentsOf: formatToolResult(result, isError: isError))
+                toolSlots[idx].resolution = finalLines
+            }
             drainResolvedToolFront()
             recomputeLive()
 
         case .agentEnd:
+            sealFoldRun()
             flushQueuedVerbose()
 
         case .streamRetry(_, let delayMs, _):
@@ -276,6 +337,12 @@ final class TranscriptRenderer {
             assistantCommittedDuringTurn = false
             lastAssistantTextIndex = nil
             queuedVerboseLines.removeAll()
+            // The failed attempt's thinking is gone with the stream; the
+            // retry's `messageStart` would clear these anyway, but the live
+            // zone must not show a ghost `[thinking Ns…]` in between.
+            thinkingTimings.removeAll()
+            thinkingBuffers.removeAll()
+            thinkingCommitted.removeAll()
             recomputeLive()
 
         case .verbose(let event):
@@ -292,7 +359,16 @@ final class TranscriptRenderer {
 
     // MARK: - Commit / live helpers
 
+    /// Every scrollback write funnels through here, which makes it the
+    /// single break point for the fold run: anything else entering
+    /// scrollback seals the pending read-only group first, so the group
+    /// always lands in chronological position.
     private func commit(_ lines: [String]) {
+        sealFoldRun()
+        rawCommit(lines)
+    }
+
+    private func rawCommit(_ lines: [String]) {
         for raw in lines {
             for sub in raw.split(separator: "\n", omittingEmptySubsequences: false) {
                 pendingCommits.append(String(sub))
@@ -300,13 +376,112 @@ final class TranscriptRenderer {
         }
     }
 
+    /// Flush the pending fold run into scrollback as a single count-headed
+    /// tree block. Internal so `TranscriptSnapshot`'s replay can seal a
+    /// trailing run without synthesizing a full `.agentEnd` payload.
+    func sealFoldRun() {
+        guard !foldRun.isEmpty else { return }
+        let entries = foldRun
+        foldRun.removeAll()
+        rawCommit(foldRunLines(entries))
+        recomputeLive()
+    }
+
+    /// One row of a read-only group: a resolved call carries its summary
+    /// (`README.md · 200 lines`); a still-running call carries just its
+    /// target (`README.md`) and fills in the count when it resolves.
+    private struct GroupRow {
+        let name: String
+        let detail: String
+    }
+
+    private func foldRunLines(_ entries: [FoldEntry]) -> [String] {
+        foldGroupLines(entries.map { GroupRow(name: $0.name, detail: $0.summary) })
+    }
+
+    /// Render a read-only group: a per-tool-count header (`read 2 files,
+    /// ls 3 times`) over a dimmed tree — the same structure for one call or
+    /// many. Used for both the committed group and the live (mid-flight)
+    /// view, so a call joining or resolving only updates its row in place —
+    /// no jump when the group settles into scrollback.
+    private func foldGroupLines(_ rows: [GroupRow]) -> [String] {
+        guard !rows.isEmpty else { return [] }
+        // Always the same structure — count header over a dimmed tree — even
+        // for a single call. A lone read/grep/ls never reshapes into a
+        // standalone line and back as sibling calls arrive; the layout stays
+        // stable regardless of how many land in the group.
+        var out = ["", Style.tool("●") + " " + Style.dimmed(foldGroupHeader(rows))]
+        for (i, r) in rows.enumerated() {
+            let glyph = i == rows.count - 1 ? "└" : "├"
+            let detail = r.detail.isEmpty ? "" : " \(r.detail)"
+            out.append(Style.dimmed("  \(glyph) \(r.name)\(detail)"))
+        }
+        return out
+    }
+
+    /// Per-tool-type count summary for a group header, in first-appearance
+    /// order: `read 2 files, ls 3 times, grep 1 time`. `read` counts files;
+    /// the search/list tools count invocations.
+    private func foldGroupHeader(_ rows: [GroupRow]) -> String {
+        var order: [String] = []
+        var counts: [String: Int] = [:]
+        for r in rows {
+            if counts[r.name] == nil { order.append(r.name) }
+            counts[r.name, default: 0] += 1
+        }
+        return order.map { name -> String in
+            let n = counts[name] ?? 0
+            let unit: String
+            switch name {
+            case "read": unit = n == 1 ? "file" : "files"
+            default: unit = n == 1 ? "time" : "times"
+            }
+            return "\(name) \(n) \(unit)"
+        }.joined(separator: ", ")
+    }
+
+    /// The leading target of a still-running read-only call — the same
+    /// prefix its resolved summary will start with, so the row doesn't jump
+    /// when the count fills in. Empty when there's nothing meaningful yet.
+    private func foldTarget(name: String, args: JSONValue) -> String {
+        guard case .object(let obj) = args else { return "" }
+        switch name {
+        case "read", "ls":
+            if case .string(let p) = obj["path"] ?? .null { return p }
+            return name == "ls" ? "." : ""
+        case "grep":
+            guard case .string(let pat) = obj["pattern"] ?? .null else { return "" }
+            var t = "\"\(truncate(pat, to: 60))\""
+            if case .string(let p) = obj["path"] ?? .null { t += " in \(p)" }
+            return t
+        case "find":
+            guard case .string(let pat) = obj["pattern"] ?? .null else { return "" }
+            var t = "\"\(truncate(pat, to: 60))\""
+            // Match the `in <path>` the resolved summary adds, so the row
+            // doesn't shift when the count fills in.
+            if case .string(let p) = obj["path"] ?? .null { t += " in \(p)" }
+            return t
+        default:
+            return ""
+        }
+    }
+
     /// Pop resolved tool slots from the front of the queue until we hit
     /// one that's still running. This preserves start-order in the
-    /// committed output even when tools finish out of order.
+    /// committed output even when tools finish out of order. Resolved
+    /// read-only calls join the fold run instead of committing; any other
+    /// resolved slot commits (sealing the run first).
     private func drainResolvedToolFront() {
-        while let front = toolSlots.first, let resolved = front.resolution {
-            commit(resolved)
-            toolSlots.removeFirst()
+        while let front = toolSlots.first {
+            if let entry = front.foldEntry {
+                foldRun.append(entry)
+                toolSlots.removeFirst()
+            } else if let resolved = front.resolution {
+                commit(resolved)
+                toolSlots.removeFirst()
+            } else {
+                break
+            }
         }
     }
 
@@ -323,7 +498,75 @@ final class TranscriptRenderer {
     /// known, even before the commit happens.
     private func recomputeLive() {
         var out: [String] = []
+        // Read-only group, live: the resolved-pending fold entries plus any
+        // foldable calls still in flight at the front of the queue, rendered
+        // as one growing tree. An in-flight `read`/`grep`/`ls` sits inside
+        // the group from the moment it starts — no separate `● read(…)`
+        // block that later jumps into the group when it finishes.
+        var groupRows: [GroupRow] = foldRun.map {
+            GroupRow(name: $0.name, detail: $0.summary)
+        }
+        var consumed = 0
         for slot in toolSlots {
+            guard Self.foldedTools.contains(slot.name) else { break }
+            if let entry = slot.foldEntry {
+                groupRows.append(GroupRow(name: entry.name, detail: entry.summary))
+            } else if slot.resolution == nil {
+                groupRows.append(GroupRow(
+                    name: slot.name,
+                    detail: foldTarget(name: slot.name, args: slot.args)
+                ))
+            } else {
+                // A foldable call that errored keeps its own full block.
+                break
+            }
+            consumed += 1
+        }
+        if !groupRows.isEmpty {
+            out.append(contentsOf: foldGroupLines(groupRows))
+        }
+        // Token-streaming tail: the assistant text that hasn't reached a
+        // hard-newline boundary yet. Rendered exactly where it will settle
+        // (foldRun seals first, this message's tools start only later), with
+        // the same leading-blank rule as `commitAssistantLines` so the
+        // commit moment doesn't visually jump.
+        if streaming && !assistantSegmentBuffer.isEmpty {
+            if !assistantCommittedDuringTurn {
+                out.append("")
+            }
+            out.append(assistantSegmentBuffer)
+        }
+        // Open thinking blocks: a ticking `[thinking Ns…]` label, plus the
+        // streaming body in expanded mode. Settled blocks are already in
+        // scrollback (committed on thinkingEnd), so only open ones render.
+        // A collapsed block stays hidden until it crosses the visibility
+        // threshold, so short reasoning never flashes a label it won't keep.
+        // Rendered *after* the text tail so an interleaved text→thinking
+        // sequence keeps chronological order, matching `messageEnd`'s commit
+        // order (the text tail settles before the thinking sweep).
+        for (idx, t) in thinkingTimings.sorted(by: { $0.key < $1.key })
+        where t.end == nil && !thinkingCommitted.contains(idx) {
+            let buf = thinkingBuffers[idx] ?? ""
+            let secs = elapsedSeconds(from: t.start, to: .now())
+            guard thinkingVisible(seconds: secs, hasContent: !buf.isEmpty) else { continue }
+            out.append("")
+            out.append(Style.dimmed("[thinking \(formatElapsed(from: t.start, to: .now()))…]"))
+            if thinkingDisplay == .expanded, !buf.isEmpty {
+                out.append(contentsOf: buf.components(separatedBy: "\n").map { Style.dimmed("  " + $0) })
+            }
+        }
+        // Remaining slots — those past the leading foldable run consumed
+        // into the group above (non-folded tools, or foldable calls blocked
+        // behind a running non-folded tool).
+        for slot in toolSlots.dropFirst(consumed) {
+            // A resolved read-only call blocked behind an earlier running
+            // non-folded slot renders as its own one-row group — byte-for-byte
+            // the form it will settle into once it unblocks, so there's no
+            // reflow on commit.
+            if let entry = slot.foldEntry {
+                out.append(contentsOf: foldGroupLines([GroupRow(name: entry.name, detail: entry.summary)]))
+                continue
+            }
             // Each tool execution is its own block — leading blank
             // separator keeps parallel tools from stacking against the
             // streaming body or each other. Matches the committed-
@@ -447,6 +690,56 @@ final class TranscriptRenderer {
         }
     }
 
+    /// Whether a thinking block that has run for `seconds` is worth
+    /// surfacing. Collapsed mode hides anything under the threshold so quick
+    /// reasoning between tool calls leaves no trace and doesn't fragment the
+    /// fold group; expanded mode shows a block as soon as it has any body
+    /// (the user asked to see reasoning), and still surfaces a long
+    /// content-less think.
+    private func thinkingVisible(seconds: Double, hasContent: Bool) -> Bool {
+        switch thinkingDisplay {
+        case .collapsed:
+            return seconds >= collapsedThinkingMinSeconds
+        case .expanded:
+            return hasContent || seconds >= collapsedThinkingMinSeconds
+        }
+    }
+
+    /// Commit a thinking block's settled form into scrollback: a dimmed
+    /// `[thought for Ns]` label, plus the full body in expanded mode. Like
+    /// any other block, a shown thought seals the pending fold run (it flows
+    /// through `commit`), so the transcript stays in chronological order. A
+    /// block below the visibility threshold commits nothing and therefore
+    /// does not seal — short thinks stay out of the way entirely.
+    private func commitThinkingBlock(_ idx: Int, content: String) {
+        guard !thinkingCommitted.contains(idx) else { return }
+        thinkingCommitted.insert(idx)
+        thinkingBuffers[idx] = nil
+        let timing = thinkingTimings[idx]
+        let seconds = timing.map { elapsedSeconds(from: $0.start, to: $0.end ?? .now()) } ?? 0
+        guard thinkingVisible(seconds: seconds, hasContent: !content.isEmpty) else { return }
+        let elapsed = timing.map { formatElapsed(from: $0.start, to: $0.end ?? .now()) } ?? "0.0s"
+        var lines = ["", Style.dimmed("[thought for \(elapsed)]")]
+        if thinkingDisplay == .expanded, !content.isEmpty {
+            lines.append(contentsOf: content.components(separatedBy: "\n").map { Style.dimmed("  " + $0) })
+        }
+        commit(lines)
+    }
+
+    /// Re-derive `liveLines` outside an agent event. The CodingTUI spinner
+    /// tick calls this while `hasActiveThinking`, so the `[thinking Ns…]`
+    /// elapsed counter advances even when the provider sends no deltas.
+    func tickLive() {
+        recomputeLive()
+    }
+
+    private func elapsedSeconds(from start: DispatchTime, to end: DispatchTime) -> Double {
+        let ns = end.uptimeNanoseconds >= start.uptimeNanoseconds
+            ? end.uptimeNanoseconds - start.uptimeNanoseconds
+            : 0
+        return Double(ns) / 1_000_000_000
+    }
+
     /// Format a DispatchTime delta as a human-readable duration. 0.1s
     /// granularity under 10 seconds so the counter visibly ticks; full
     /// seconds above that; `Nm Ss` once we cross a minute.
@@ -484,6 +777,104 @@ final class TranscriptRenderer {
         case .array(let arr): return "[\(arr.count) items]"
         case .object: return "{…}"
         }
+    }
+
+    // MARK: - Read-only tool folding
+
+    /// One-line summary for a successful read-only tool call, or nil for
+    /// tools that keep their full block. The tool name is prepended by the
+    /// caller (`● name summary` inline, or `name summary` as a tree row),
+    /// so the summary here is name-free.
+    private func foldedSummary(name: String, args: JSONValue, result: AgentToolResult) -> String? {
+        guard Self.foldedTools.contains(name) else { return nil }
+        guard case .object(let obj) = args else { return nil }
+        switch name {
+        case "read":
+            guard case .string(let path) = obj["path"] ?? .null else { return nil }
+            if result.content.contains(where: { if case .image = $0 { return true } else { return false } }) {
+                return "\(path) · image"
+            }
+            let lines = resultLineCount(result)
+            var label = path
+            let offset = intArg(obj["offset"])
+            if offset != nil || intArg(obj["limit"]) != nil {
+                let start = offset ?? 1
+                label += ":\(start)-\(start + max(lines, 1) - 1)"
+            }
+            return "\(label) · \(lines) \(lines == 1 ? "line" : "lines")"
+        case "grep":
+            guard case .string(let pattern) = obj["pattern"] ?? .null else { return nil }
+            let matches = detailsArray(result, key: "matches")
+            var label = "\"\(truncate(pattern, to: 60))\""
+            if case .string(let path) = obj["path"] ?? .null {
+                label += " in \(path)"
+            }
+            if matches.isEmpty {
+                return "\(label) · no matches"
+            }
+            var files = Set<String>()
+            for m in matches {
+                if case .object(let mo) = m, case .string(let f) = mo["file"] ?? .null {
+                    files.insert(f)
+                }
+            }
+            label += " · \(matches.count) \(matches.count == 1 ? "match" : "matches")"
+            if files.count > 1 {
+                label += " · \(files.count) files"
+            }
+            return label
+        case "find":
+            guard case .string(let pattern) = obj["pattern"] ?? .null else { return nil }
+            var label = "\"\(truncate(pattern, to: 60))\""
+            // Surface the search root: `find "*.swift"` scoped to a subdir
+            // that has no top-level match reads as a mysterious "no files"
+            // otherwise (the glob's `*` doesn't cross `/`).
+            if case .string(let path) = obj["path"] ?? .null {
+                label += " in \(path)"
+            }
+            let files = detailsArray(result, key: "files")
+            let count = files.isEmpty ? "no files" : "\(files.count) \(files.count == 1 ? "file" : "files")"
+            return "\(label) · \(count)"
+        case "ls":
+            let path: String = {
+                if case .string(let p) = obj["path"] ?? .null { return p }
+                return "."
+            }()
+            let entries = detailsArray(result, key: "entries")
+            return "\(path) · \(entries.count) \(entries.count == 1 ? "entry" : "entries")"
+        default:
+            return nil
+        }
+    }
+
+    private func intArg(_ v: JSONValue?) -> Int? {
+        switch v ?? .null {
+        case .int(let i): return i
+        case .double(let d): return Int(d)
+        default: return nil
+        }
+    }
+
+    private func detailsArray(_ result: AgentToolResult, key: String) -> [JSONValue] {
+        guard case .object(let details) = result.details ?? .null,
+              case .array(let arr) = details[key] ?? .null else { return [] }
+        return arr
+    }
+
+    /// Count the content lines of a tool result, excluding the trailing
+    /// `[Showing lines X-Y of Z…]`-style bracket note the read tool appends
+    /// after a blank line.
+    private func resultLineCount(_ result: AgentToolResult) -> Int {
+        let text = result.content.compactMap { block -> String? in
+            if case .text(let t) = block { return t.text } else { return nil }
+        }.joined(separator: "\n")
+        var lines = text.components(separatedBy: "\n")
+        if lines.count >= 3,
+           let last = lines.last, last.hasPrefix("["), last.hasSuffix("]"),
+           lines[lines.count - 2].isEmpty {
+            lines.removeLast(2)
+        }
+        return lines.count
     }
 
     private func formatToolResult(_ result: AgentToolResult, isError: Bool) -> [String] {

--- a/Sources/KWWKCli/TranscriptSnapshot.swift
+++ b/Sources/KWWKCli/TranscriptSnapshot.swift
@@ -1,75 +1,52 @@
 import Foundation
 import KWWKAI
+import KWWKAgent
 
 /// Render a stored `[Message]` transcript into display lines for the retained
-/// frame. Used by `/resume` to show a readable history of the session being
-/// restored (the model itself receives the full messages; this is only the
-/// visual recap). Deliberately compact: user turns, assistant prose, and a
-/// one-line marker per tool call. Thinking blocks and tool results are
-/// omitted to keep the recap skimmable.
+/// frame. Used by `/resume` and `/rewind` to repaint history.
+///
+/// Replays the messages through a fresh `TranscriptRenderer` as synthetic
+/// agent events, so the recap is rendered by the exact same code path as the
+/// live stream: user bars, markdown-committed assistant prose, `●` tool
+/// blocks with result previews, folded read runs — and, critically, one
+/// physical line per array element (embedded newlines are split), which the
+/// raw-mode terminal requires. Thinking blocks don't replay (they only ever
+/// render from live deltas); tool `uiDisplay` summaries aren't persisted, so
+/// replayed tool results show the default content preview.
+@MainActor
 enum TranscriptSnapshot {
     static func render(_ messages: [Message], width: Int) -> [String] {
-        var out: [String] = []
+        let renderer = TranscriptRenderer()
+        renderer.displayWidth = width
         for message in messages {
             switch message {
-            case .user(let u):
-                let text = userText(u)
-                guard !text.isEmpty else { continue }
-                if !out.isEmpty { out.append("") }
-                out.append(Theme.paint("❯ \(text)", Theme.text, bold: true))
+            case .user:
+                renderer.apply(.messageStart(message: message))
             case .assistant(let a):
-                var blockLines: [String] = []
+                renderer.apply(.messageStart(message: message))
+                renderer.apply(.messageEnd(message: message))
                 for block in a.content {
-                    switch block {
-                    case .text(let t):
-                        let trimmed = t.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty { blockLines.append(Theme.bodyText(trimmed)) }
-                    case .toolCall(let call):
-                        blockLines.append(Theme.accentText("● \(call.name)\(argHint(call.arguments))", bold: false))
-                    case .thinking:
-                        continue
+                    if case .toolCall(let call) = block {
+                        renderer.apply(.toolExecutionStart(
+                            toolCallId: call.id, toolName: call.name, args: call.arguments))
                     }
                 }
-                guard !blockLines.isEmpty else { continue }
-                if !out.isEmpty { out.append("") }
-                out.append(contentsOf: blockLines)
-            case .toolResult:
-                continue
+            case .toolResult(let tr):
+                renderer.apply(.toolExecutionEnd(
+                    toolCallId: tr.toolCallId,
+                    toolName: tr.toolName,
+                    result: AgentToolResult(content: tr.content, details: tr.details),
+                    isError: tr.isError
+                ))
             }
         }
-        return out
-    }
-
-    private static func userText(_ u: UserMessage) -> String {
-        let text = u.content.compactMap { block -> String? in
-            if case .text(let t) = block { return t.text }
-            return nil
-        }.joined(separator: " ")
-        // Drop synthetic system blocks (task notifications, attachment
-        // manifests) so the recap shows only real user prose.
-        if text.hasPrefix("<") { return "" }
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Short single-arg hint for a tool call, e.g. `(path: Foo.swift)`.
-    private static func argHint(_ args: JSONValue) -> String {
-        guard case .object(let fields) = args, !fields.isEmpty else { return "" }
-        let preferred = ["path", "file_path", "command", "pattern", "query", "cmd"]
-        let key = preferred.first { fields[$0] != nil } ?? fields.keys.sorted().first
-        guard let key, let value = fields[key] else { return "" }
-        let str = scalar(value)
-        guard !str.isEmpty else { return "" }
-        let clipped = str.count > 40 ? String(str.prefix(40)) + "…" : str
-        return "(\(key): \(clipped))"
-    }
-
-    private static func scalar(_ v: JSONValue) -> String {
-        switch v {
-        case .string(let s): return s.replacingOccurrences(of: "\n", with: " ")
-        case .int(let i): return String(i)
-        case .double(let d): return String(d)
-        case .bool(let b): return String(b)
-        default: return ""
-        }
+        // Seal any trailing read-only fold run into its count-headed tree block.
+        // A trailing tool call with no persisted result (the process died
+        // mid-execution) stays in the renderer's live zone and is deliberately
+        // dropped from the recap — a frozen "calling…" row in scrollback reads
+        // worse than the call simply not appearing, and the resumed model
+        // context has no result for it either.
+        renderer.sealFoldRun()
+        return renderer.drainCommits()
     }
 }

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -577,6 +577,36 @@ struct GrepToolTests {
         #expect(output.contains("needle two"))
         #expect(!output.contains("something else"))
     }
+
+    @Test("a glob with a slash matches relative to the search root")
+    func slashGlobMatchesRelativeToRoot() async throws {
+        // makeTempDir lives under /var on macOS — a firmlink the enumerator
+        // resolves to /private/var. The relative-path slice must use the same
+        // canonical base or the glob prefix is cut at the wrong offset and
+        // nothing matches (the bug Glob.canonicalDirectoryPath fixes).
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent("src/nested"), withIntermediateDirectories: true)
+        try write("needle direct", to: dir.appendingPathComponent("src/direct.swift"))
+        try write("needle buried", to: dir.appendingPathComponent("src/nested/buried.swift"))
+        try write("needle outside", to: dir.appendingPathComponent("top.swift"))
+
+        let tool = createGrepTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-1",
+            [
+                "pattern": .string("needle"),
+                "path": .string(dir.path),
+                "glob": .string("src/*.swift"),
+            ],
+            nil, nil
+        )
+        let output = textOutput(result)
+        #expect(output.contains("needle direct"))
+        // `src/*.swift` does not cross into src/nested and never leaves src.
+        #expect(!output.contains("needle buried"))
+        #expect(!output.contains("needle outside"))
+    }
 }
 
 @Suite("Find tool")
@@ -600,6 +630,50 @@ struct FindToolTests {
         #expect(output.contains("one.swift"))
         #expect(output.contains("two.swift"))
         #expect(!output.contains("three.txt"))
+    }
+
+    @Test("a slashless pattern matches by name at any depth (recursive)")
+    func slashlessPatternRecurses() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent("sub/deep"), withIntermediateDirectories: true)
+        try write("x", to: dir.appendingPathComponent("top.swift"))
+        try write("x", to: dir.appendingPathComponent("sub/mid.swift"))
+        try write("x", to: dir.appendingPathComponent("sub/deep/low.swift"))
+        try write("x", to: dir.appendingPathComponent("sub/note.txt"))
+
+        let tool = createFindTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-1",
+            ["pattern": .string("*.swift"), "path": .string(dir.path)],
+            nil, nil
+        )
+        let output = textOutput(result)
+        // Every .swift, regardless of depth — not just the top-level one.
+        #expect(output.contains("top.swift"))
+        #expect(output.contains("mid.swift"))
+        #expect(output.contains("low.swift"))
+        #expect(!output.contains("note.txt"))
+    }
+
+    @Test("a pattern with a slash scopes to that directory, not deeper")
+    func slashPatternScopesToDirectory() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent("src/nested"), withIntermediateDirectories: true)
+        try write("x", to: dir.appendingPathComponent("src/direct.swift"))
+        try write("x", to: dir.appendingPathComponent("src/nested/buried.swift"))
+
+        let tool = createFindTool(cwd: dir.path)
+        let result = try await tool.execute(
+            "call-1",
+            ["pattern": .string("src/*.swift"), "path": .string(dir.path)],
+            nil, nil
+        )
+        let output = textOutput(result)
+        #expect(output.contains("direct.swift"))
+        // `src/*.swift` does not cross into src/nested — that needs src/**/*.swift.
+        #expect(!output.contains("buried.swift"))
     }
 }
 

--- a/Tests/KWWKAgentTests/SessionStoreTests.swift
+++ b/Tests/KWWKAgentTests/SessionStoreTests.swift
@@ -281,7 +281,8 @@ struct SessionStoreTests {
             replacementMessages: [summary],
             messagesCompacted: before.count,
             tokensBefore: 123,
-            contextWindow: 456
+            contextWindow: 456,
+            reason: .compact
         )
 
         let after = userMsg("after compact")
@@ -289,7 +290,7 @@ struct SessionStoreTests {
 
         let loaded = try await store.load(id: id)
         #expect(loaded.messages == [summary, after])
-        #expect(loaded.transcriptMessages == before + [after])
+        #expect(loaded.displayMessages == before + [after])
         #expect(loaded.persistedContextCount == 2)
 
         let raw = try String(contentsOf: dir.appendingPathComponent("\(id).jsonl"), encoding: .utf8)
@@ -313,7 +314,8 @@ struct SessionStoreTests {
             id: id,
             cwd: cwd,
             replacementMessages: [firstSummary],
-            messagesCompacted: 2
+            messagesCompacted: 2,
+            reason: .compact
         )
 
         let c = userMsg("c")
@@ -324,7 +326,8 @@ struct SessionStoreTests {
             id: id,
             cwd: cwd,
             replacementMessages: [secondSummary],
-            messagesCompacted: 2
+            messagesCompacted: 2,
+            reason: .compact
         )
 
         let d = assistantMsg("d")
@@ -332,8 +335,146 @@ struct SessionStoreTests {
 
         let loaded = try await store.load(id: id)
         #expect(loaded.messages == [secondSummary, d])
-        #expect(loaded.transcriptMessages == [a, b, c, d])
+        #expect(loaded.displayMessages == [a, b, c, d])
         #expect(loaded.persistedContextCount == 2)
+    }
+
+    @Test("context compaction leaves displayMessages (the visual history) intact")
+    func compactionKeepsDisplayMessages() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-display-compact"
+        let cwd = "/w"
+        let before = [userMsg("one"), assistantMsg("two")]
+        try await store.append(id: id, cwd: cwd, messages: before)
+
+        let summary = userMsg("<previous-session-summary>one-two</previous-session-summary>")
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [summary],
+            messagesCompacted: before.count,
+            reason: .compact
+        )
+
+        let after = userMsg("after")
+        try await store.append(id: id, cwd: cwd, message: after)
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [summary, after])
+        #expect(loaded.displayMessages == before + [after])
+    }
+
+    @Test("rewind compaction truncates displayMessages to the kept prefix")
+    func rewindTruncatesDisplayMessages() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-display-rewind"
+        let cwd = "/w"
+        let a = userMsg("a")
+        let b = assistantMsg("b")
+        let c = userMsg("c")
+        let d = assistantMsg("d")
+        try await store.append(id: id, cwd: cwd, messages: [a, b, c, d])
+
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [a, b],
+            messagesCompacted: 2,
+            reason: .rewind
+        )
+
+        let e = userMsg("e")
+        try await store.append(id: id, cwd: cwd, message: e)
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [a, b, e])
+        #expect(loaded.displayMessages == [a, b, e])
+
+        let resolved = try await store.resolveResume(.id(id), cwd: cwd)
+        #expect(resolved.displayMessages == [a, b, e])
+    }
+
+    @Test("rewind after a context compaction keeps the pre-compact visual history")
+    func rewindAfterCompactionKeepsDisplayHistory() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-compact-then-rewind"
+        let cwd = "/w"
+        let a = userMsg("a")
+        let b = assistantMsg("b")
+        let c = userMsg("c")
+        let d = assistantMsg("d")
+        try await store.append(id: id, cwd: cwd, messages: [a, b, c, d])
+
+        // Context compaction: the model context becomes summary + kept tail;
+        // the visual history is untouched.
+        let summary = userMsg("<previous-session-summary>a-b</previous-session-summary>")
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [summary, c, d],
+            messagesCompacted: 2,
+            reason: .compact
+        )
+
+        let e = userMsg("e")
+        let f = assistantMsg("f")
+        try await store.append(id: id, cwd: cwd, messages: [e, f])
+
+        // Rewind at prompt `e`: the kept model prefix starts with the summary
+        // message the user never saw. The display history must drop the same
+        // tail (e, f) but keep everything the compaction summarized away.
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [summary, c, d],
+            messagesCompacted: 2,
+            reason: .rewind
+        )
+
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [summary, c, d])
+        #expect(loaded.displayMessages == [a, b, c, d])
+    }
+
+    @Test("legacy compaction entries (no reason field) truncate both contexts")
+    func legacyCompactionTruncatesBoth() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-legacy-compaction"
+        let cwd = "/w"
+        let a = userMsg("a")
+        let b = assistantMsg("b")
+        let c = userMsg("c")
+        let d = assistantMsg("d")
+        try await store.append(id: id, cwd: cwd, messages: [a, b, c, d])
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [a, b],
+            messagesCompacted: 2,
+            reason: .rewind
+        )
+        let e = userMsg("e")
+        try await store.append(id: id, cwd: cwd, message: e)
+
+        // Strip the reason field to reproduce a pre-CompactionReason file.
+        let file = dir.appendingPathComponent("\(id).jsonl")
+        let raw = try String(contentsOf: file, encoding: .utf8)
+        let legacy = raw.replacingOccurrences(of: #""reason":"rewind","#, with: "")
+        #expect(legacy != raw)
+        try legacy.write(to: file, atomically: true, encoding: .utf8)
+
+        // Legacy entries predate the model/display split and truncated both.
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [a, b, e])
+        #expect(loaded.displayMessages == [a, b, e])
     }
 
     @Test("resolveResume(.latestForCwd) seeds the stored transcript")
@@ -411,7 +552,8 @@ struct SessionStoreTests {
             messages: [summary],
             messagesCompacted: before.count,
             tokensBefore: 99,
-            contextWindow: 1000
+            contextWindow: 1000,
+            reason: .compact
         )
 
         let after = userMsg("post-compact")
@@ -419,7 +561,7 @@ struct SessionStoreTests {
 
         let loaded = try await store.load(id: id)
         #expect(loaded.messages == [summary, after])
-        #expect(loaded.transcriptMessages == before + [after])
+        #expect(loaded.displayMessages == before + [after])
         #expect(loaded.persistedContextCount == 2)
 
         let raw = try String(contentsOf: dir.appendingPathComponent("\(id).jsonl"), encoding: .utf8)
@@ -480,7 +622,7 @@ struct SessionStoreTests {
         let loaded = try await store.load(id: id)
         #expect(loaded.messages.count == 1)
         #expect(text(from: loaded.messages.first).contains("event summary"))
-        #expect(loaded.transcriptMessages.count > loaded.messages.count)
+        #expect(loaded.displayMessages.count > loaded.messages.count)
         #expect(loaded.persistedContextCount == 1)
 
         let resolved = try await store.resolveResume(.id(id), cwd: "/w", freshId: "fresh")

--- a/Tests/KWWKCliTests/NewSlashCommandTests.swift
+++ b/Tests/KWWKCliTests/NewSlashCommandTests.swift
@@ -12,13 +12,13 @@ struct NewSlashCommandTests {
     func registeredAndInHelp() async {
         let registry = SlashCommandRegistry()
         registerBuiltinSlashCommands(registry)
-        for name in ["context", "init", "tools", "hotkeys", "copy", "dump", "rename"] {
+        for name in ["context", "init", "tools", "hotkeys", "copy", "rename"] {
             #expect(registry.find(name) != nil, "/\(name) should be registered")
         }
 
         let (ctx, notifier) = await makeContext()
         await registry.find("help")?.handler(ctx, "")
-        for name in ["context", "init", "tools", "hotkeys", "copy", "dump", "rename"] {
+        for name in ["context", "init", "tools", "hotkeys", "copy", "rename"] {
             #expect(notifier.joined.contains("/\(name)"), "/help should list /\(name)")
         }
     }

--- a/Tests/KWWKCliTests/TranscriptCommitTests.swift
+++ b/Tests/KWWKCliTests/TranscriptCommitTests.swift
@@ -63,8 +63,8 @@ struct TranscriptCommitTests {
     }
 
     @MainActor
-    @Test("assistant partial text is buffered until messageEnd")
-    func assistantPartialTextBuffersUntilEnd() {
+    @Test("assistant partial text streams live and commits on messageEnd")
+    func assistantPartialTextStreamsLive() {
         let r = TranscriptRenderer()
 
         r.apply(.messageStart(message: .assistant(stubAssistant(""))))
@@ -74,17 +74,52 @@ struct TranscriptCommitTests {
             assistantMessageEvent: .textDelta(contentIndex: 0, delta: "hello", partial: partial)
         ))
 
-        // Mid-stream without a stable segment boundary: no text is committed
-        // and no assistant text enters the retained live zone.
+        // Mid-stream without a stable segment boundary: nothing is committed,
+        // but the token tail is visible in the live zone — with the same
+        // leading blank its committed form will carry.
         #expect(r.drainCommits().isEmpty)
-        #expect(!r.liveLines.contains(where: { $0.contains("hello") }))
+        #expect(r.liveLines == ["", "hello"])
 
         // On end: the buffered tail moves to the commit buffer with a leading
-        // blank (no trailing one), live stays empty.
+        // blank (no trailing one), live empties.
         r.apply(.messageEnd(message: .assistant(stubAssistant("hello"))))
         let commits = r.drainCommits()
         #expect(commits == ["", "hello"])
         #expect(r.liveLines.isEmpty)
+    }
+
+    @MainActor
+    @Test("live tail after a committed line carries no extra leading blank")
+    func liveTailAfterCommittedLineHasNoBlank() {
+        let r = TranscriptRenderer()
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("line1\nline2")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .textDelta(contentIndex: 0, delta: "line1\nline2", partial: partial)
+        ))
+
+        // "line1" settled into scrollback; the tail "line2" continues the
+        // same block, so live shows it without another separator row.
+        #expect(r.drainCommits() == ["", "line1"])
+        #expect(r.liveLines == ["line2"])
+    }
+
+    @MainActor
+    @Test("streamRewind clears the live tail")
+    func streamRewindClearsLiveTail() {
+        let r = TranscriptRenderer()
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("doomed tail")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .textDelta(contentIndex: 0, delta: "doomed tail", partial: partial)
+        ))
+        #expect(r.liveLines.contains(where: { $0.contains("doomed tail") }))
+
+        r.apply(.streamRewind)
+        #expect(!r.liveLines.contains(where: { $0.contains("doomed tail") }))
+        #expect(r.drainCommits().isEmpty, "an uncommitted tail leaves no trace after rewind")
     }
 
     @MainActor
@@ -100,10 +135,12 @@ struct TranscriptCommitTests {
         ))
 
         #expect(r.drainCommits() == ["", "line1"])
-        #expect(r.liveLines.isEmpty)
+        // The unsettled tail stays visible in the live zone until it commits.
+        #expect(r.liveLines == ["line2"])
 
         r.apply(.messageEnd(message: .assistant(stubAssistant("line1\nline2"))))
         #expect(r.drainCommits() == ["line2"])
+        #expect(r.liveLines.isEmpty)
     }
 
     @MainActor
@@ -352,6 +389,277 @@ struct TranscriptCommitTests {
     }
 
     @MainActor
+    @Test("a lone successful read folds to a one-row group, sealed by assistant text")
+    func readFoldsToOneLine() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("src/foo.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("line1\nline2\nline3"),
+            isError: false
+        ))
+
+        // The read joins the pending run: nothing committed yet, but the
+        // stable group form (header + one tree row) is visible live.
+        #expect(r.drainCommits().isEmpty)
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.contains("● read 1 file") }))
+        #expect(live.contains(where: { $0.contains("└ read src/foo.swift · 3 lines") }))
+        #expect(!live.contains(where: { $0.contains("line1") }))
+
+        // Assistant text entering scrollback seals the run ahead of it.
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        r.apply(.messageEnd(message: .assistant(stubAssistant("done"))))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        let readIdx = commits.firstIndex(where: { $0.contains("└ read src/foo.swift · 3 lines") })
+        let textIdx = commits.firstIndex(where: { $0 == "done" })
+        #expect(readIdx != nil && textIdx != nil)
+        #expect((readIdx ?? 0) < (textIdx ?? 0))
+        // No content preview lines in scrollback.
+        #expect(!commits.contains(where: { $0.contains("line1") }))
+    }
+
+    @MainActor
+    @Test("consecutive reads merge into a tools (N) tree")
+    func consecutiveReadsMergeIntoTree() {
+        let r = TranscriptRenderer()
+        for (id, path) in [("1", "a.swift"), ("2", "b.swift"), ("3", "c.swift")] {
+            r.apply(.toolExecutionStart(
+                toolCallId: id, toolName: "read",
+                args: .object(["path": .string(path)])
+            ))
+            r.apply(.toolExecutionEnd(
+                toolCallId: id, toolName: "read",
+                result: toolResult("x\ny"),
+                isError: false
+            ))
+        }
+
+        #expect(r.drainCommits().isEmpty)
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.contains("● read 3 files") }))
+        #expect(live.contains(where: { $0.contains("├ read a.swift") }))
+        #expect(live.contains(where: { $0.contains("└ read c.swift") }))
+
+        // A non-folded tool block seals the run before its own output.
+        r.apply(.toolExecutionStart(toolCallId: "4", toolName: "bash", args: .object([:])))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "4", toolName: "bash",
+            result: toolResult("ok"), isError: false
+        ))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        let treeIdx = commits.firstIndex(where: { $0.contains("● read 3 files") })
+        let bashIdx = commits.firstIndex(where: { $0.contains("bash") })
+        #expect(treeIdx != nil && bashIdx != nil)
+        #expect((treeIdx ?? 0) < (bashIdx ?? 0))
+        #expect(r.liveLines.isEmpty)
+    }
+
+    @MainActor
+    @Test("mixed read/grep/ls calls merge into one tools (N) tree")
+    func mixedReadOnlyToolsMergeIntoOneTree() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(toolCallId: "1", toolName: "ls", args: .object([:])))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "ls",
+            result: AgentToolResult(
+                content: [.text(TextContent(text: "a\nb"))],
+                details: .object(["entries": .array([
+                    .object(["name": .string("a"), "kind": .string("file"), "size": .int(0)]),
+                    .object(["name": .string("b"), "kind": .string("file"), "size": .int(0)]),
+                ])])
+            ),
+            isError: false
+        ))
+        r.apply(.toolExecutionStart(
+            toolCallId: "2", toolName: "read",
+            args: .object(["path": .string("README.md")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "2", toolName: "read",
+            result: toolResult("x\ny\nz"), isError: false
+        ))
+        r.apply(.toolExecutionStart(
+            toolCallId: "3", toolName: "grep",
+            args: .object(["pattern": .string("foo")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "3", toolName: "grep",
+            result: AgentToolResult(
+                content: [.text(TextContent(text: "a.swift:1:foo"))],
+                details: .object(["matches": .array([
+                    .object(["file": .string("a.swift"), "line": .int(1), "text": .string("foo")]),
+                ])])
+            ),
+            isError: false
+        ))
+
+        // All three sit in one live group with no per-call blank rows, and
+        // the header counts each tool type in first-appearance order.
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.contains("● ls 1 time, read 1 file, grep 1 time") }))
+        #expect(live.contains(where: { $0.contains("├ ls . · 2 entries") }))
+        #expect(live.contains(where: { $0.contains("├ read README.md · 3 lines") }))
+        #expect(live.contains(where: { $0.contains("└ grep \"foo\" · 1 match") }))
+        // Exactly one leading blank for the whole group — no blank between rows.
+        #expect(live.first == "")
+        #expect(!live.dropFirst().contains(""))
+
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.contains("● ls 1 time, read 1 file, grep 1 time") }))
+        #expect(commits.contains(where: { $0.contains("├ ls . · 2 entries") }))
+        #expect(commits.contains(where: { $0.contains("└ grep \"foo\" · 1 match") }))
+    }
+
+    @MainActor
+    @Test("in-flight read-only calls render inside the group while running")
+    func runningCallsRenderInsideGroup() {
+        let r = TranscriptRenderer()
+        // First read finishes; second is still running.
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("done.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("x\ny"), isError: false
+        ))
+        r.apply(.toolExecutionStart(
+            toolCallId: "2", toolName: "grep",
+            args: .object(["pattern": .string("wip")])
+        ))
+
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        // One group, header counts both the finished read and the running
+        // grep — the in-flight call is not a separate block.
+        #expect(live.contains(where: { $0.contains("● read 1 file, grep 1 time") }))
+        #expect(live.contains(where: { $0.contains("├ read done.swift · 2 lines") }))
+        // Running grep shows its target, no count yet, and no "calling…".
+        #expect(live.contains(where: { $0.contains("└ grep \"wip\"") }))
+        #expect(!live.contains(where: { $0.contains("calling") }))
+        #expect(!live.contains(where: { $0.contains("grep(pattern") }))
+
+        // When it resolves the row fills in its count in place.
+        r.apply(.toolExecutionEnd(
+            toolCallId: "2", toolName: "grep",
+            result: AgentToolResult(
+                content: [.text(TextContent(text: "a:1:wip"))],
+                details: .object(["matches": .array([
+                    .object(["file": .string("a"), "line": .int(1), "text": .string("wip")]),
+                ])])
+            ),
+            isError: false
+        ))
+        let live2 = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live2.contains(where: { $0.contains("└ grep \"wip\" · 1 match") }))
+    }
+
+    @MainActor
+    @Test("a folded read resolving behind a running non-folded tool renders as a tree, not a standalone line")
+    func blockedFoldableRendersAsTree() {
+        let r = TranscriptRenderer()
+        // A non-folded tool starts first and stays running, blocking the
+        // queue; a read starts after it and resolves while still blocked.
+        r.apply(.toolExecutionStart(toolCallId: "b", toolName: "bash", args: .object(["cmd": .string("sleep")])))
+        r.apply(.toolExecutionStart(
+            toolCallId: "r", toolName: "read",
+            args: .object(["path": .string("a.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "r", toolName: "read",
+            result: toolResult("x\ny"), isError: false
+        ))
+
+        // Live: the blocked read must render as its own one-row tree (header +
+        // row), byte-identical to the form it will settle into — never a
+        // standalone `● read a.swift` line that would reflow on commit.
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.contains("● read 1 file") }))
+        #expect(live.contains(where: { $0.contains("└ read a.swift · 2 lines") }))
+
+        // When bash resolves, the read joins the pending fold run (still open
+        // so later read/grep calls can merge into the same tree); the turn end
+        // seals it into scrollback in the exact same tree form — no reflow.
+        r.apply(.toolExecutionEnd(
+            toolCallId: "b", toolName: "bash",
+            result: toolResult("done"), isError: false
+        ))
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.contains("● read 1 file") }))
+        #expect(commits.contains(where: { $0.contains("└ read a.swift · 2 lines") }))
+    }
+
+    @MainActor
+    @Test("agentEnd seals a pending fold run")
+    func agentEndSealsReadRun() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("a.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("x"), isError: false
+        ))
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.contains("● read 1 file") }))
+        #expect(commits.contains(where: { $0.contains("└ read a.swift · 1 line") }))
+        #expect(r.liveLines.isEmpty)
+    }
+
+    @MainActor
+    @Test("a lone grep folds to a one-line summary with match counts")
+    func grepFoldsToSummaryLine() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "grep",
+            args: .object(["pattern": .string("needle")])
+        ))
+        let result = AgentToolResult(
+            content: [.text(TextContent(text: "a.swift:1:needle\nb.swift:2:needle\nb.swift:9:needle"))],
+            details: .object(["matches": .array([
+                .object(["file": .string("a.swift"), "line": .int(1), "text": .string("needle")]),
+                .object(["file": .string("b.swift"), "line": .int(2), "text": .string("needle")]),
+                .object(["file": .string("b.swift"), "line": .int(9), "text": .string("needle")]),
+            ])])
+        )
+        r.apply(.toolExecutionEnd(toolCallId: "1", toolName: "grep", result: result, isError: false))
+        // A lone read-only call is held in the fold run; agentEnd seals it
+        // as a single `● grep …` line (no tree).
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.contains("● grep 1 time") }))
+        #expect(commits.contains(where: { $0.contains("└ grep \"needle\" · 3 matches · 2 files") }))
+        // Match content lines never reach scrollback.
+        #expect(!commits.contains(where: { $0.contains("a.swift:1:needle") }))
+    }
+
+    @MainActor
+    @Test("read errors keep the full unfolded error block")
+    func readErrorKeepsFullBlock() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("missing.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("file not found: missing.swift"),
+            isError: true
+        ))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.contains("● read(path: \"missing.swift\")") }))
+        #expect(commits.contains(where: { $0.contains("file not found") }))
+    }
+
+    @MainActor
     @Test("drainCommits yields each batch exactly once")
     func drainIsIdempotent() {
         let r = TranscriptRenderer()
@@ -364,7 +672,7 @@ struct TranscriptCommitTests {
     }
 
     @MainActor
-    @Test("incomplete assistant text is not committed or retained live")
+    @Test("incomplete assistant text stays out of scrollback but shows live")
     func incompleteAssistantTextDoesNotSpill() {
         let r = TranscriptRenderer()
         r.apply(.messageStart(message: .assistant(stubAssistant(""))))
@@ -375,7 +683,243 @@ struct TranscriptCommitTests {
         ))
 
         #expect(r.drainCommits().isEmpty)
-        #expect(r.liveLines.isEmpty)
+        #expect(r.liveLines.contains(where: { $0.contains("unfinished text") }))
+    }
+
+    @MainActor
+    @Test("live tail renders below a pending read run, matching commit order")
+    func liveTailOrdersAfterReadRun() {
+        let r = TranscriptRenderer()
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("a.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("x"), isError: false
+        ))
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("summarizing")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .textDelta(contentIndex: 0, delta: "summarizing", partial: partial)
+        ))
+
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        let readIdx = live.firstIndex(where: { $0.contains("└ read a.swift") })
+        let tailIdx = live.firstIndex(where: { $0.contains("summarizing") })
+        #expect(readIdx != nil && tailIdx != nil)
+        #expect((readIdx ?? 0) < (tailIdx ?? 0))
+
+        // When the tail settles, the run seals above it — same order.
+        r.apply(.messageEnd(message: .assistant(stubAssistant("summarizing"))))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        let cReadIdx = commits.firstIndex(where: { $0.contains("└ read a.swift") })
+        let cTextIdx = commits.firstIndex(where: { $0.contains("summarizing") })
+        #expect(cReadIdx != nil && cTextIdx != nil)
+        #expect((cReadIdx ?? 0) < (cTextIdx ?? 0))
+    }
+
+    @MainActor
+    @Test("collapsed thinking shows a ticking label live and commits a timing row")
+    func collapsedThinkingLabel() {
+        let r = TranscriptRenderer()
+        // Show reasoning of any length so the synchronous test doesn't have
+        // to burn 3s of wall clock to cross the visibility threshold.
+        r.collapsedThinkingMinSeconds = 0
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingDelta(contentIndex: 0, delta: "pondering deeply", partial: partial)
+        ))
+
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.hasPrefix("[thinking ") }))
+        // Collapsed mode: the body never renders.
+        #expect(!live.contains(where: { $0.contains("pondering deeply") }))
+        #expect(r.hasActiveThinking)
+
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingEnd(contentIndex: 0, content: "pondering deeply", partial: partial)
+        ))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.hasPrefix("[thought for ") }))
+        #expect(!commits.contains(where: { $0.contains("pondering deeply") }))
+        #expect(!r.hasActiveThinking)
+        #expect(!r.liveLines.contains(where: { $0.contains("[thinking") }))
+    }
+
+    @MainActor
+    @Test("expanded thinking streams its body live and commits it on end")
+    func expandedThinkingStreamsBody() {
+        let r = TranscriptRenderer()
+        r.setThinkingDisplay(.expanded)
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingDelta(contentIndex: 0, delta: "step one\nstep two", partial: partial)
+        ))
+
+        let live = r.liveLines.map(ANSI.stripEscapes)
+        #expect(live.contains(where: { $0.contains("step one") }))
+        #expect(live.contains(where: { $0.contains("step two") }))
+
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingEnd(contentIndex: 0, content: "step one\nstep two", partial: partial)
+        ))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.hasPrefix("[thought for ") }))
+        #expect(commits.contains(where: { $0.contains("step one") }))
+        #expect(commits.contains(where: { $0.contains("step two") }))
+    }
+
+    @MainActor
+    @Test("aborted mid-thought commits the sealed thinking block on messageEnd")
+    func abortedThinkingCommitsOnEnd() {
+        let r = TranscriptRenderer()
+        r.collapsedThinkingMinSeconds = 0
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingDelta(contentIndex: 0, delta: "interrupted thought", partial: partial)
+        ))
+
+        // No thinkingEnd — the turn aborts.
+        r.apply(.messageEnd(message: .assistant(stubAssistant("", stop: .aborted))))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(commits.contains(where: { $0.hasPrefix("[thought for ") }))
+        #expect(!r.hasActiveThinking)
+    }
+
+    @MainActor
+    @Test("collapsed thinking under the threshold shows nothing, live or committed")
+    func shortCollapsedThinkingHidden() {
+        let r = TranscriptRenderer()
+        // Default 3s threshold; a synchronous think elapses ~0s.
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingDelta(contentIndex: 0, delta: "quick idea", partial: partial)
+        ))
+        // Not shown live while under threshold.
+        #expect(!r.liveLines.contains(where: { $0.contains("[thinking") }))
+
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingEnd(contentIndex: 0, content: "quick idea", partial: partial)
+        ))
+        r.apply(.messageEnd(message: .assistant(stubAssistant("done"))))
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(!commits.contains(where: { $0.contains("[thought for") }))
+        #expect(commits.contains(where: { $0 == "done" }))
+    }
+
+    @MainActor
+    @Test("a short think between read-only calls does not split the fold group")
+    func shortThinkKeepsFoldGroupIntact() {
+        let r = TranscriptRenderer()
+        // Two reads with a brief (sub-threshold) think wedged between them.
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("a.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("x"), isError: false
+        ))
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingEnd(contentIndex: 0, content: "hm", partial: partial)
+        ))
+        r.apply(.toolExecutionStart(
+            toolCallId: "2", toolName: "read",
+            args: .object(["path": .string("b.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "2", toolName: "read",
+            result: toolResult("y"), isError: false
+        ))
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+
+        // The sub-threshold think never committed, so it never sealed the
+        // run — both reads land in one group with no `[thought]` between.
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        #expect(!commits.contains(where: { $0.contains("[thought for") }))
+        #expect(commits.contains(where: { $0.contains("● read 2 files") }))
+        #expect(commits.contains(where: { $0.contains("├ read a.swift") }))
+        #expect(commits.contains(where: { $0.contains("└ read b.swift") }))
+    }
+
+    @MainActor
+    @Test("a shown (long) think seals the fold group like any other block")
+    func longThinkSealsFoldGroup() {
+        let r = TranscriptRenderer()
+        r.collapsedThinkingMinSeconds = 0  // make the think count as "shown"
+        r.apply(.toolExecutionStart(
+            toolCallId: "1", toolName: "read",
+            args: .object(["path": .string("a.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1", toolName: "read",
+            result: toolResult("x"), isError: false
+        ))
+        r.apply(.messageStart(message: .assistant(stubAssistant(""))))
+        let partial = stubAssistant("")
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingStart(contentIndex: 0, partial: partial)
+        ))
+        r.apply(.messageUpdate(
+            message: partial,
+            assistantMessageEvent: .thinkingEnd(contentIndex: 0, content: "deliberating", partial: partial)
+        ))
+        r.apply(.toolExecutionStart(
+            toolCallId: "2", toolName: "read",
+            args: .object(["path": .string("b.swift")])
+        ))
+        r.apply(.toolExecutionEnd(
+            toolCallId: "2", toolName: "read",
+            result: toolResult("y"), isError: false
+        ))
+        r.apply(.agentEnd(messages: [], summary: AgentRunSummary()))
+
+        // The shown think sits between two separate single-read groups,
+        // in chronological order.
+        let commits = r.drainCommits().map(ANSI.stripEscapes)
+        let firstRead = commits.firstIndex(where: { $0.contains("└ read a.swift") })
+        let thought = commits.firstIndex(where: { $0.contains("[thought for") })
+        let secondRead = commits.firstIndex(where: { $0.contains("└ read b.swift") })
+        #expect(firstRead != nil && thought != nil && secondRead != nil)
+        #expect((firstRead ?? 0) < (thought ?? 0))
+        #expect((thought ?? 0) < (secondRead ?? 0))
     }
 
     @MainActor

--- a/Tests/KWWKCliTests/TranscriptSnapshotTests.swift
+++ b/Tests/KWWKCliTests/TranscriptSnapshotTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+@testable import KWWKAgent
+@testable import KWWKCli
+
+/// TranscriptSnapshot replays a stored transcript through TranscriptRenderer,
+/// so a `/resume` / `/rewind` recap must look exactly like the live stream
+/// did. These tests pin the two properties the repaint path depends on:
+/// every element is ONE physical line (the TUI writes each element with its
+/// own `\r\n`; an embedded bare `\n` staircases in raw mode), and the recap
+/// carries the same user-bar / `●` tool blocks as live rendering.
+@Suite("TranscriptSnapshot replay")
+@MainActor
+struct TranscriptSnapshotTests {
+
+    private func assistant(_ blocks: [AssistantBlock]) -> Message {
+        .assistant(AssistantMessage(
+            content: blocks,
+            api: "faux",
+            provider: "faux",
+            model: "faux"
+        ))
+    }
+
+    @Test("multi-line assistant text splits into one element per physical line")
+    func noEmbeddedNewlines() {
+        let messages: [Message] = [
+            .user(UserMessage(text: "first\nprompt")),
+            assistant([.text(TextContent(text: "line one\n\n```sh\nswift test\n```\nline two"))]),
+        ]
+        let lines = TranscriptSnapshot.render(messages, width: 80)
+        #expect(!lines.isEmpty)
+        #expect(lines.allSatisfy { !$0.contains("\n") })
+        #expect(lines.contains { $0.contains("swift test") })
+    }
+
+    @Test("recap matches the live renderer's messageStart/messageEnd output")
+    func matchesLiveRenderer() {
+        let user = Message.user(UserMessage(text: "do the thing"))
+        let reply = assistant([.text(TextContent(text: "done\nwith detail"))])
+
+        let live = TranscriptRenderer()
+        live.displayWidth = 80
+        live.apply(.messageStart(message: user))
+        live.apply(.messageStart(message: reply))
+        live.apply(.messageEnd(message: reply))
+        let liveLines = live.drainCommits()
+
+        let recap = TranscriptSnapshot.render([user, reply], width: 80)
+        #expect(recap == liveLines)
+    }
+
+    @Test("tool calls replay as ● blocks with their result previews")
+    func toolBlocksReplay() {
+        let call = ToolCall(id: "t1", name: "bash", arguments: .object(["command": .string("ls")]))
+        let messages: [Message] = [
+            .user(UserMessage(text: "run ls")),
+            assistant([.toolCall(call)]),
+            .toolResult(ToolResultMessage(
+                toolCallId: "t1",
+                toolName: "bash",
+                content: [.text(TextContent(text: "a.txt\nb.txt"))]
+            )),
+        ]
+        let lines = TranscriptSnapshot.render(messages, width: 80)
+        #expect(lines.contains { $0.contains("● bash") })
+        #expect(lines.contains { $0.contains("a.txt") })
+        #expect(lines.allSatisfy { !$0.contains("\n") })
+    }
+}


### PR DESCRIPTION
## Summary
- Sessions track `displayMessages` (what the user saw) separately from the compacted model context: compaction markers carry a `reason` (`compact` vs `rewind`), rewind truncates the visual history by the dropped tail instead of replacing it with the model prefix — a post-compact rewind keeps the pre-compact screen history and never renders the summary XML as a user message; legacy no-`reason` entries keep the old truncate-both semantics. `/resume` and `/rewind` repaint from the stored visual history via a TranscriptRenderer replay.
- TUI rendering: read/grep/find/ls calls fold into count-headed tree groups, streaming text tails render live, and pure token deltas repaint on a ~30fps coalesced cadence (`RenderCoalescer`) instead of per delta.
- Also: fix firmlink-root relative-glob matching in `Glob.expand` and grep (shared `Glob.canonicalDirectoryPath`), make slashless `find` patterns recurse by basename, drop the dead `LoadedSession.transcriptMessages` channel and the defaulted `recordCompaction` reason, and remove the `/dump` command.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 929 tests, all passing, including new coverage for: post-compact rewind preserving display history, legacy (no-`reason`) compaction decoding/truncation, slash-anchored grep globs under a firmlinked root, and TranscriptSnapshot replay parity with live rendering

Made with [Cursor](https://cursor.com)