### PR TITLE
Update model catalog

### DIFF
--- a/Sources/KWWKAI/AnthropicProvider.swift
+++ b/Sources/KWWKAI/AnthropicProvider.swift
@@ -374,7 +374,8 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
             if adaptive {
                 // Adaptive thinking (Opus 4.6/4.7/4.8, Fable 5): Claude decides
                 // when/how much to think; we only pass an effort level via
-                // `output_config`. `max` is Opus-4.6-only; 4.7+/Fable map xhigh.
+                // `output_config`. Newer catalogs distinguish native `xhigh`
+                // from the unconstrained `max` effort.
                 root["thinking"] = ["type": "adaptive", "display": "summarized"]
                 root["output_config"] = ["effort": adaptiveEffort(model, reasoning)]
             } else {
@@ -487,26 +488,26 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
         message["content"] = content
     }
 
+    /// Map a reasoning level to an Anthropic adaptive-thinking effort, honoring
+    /// the per-model `thinkingLevelMap`. Falls back to pi's defaults:
+    /// minimal/low→low, medium→medium, and extended levels→high.
+    /// Valid efforts are low/medium/high/xhigh/max.
+    private static func adaptiveEffort(_ model: Model, _ reasoning: ReasoningLevel) -> String {
+        let level = clampThinkingLevel(model, ModelThinkingLevel(reasoning: reasoning))
+        if let map = model.thinkingLevelMap, let entry = map[level.rawValue], let mapped = entry {
+            return mapped
+        }
+        switch level {
+        case .minimal, .low: return "low"
+        case .medium: return "medium"
+        case .off, .high, .xhigh, .max: return "high"
+        }
+    }
+
     /// Fallback thinking budget per reasoning level when the caller didn't
     /// supply explicit `ThinkingBudgets`. Anthropic requires a minimum of
     /// 1024; these numbers are conservative enough to work across Claude
     /// 4.x Sonnet/Haiku/Opus without tripping per-model caps.
-    /// Map a reasoning level to an Anthropic adaptive-thinking effort, honoring
-    /// the per-model `thinkingLevelMap` (e.g. Opus 4.6 maps xhigh→"max"). Falls
-    /// back to pi's defaults: minimal/low→low, medium→medium, high/xhigh→high.
-    /// Valid efforts are low/medium/high/xhigh/max.
-    private static func adaptiveEffort(_ model: Model, _ reasoning: ReasoningLevel) -> String {
-        let level = ModelThinkingLevel(reasoning: reasoning)
-        if let map = model.thinkingLevelMap, let entry = map[level.rawValue], let mapped = entry {
-            return mapped
-        }
-        switch reasoning {
-        case .minimal, .low: return "low"
-        case .medium: return "medium"
-        case .high, .xhigh: return "high"
-        }
-    }
-
     private static func defaultThinkingBudget(for level: ReasoningLevel) -> Int {
         switch level {
         case .minimal: return 1024
@@ -514,6 +515,7 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
         case .medium: return 8192
         case .high: return 16_384
         case .xhigh: return 24_576
+        case .max: return 16_384
         }
     }
 

--- a/Sources/KWWKAI/BedrockProvider.swift
+++ b/Sources/KWWKAI/BedrockProvider.swift
@@ -415,11 +415,12 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
 
     private static func mapThinkingLevelToEffort(_ model: Model, _ level: ReasoningLevel) -> String {
         if level == .xhigh, supportsNativeXhighEffort(model) { return "xhigh" }
-        if let mapped = model.thinkingLevelMap?[level.rawValue], let m = mapped { return m }
-        switch level {
+        let clamped = clampThinkingLevel(model, ModelThinkingLevel(reasoning: level))
+        if let mapped = model.thinkingLevelMap?[clamped.rawValue], let m = mapped { return m }
+        switch clamped {
         case .minimal, .low: return "low"
         case .medium: return "medium"
-        case .high, .xhigh: return "high"
+        case .off, .high, .xhigh, .max: return "high"
         }
     }
 
@@ -455,9 +456,10 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
             ]
         } else {
             let defaults: [ReasoningLevel: Int] = [
-                .minimal: 1024, .low: 2048, .medium: 8192, .high: 16384, .xhigh: 16384,
+                .minimal: 1024, .low: 2048, .medium: 8192, .high: 16384,
+                .xhigh: 16384, .max: 16384,
             ]
-            let budgetLevel: ReasoningLevel = reasoning == .xhigh ? .high : reasoning
+            let budgetLevel: ReasoningLevel = reasoning == .xhigh || reasoning == .max ? .high : reasoning
             let budget = options?.thinkingBudgets?.budget(for: budgetLevel) ?? defaults[reasoning]!
             var thinking: [String: Any] = ["type": "enabled", "budget_tokens": budget]
             if let display { thinking["display"] = display }

--- a/Sources/KWWKAI/Context.swift
+++ b/Sources/KWWKAI/Context.swift
@@ -32,6 +32,7 @@ public enum ReasoningLevel: String, Codable, Sendable, Hashable {
     case medium
     case high
     case xhigh
+    case max
 }
 
 /// OpenAI Responses reasoning-summary verbosity. `nil` (field absent) ⇒

--- a/Sources/KWWKAI/Cursor/CursorAgentProvider.swift
+++ b/Sources/KWWKAI/Cursor/CursorAgentProvider.swift
@@ -60,16 +60,10 @@ public final class CursorAgentProvider: APIProvider, @unchecked Sendable {
     /// reasoning level to its wire id.
     static func wireModelId(model: Model, reasoning: ReasoningLevel?) -> String {
         guard let map = model.thinkingLevelMap else { return model.id }
-        let level = reasoning?.rawValue ?? "off"
-        // Fall down the ladder when the exact level has no entry (e.g. xhigh
-        // on a model whose routing tops out at high).
-        let ladder = ["xhigh", "high", "medium", "low", "minimal"]
-        var candidates = [level]
-        if let idx = ladder.firstIndex(of: level) {
-            candidates.append(contentsOf: ladder[(idx + 1)...])
-        }
-        for candidate in candidates {
-            if let entry = map[candidate], let mapped = entry { return mapped }
+        let requested = ModelThinkingLevel(reasoning: reasoning)
+        let clamped = clampThinkingLevel(model, requested)
+        if let entry = map[clamped.rawValue], let mapped = entry {
+            return mapped
         }
         return model.id
     }

--- a/Sources/KWWKAI/GoogleGeminiProvider.swift
+++ b/Sources/KWWKAI/GoogleGeminiProvider.swift
@@ -363,20 +363,20 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
         if isGemini3Pro(id) {
             switch reasoning {
             case .minimal, .low: return "LOW"
-            case .medium, .high, .xhigh: return "HIGH"
+            case .medium, .high, .xhigh, .max: return "HIGH"
             }
         }
         if isGemma4(id) {
             switch reasoning {
             case .minimal, .low: return "MINIMAL"
-            case .medium, .high, .xhigh: return "HIGH"
+            case .medium, .high, .xhigh, .max: return "HIGH"
             }
         }
         switch reasoning {
         case .minimal: return "MINIMAL"
         case .low: return "LOW"
         case .medium: return "MEDIUM"
-        case .high, .xhigh: return "HIGH"
+        case .high, .xhigh, .max: return "HIGH"
         }
     }
 
@@ -395,7 +395,7 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
             case .minimal: return minimal
             case .low: return low
             case .medium: return medium
-            case .high, .xhigh: return high
+            case .high, .xhigh, .max: return high
             }
         }
         if id.contains("2.5-pro") { return pick(128, 2048, 8192, 32768) }
@@ -629,7 +629,7 @@ extension ThinkingBudgets {
         case .minimal: return minimal
         case .low: return low
         case .medium: return medium
-        case .high, .xhigh: return high
+        case .high, .xhigh, .max: return high
         }
     }
 }

--- a/Sources/KWWKAI/Model.swift
+++ b/Sources/KWWKAI/Model.swift
@@ -5,18 +5,52 @@ public enum InputModality: String, Codable, Sendable, Hashable {
     case image
 }
 
-public struct ModelCost: Codable, Sendable, Hashable {
+public struct ModelCostTier: Codable, Sendable, Hashable {
+    /// Apply this tier when total input usage is strictly above the threshold.
+    public var inputTokensAbove: Int
     /// USD per 1M tokens.
     public var input: Double
     public var output: Double
     public var cacheRead: Double
     public var cacheWrite: Double
 
-    public init(input: Double = 0, output: Double = 0, cacheRead: Double = 0, cacheWrite: Double = 0) {
+    public init(
+        inputTokensAbove: Int,
+        input: Double,
+        output: Double,
+        cacheRead: Double,
+        cacheWrite: Double
+    ) {
+        self.inputTokensAbove = inputTokensAbove
         self.input = input
         self.output = output
         self.cacheRead = cacheRead
         self.cacheWrite = cacheWrite
+    }
+}
+
+public struct ModelCost: Codable, Sendable, Hashable {
+    /// USD per 1M tokens.
+    public var input: Double
+    public var output: Double
+    public var cacheRead: Double
+    public var cacheWrite: Double
+    /// Request-wide pricing tiers. The highest matching threshold applies to
+    /// every token in the request, not only the tokens above the threshold.
+    public var tiers: [ModelCostTier]?
+
+    public init(
+        input: Double = 0,
+        output: Double = 0,
+        cacheRead: Double = 0,
+        cacheWrite: Double = 0,
+        tiers: [ModelCostTier]? = nil
+    ) {
+        self.input = input
+        self.output = output
+        self.cacheRead = cacheRead
+        self.cacheWrite = cacheWrite
+        self.tiers = tiers
     }
 }
 
@@ -36,7 +70,7 @@ public struct Model: Codable, Sendable, Hashable {
     /// Per-API compatibility overrides (cache format, thinking format, store
     /// support, etc.). nil = auto-detect from baseURL / provider defaults.
     public var compat: ModelCompat?
-    /// Maps pi thinking levels (off/minimal/low/medium/high/xhigh) to
+    /// Maps pi thinking levels (off/minimal/low/medium/high/xhigh/max) to
     /// provider/model-specific wire values. A `.some(nil)` entry marks a level
     /// as unsupported; a missing key uses provider defaults.
     public var thinkingLevelMap: [String: String?]?
@@ -86,11 +120,27 @@ public func modelsAreEqual(_ a: Model, _ b: Model) -> Bool {
 
 /// Compute USD cost from usage and model pricing (per 1M tokens).
 public func calculateCost(model: Model, usage: Usage) -> Cost {
+    let inputTokens = usage.input + usage.cacheRead + usage.cacheWrite
+    var inputRate = model.cost.input
+    var outputRate = model.cost.output
+    var cacheReadRate = model.cost.cacheRead
+    var cacheWriteRate = model.cost.cacheWrite
+    var matchedThreshold = -1
+
+    for tier in model.cost.tiers ?? []
+    where inputTokens > tier.inputTokensAbove && tier.inputTokensAbove > matchedThreshold {
+        inputRate = tier.input
+        outputRate = tier.output
+        cacheReadRate = tier.cacheRead
+        cacheWriteRate = tier.cacheWrite
+        matchedThreshold = tier.inputTokensAbove
+    }
+
     let scale = 1_000_000.0
-    let input = Double(usage.input) * model.cost.input / scale
-    let output = Double(usage.output) * model.cost.output / scale
-    let cacheRead = Double(usage.cacheRead) * model.cost.cacheRead / scale
-    let cacheWrite = Double(usage.cacheWrite) * model.cost.cacheWrite / scale
+    let input = Double(usage.input) * inputRate / scale
+    let output = Double(usage.output) * outputRate / scale
+    let cacheRead = Double(usage.cacheRead) * cacheReadRate / scale
+    let cacheWrite = Double(usage.cacheWrite) * cacheWriteRate / scale
     return Cost(
         input: input,
         output: output,

--- a/Sources/KWWKAI/ModelCompat.swift
+++ b/Sources/KWWKAI/ModelCompat.swift
@@ -57,6 +57,7 @@ public enum ModelThinkingLevel: String, Codable, Sendable, Hashable, CaseIterabl
     case medium
     case high
     case xhigh
+    case max
 
     public init(reasoning: ReasoningLevel?) {
         guard let reasoning else { self = .off; return }
@@ -66,6 +67,7 @@ public enum ModelThinkingLevel: String, Codable, Sendable, Hashable, CaseIterabl
         case .medium: self = .medium
         case .high: self = .high
         case .xhigh: self = .xhigh
+        case .max: self = .max
         }
     }
 
@@ -78,21 +80,25 @@ public enum ModelThinkingLevel: String, Codable, Sendable, Hashable, CaseIterabl
         case .medium: return .medium
         case .high: return .high
         case .xhigh: return .xhigh
+        case .max: return .max
         }
     }
 }
 
-private let extendedThinkingLevels: [ModelThinkingLevel] = [.off, .minimal, .low, .medium, .high, .xhigh]
+private let extendedThinkingLevels: [ModelThinkingLevel] = [
+    .off, .minimal, .low, .medium, .high, .xhigh, .max,
+]
 
 /// Ported from pi `getSupportedThinkingLevels`. Honors `thinkingLevelMap`:
-/// a level mapped to an explicit `null` is unsupported, `xhigh` requires an
-/// explicit mapping entry to be offered at all.
+/// a level mapped to an explicit `null` is unsupported, while `xhigh` and
+/// `max` require an explicit mapping entry to be offered at all.
 public func supportedThinkingLevels(_ model: Model) -> [ModelThinkingLevel] {
     guard model.reasoning else { return [.off] }
     return extendedThinkingLevels.filter { level in
         guard let map = model.thinkingLevelMap, let entry = map[level.rawValue] else {
-            // key absent: supported (except xhigh which needs an explicit entry)
-            return level != .xhigh
+            // Extended levels need an explicit entry; lower levels use the
+            // provider default when absent.
+            return level != .xhigh && level != .max
         }
         // entry present: nil (NSNull) => unsupported
         if entry == nil { return false }

--- a/Sources/KWWKAI/ModelsCatalog.swift
+++ b/Sources/KWWKAI/ModelsCatalog.swift
@@ -111,6 +111,24 @@ public enum ModelsCatalog {
             cost.output = doubleValue(c["output"]) ?? 0
             cost.cacheRead = doubleValue(c["cacheRead"]) ?? 0
             cost.cacheWrite = doubleValue(c["cacheWrite"]) ?? 0
+            if let tierObjects = c["tiers"] as? [[String: Any]] {
+                cost.tiers = tierObjects.compactMap { tier in
+                    guard let inputTokensAbove = intValue(tier["inputTokensAbove"]),
+                          let input = doubleValue(tier["input"]),
+                          let output = doubleValue(tier["output"]),
+                          let cacheRead = doubleValue(tier["cacheRead"]),
+                          let cacheWrite = doubleValue(tier["cacheWrite"]) else {
+                        return nil
+                    }
+                    return ModelCostTier(
+                        inputTokensAbove: inputTokensAbove,
+                        input: input,
+                        output: output,
+                        cacheRead: cacheRead,
+                        cacheWrite: cacheWrite
+                    )
+                }
+            }
         }
 
         let headers = dict["headers"] as? [String: String]
@@ -159,6 +177,12 @@ public enum ModelsCatalog {
         if let d = v as? Double { return d }
         if let i = v as? Int { return Double(i) }
         if let n = v as? NSNumber { return n.doubleValue }
+        return nil
+    }
+
+    private static func intValue(_ v: Any?) -> Int? {
+        if let i = v as? Int { return i }
+        if let n = v as? NSNumber { return n.intValue }
         return nil
     }
 }

--- a/Sources/KWWKAI/RegisterBuiltins.swift
+++ b/Sources/KWWKAI/RegisterBuiltins.swift
@@ -140,7 +140,21 @@ public enum Models {
         baseURL: "https://api.openai.com",
         reasoning: true,
         input: [.text, .image],
-        cost: ModelCost(input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0),
+        cost: ModelCost(
+            input: 5,
+            output: 30,
+            cacheRead: 0.5,
+            cacheWrite: 0,
+            tiers: [
+                ModelCostTier(
+                    inputTokensAbove: 272_000,
+                    input: 10,
+                    output: 45,
+                    cacheRead: 1,
+                    cacheWrite: 0
+                ),
+            ]
+        ),
         contextWindow: 272_000,
         maxTokens: 128_000
     )

--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -2722,12 +2722,12 @@
       "input" : 0,
       "output" : 0
     },
-    "id" : "grok-4.3",
+    "id" : "gpt-5.6-luna-high",
     "input" : [
       "text"
     ],
     "maxTokens" : 64000,
-    "name" : "Grok 4.3 1M",
+    "name" : "GPT-5.6 Luna 1M High",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -2741,12 +2741,772 @@
       "input" : 0,
       "output" : 0
     },
-    "id" : "grok-build-0.1",
+    "id" : "gpt-5.6-luna-high-fast",
     "input" : [
       "text"
     ],
     "maxTokens" : 64000,
-    "name" : "Grok Build 0.1 1M",
+    "name" : "GPT-5.6 Luna High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-low",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna 1M Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-low-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-max",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna 1M Max",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-max-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna Max Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna 1M",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-medium-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-none",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna 1M None",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-none-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna None Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna 1M Extra High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-luna-xhigh-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Luna Extra High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-high",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-high-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-low",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-low-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-max",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M Max",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-max-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol Max Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-medium-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-none",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M None",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-none-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol None Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol 1M Extra High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-sol-xhigh-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Sol Extra High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-high",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-high-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-low",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-low-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-max",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M Max",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-max-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra Max Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-medium-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-none",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M None",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-none-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra None Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra 1M Extra High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gpt-5.6-terra-xhigh-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "GPT-5.6 Terra Extra High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-fast-high",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Medium Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-fast-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-fast-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-high",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Medium",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "grok-4.5-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5",
     "provider" : "cursor",
     "reasoning" : false
   },

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -99,6 +99,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -183,7 +184,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "anthropic.claude-opus-4-7" : {
@@ -206,6 +207,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -229,6 +231,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -270,7 +273,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -290,7 +296,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -332,7 +342,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "au.anthropic.claude-opus-4-8" : {
@@ -355,6 +365,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -396,7 +407,10 @@
       "maxTokens" : 128000,
       "name" : "AU Anthropic Claude Sonnet 4.6",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "au.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -416,7 +430,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5 (AU)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "deepseek.r1-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -495,6 +513,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -559,7 +578,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "eu.anthropic.claude-opus-4-7" : {
@@ -582,6 +601,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -605,6 +625,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -646,7 +667,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (EU)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "eu.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -666,7 +690,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5 (EU)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "global.anthropic.claude-fable-5" : {
       "api" : "bedrock-converse-stream",
@@ -688,6 +716,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -752,7 +781,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "global.anthropic.claude-opus-4-7" : {
@@ -775,6 +804,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -798,6 +828,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -839,7 +870,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (Global)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "global.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -859,7 +893,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5 (Global)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "google.gemma-3-4b-it" : {
       "api" : "bedrock-converse-stream",
@@ -941,6 +979,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -964,6 +1003,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -1005,7 +1045,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (JP)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "jp.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -1025,7 +1068,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5 (JP)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "meta.llama3-1-8b-instruct-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -1786,6 +1833,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -1870,7 +1918,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "us.anthropic.claude-opus-4-7" : {
@@ -1893,6 +1941,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -1916,6 +1965,7 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -1957,7 +2007,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6 (US)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "us.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
@@ -1977,7 +2030,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5 (US)",
       "provider" : "amazon-bedrock",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "us.deepseek.r1-v1:0" : {
       "api" : "bedrock-converse-stream",
@@ -2269,6 +2326,7 @@
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -2416,7 +2474,7 @@
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "claude-opus-4-7" : {
@@ -2443,6 +2501,7 @@
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -2470,6 +2529,7 @@
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -2534,7 +2594,10 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "anthropic",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "claude-sonnet-5" : {
       "api" : "anthropic-messages",
@@ -2557,7 +2620,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "anthropic",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     }
   },
   "azure-openai-responses" : {
@@ -3327,6 +3394,81 @@
         "xhigh" : "xhigh"
       }
     },
+    "gpt-5.6-luna" : {
+      "api" : "azure-openai-responses",
+      "baseUrl" : "",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
+      },
+      "id" : "gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Luna",
+      "provider" : "azure-openai-responses",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-sol" : {
+      "api" : "azure-openai-responses",
+      "baseUrl" : "",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Sol",
+      "provider" : "azure-openai-responses",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-terra" : {
+      "api" : "azure-openai-responses",
+      "baseUrl" : "",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
+      },
+      "id" : "gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Terra",
+      "provider" : "azure-openai-responses",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "o1" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
@@ -3722,6 +3864,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -3842,7 +3985,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "claude-opus-4-7" : {
@@ -3870,6 +4013,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -3898,6 +4042,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -3969,7 +4114,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "claude-sonnet-5" : {
       "api" : "anthropic-messages",
@@ -3993,7 +4141,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "gpt-4" : {
       "api" : "openai-responses",
@@ -4813,9 +4965,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "deepseek-v4-pro" : {
@@ -4845,9 +4997,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     }
   },
@@ -4936,7 +5088,7 @@
       },
       "contextWindow" : 1048575,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.14000000000000001,
         "cacheWrite" : 0,
         "input" : 1.3999999999999999,
         "output" : 4.4000000000000004
@@ -4951,10 +5103,10 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "low" : "high",
+        "max" : "max",
         "medium" : "high",
         "minimal" : null,
-        "off" : "none",
-        "xhigh" : "max"
+        "off" : "none"
       }
     },
     "accounts\/fireworks\/models\/gpt-oss-20b" : {
@@ -5184,10 +5336,10 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "low" : "high",
+        "max" : "max",
         "medium" : "high",
         "minimal" : null,
-        "off" : "none",
-        "xhigh" : "max"
+        "off" : "none"
       }
     },
     "accounts\/fireworks\/routers\/kimi-k2p6-fast" : {
@@ -5385,7 +5537,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "claude-opus-4.7" : {
@@ -5395,7 +5547,7 @@
         "forceAdaptiveThinking" : true,
         "supportsTemperature" : false
       },
-      "contextWindow" : 200000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
         "cacheWrite" : 6.25,
@@ -5418,6 +5570,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "minimal" : "low",
         "xhigh" : "xhigh"
       }
@@ -5429,7 +5582,7 @@
         "forceAdaptiveThinking" : true,
         "supportsTemperature" : false
       },
-      "contextWindow" : 200000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
         "cacheWrite" : 6.25,
@@ -5452,6 +5605,7 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "minimal" : "low",
         "xhigh" : "xhigh"
       }
@@ -5543,8 +5697,8 @@
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "minimal" : "low",
-        "xhigh" : "max"
+        "max" : "max",
+        "minimal" : "low"
       }
     },
     "claude-sonnet-5" : {
@@ -5574,7 +5728,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "github-copilot",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "gemini-2.5-pro" : {
       "api" : "openai-completions",
@@ -5826,7 +5984,7 @@
     "gpt-5.3-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.17499999999999999,
         "cacheWrite" : 0,
@@ -5857,7 +6015,7 @@
     "gpt-5.4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
@@ -5950,7 +6108,7 @@
     "gpt-5.5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "contextWindow" : 400000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
         "cacheWrite" : 0,
@@ -7210,6 +7368,28 @@
       ],
       "maxTokens" : 262144,
       "name" : "Kimi K2.7 Code",
+      "provider" : "huggingface",
+      "reasoning" : true
+    },
+    "openai\/gpt-oss-20b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.10000000000000001,
+        "output" : 0.5
+      },
+      "id" : "openai\/gpt-oss-20b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT OSS 20B",
       "provider" : "huggingface",
       "reasoning" : true
     },
@@ -10386,7 +10566,16 @@
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2.5,
-        "output" : 15
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 0,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
       },
       "id" : "gpt-5.4",
       "input" : [
@@ -10458,7 +10647,16 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 30,
-        "output" : 180
+        "output" : 180,
+        "tiers" : [
+          {
+            "cacheRead" : 0,
+            "cacheWrite" : 0,
+            "input" : 60,
+            "inputTokensAbove" : 272000,
+            "output" : 270
+          }
+        ]
       },
       "id" : "gpt-5.4-pro",
       "input" : [
@@ -10482,7 +10680,16 @@
         "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 5,
-        "output" : 30
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 0,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
       },
       "id" : "gpt-5.5",
       "input" : [
@@ -10507,7 +10714,16 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 30,
-        "output" : 180
+        "output" : 180,
+        "tiers" : [
+          {
+            "cacheRead" : 0,
+            "cacheWrite" : 0,
+            "input" : 60,
+            "inputTokensAbove" : 272000,
+            "output" : 270
+          }
+        ]
       },
       "id" : "gpt-5.5-pro",
       "input" : [
@@ -10522,6 +10738,108 @@
         "low" : null,
         "minimal" : null,
         "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-luna" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "contextWindow" : 272000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6,
+        "tiers" : [
+          {
+            "cacheRead" : 0.20000000000000001,
+            "cacheWrite" : 2.5,
+            "input" : 2,
+            "inputTokensAbove" : 272000,
+            "output" : 9
+          }
+        ]
+      },
+      "id" : "gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Luna",
+      "provider" : "openai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-sol" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "contextWindow" : 272000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 12.5,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
+      },
+      "id" : "gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Sol",
+      "provider" : "openai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-terra" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "contextWindow" : 272000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 6.25,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
+      },
+      "id" : "gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Terra",
+      "provider" : "openai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -10717,7 +11035,16 @@
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2.5,
-        "output" : 15
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 0,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
       },
       "id" : "gpt-5.4",
       "input" : [
@@ -10765,7 +11092,16 @@
         "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 5,
-        "output" : 30
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 0,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
       },
       "id" : "gpt-5.5",
       "input" : [
@@ -10777,6 +11113,108 @@
       "provider" : "openai-codex",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "minimal" : "low",
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-luna" : {
+      "api" : "openai-codex-responses",
+      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "contextWindow" : 372000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6,
+        "tiers" : [
+          {
+            "cacheRead" : 0.20000000000000001,
+            "cacheWrite" : 2.5,
+            "input" : 2,
+            "inputTokensAbove" : 272000,
+            "output" : 9
+          }
+        ]
+      },
+      "id" : "gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Luna",
+      "provider" : "openai-codex",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "minimal" : "low",
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-sol" : {
+      "api" : "openai-codex-responses",
+      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "contextWindow" : 372000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 12.5,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
+      },
+      "id" : "gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Sol",
+      "provider" : "openai-codex",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "minimal" : "low",
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6-terra" : {
+      "api" : "openai-codex-responses",
+      "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "contextWindow" : 372000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 6.25,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
+      },
+      "id" : "gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Terra",
+      "provider" : "openai-codex",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
         "minimal" : "low",
         "xhigh" : "xhigh"
       }
@@ -10830,6 +11268,7 @@
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -10917,7 +11356,7 @@
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "claude-opus-4-7" : {
@@ -10944,6 +11383,7 @@
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -10971,6 +11411,7 @@
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -11035,7 +11476,10 @@
       "maxTokens" : 64000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "opencode",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "claude-sonnet-5" : {
       "api" : "anthropic-messages",
@@ -11058,7 +11502,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "opencode",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "deepseek-v4-flash" : {
       "api" : "openai-completions",
@@ -11088,9 +11536,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "deepseek-v4-flash-free" : {
@@ -11120,9 +11568,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "deepseek-v4-pro" : {
@@ -11153,9 +11601,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "gemini-3-flash" : {
@@ -11682,6 +12130,31 @@
         "xhigh" : "xhigh"
       }
     },
+    "grok-4.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "grok-4.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.5",
+      "provider" : "opencode",
+      "reasoning" : true
+    },
     "grok-build-0.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -11713,6 +12186,30 @@
         "minimal" : null,
         "off" : null
       }
+    },
+    "hy3-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "hy3-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Hy3 Free",
+      "provider" : "opencode",
+      "reasoning" : true
     },
     "kimi-k2.5" : {
       "api" : "openai-completions",
@@ -12010,9 +12507,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "deepseek-v4-pro" : {
@@ -12043,9 +12540,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "glm-5.1" : {
@@ -12098,10 +12595,10 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
         "medium" : null,
         "minimal" : null,
-        "off" : null,
-        "xhigh" : "max"
+        "off" : null
       }
     },
     "kimi-k2.6" : {
@@ -12475,7 +12972,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14000000000000001,
+        "cacheRead" : 0.14999999999999999,
         "cacheWrite" : 0,
         "input" : 0.66000000000000003,
         "output" : 3.4100000000000001
@@ -12500,7 +12997,7 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
-        "cacheWrite" : 0,
+        "cacheWrite" : 6.25,
         "input" : 5,
         "output" : 30
       },
@@ -12538,6 +13035,30 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "~x-ai\/grok-latest" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "~x-ai\/grok-latest",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "xAI: Grok Latest",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "ai21\/jamba-large-1.7" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -12560,6 +13081,75 @@
       "name" : "AI21: Jamba Large 1.7",
       "provider" : "openrouter",
       "reasoning" : false
+    },
+    "aion-labs\/aion-2.0" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.20000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.80000000000000004,
+        "output" : 1.6000000000000001
+      },
+      "id" : "aion-labs\/aion-2.0",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "AionLabs: Aion-2.0",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "aion-labs\/aion-3.0" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.75,
+        "cacheWrite" : 0,
+        "input" : 3,
+        "output" : 6
+      },
+      "id" : "aion-labs\/aion-3.0",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "AionLabs: Aion-3.0",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "aion-labs\/aion-3.0-mini" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.17999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.69999999999999996,
+        "output" : 1.3999999999999999
+      },
+      "id" : "aion-labs\/aion-3.0-mini",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "AionLabs: Aion-3.0-Mini",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "amazon\/nova-2-lite-v1" : {
       "api" : "openai-completions",
@@ -12848,7 +13438,7 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "anthropic\/claude-opus-4.7" : {
@@ -12875,6 +13465,7 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -12902,6 +13493,7 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -12929,6 +13521,7 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -12956,6 +13549,7 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -13029,7 +13623,10 @@
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Sonnet 4.6",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "anthropic\/claude-sonnet-5" : {
       "api" : "openai-completions",
@@ -13053,7 +13650,11 @@
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Sonnet 5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "arcee-ai\/trinity-large-thinking" : {
       "api" : "openai-completions",
@@ -13516,13 +14117,14 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 65536,
       "name" : "DeepSeek: DeepSeek V4 Flash",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : null,
         "medium" : null,
         "minimal" : null,
         "xhigh" : "xhigh"
@@ -13554,6 +14156,7 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : null,
         "medium" : null,
         "minimal" : null,
         "xhigh" : "xhigh"
@@ -13604,30 +14207,6 @@
       ],
       "maxTokens" : 65535,
       "name" : "Google: Gemini 2.5 Flash Lite",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "google\/gemini-2.5-flash-lite-preview-09-2025" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
-      },
-      "id" : "google\/gemini-2.5-flash-lite-preview-09-2025",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65535,
-      "name" : "Google: Gemini 2.5 Flash Lite Preview 09-2025",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -14397,10 +14976,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.47999999999999998
+        "input" : 0.14999999999999999,
+        "output" : 0.90000000000000002
       },
       "id" : "minimax\/minimax-m2.5",
       "input" : [
@@ -14422,8 +15001,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17999999999999999,
-        "output" : 0.71999999999999997
+        "input" : 0.23999999999999999,
+        "output" : 0.95999999999999996
       },
       "id" : "minimax\/minimax-m2.7",
       "input" : [
@@ -14453,7 +15032,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 512000,
+      "maxTokens" : 131072,
       "name" : "MiniMax: MiniMax M3",
       "provider" : "openrouter",
       "reasoning" : true
@@ -14961,7 +15540,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14000000000000001,
+        "cacheRead" : 0.14999999999999999,
         "cacheWrite" : 0,
         "input" : 0.66000000000000003,
         "output" : 3.4100000000000001
@@ -14985,18 +15564,66 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.159,
         "cacheWrite" : 0,
-        "input" : 0.73999999999999999,
-        "output" : 3.5
+        "input" : 0.71999999999999997,
+        "output" : 3.4900000000000002
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 262144,
       "name" : "MoonshotAI: Kimi K2.7 Code",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "nex-agi\/nex-n2-mini" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.0025000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.025000000000000001,
+        "output" : 0.10000000000000001
+      },
+      "id" : "nex-agi\/nex-n2-mini",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Nex AGI: Nex-N2-Mini",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "nex-agi\/nex-n2-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.025000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 1
+      },
+      "id" : "nex-agi\/nex-n2-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Nex AGI: Nex-N2-Pro",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -16117,6 +16744,168 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.6-luna" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
+      },
+      "id" : "openai\/gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Luna",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-luna-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
+      },
+      "id" : "openai\/gpt-5.6-luna-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Luna Pro",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-sol" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Sol",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-sol-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-5.6-sol-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Sol Pro",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-terra" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
+      },
+      "id" : "openai\/gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Terra",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-terra-pro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
+      },
+      "id" : "openai\/gpt-5.6-terra-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "OpenAI: GPT-5.6 Terra Pro",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-audio" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -16238,14 +17027,14 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.029999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.035999999999999997,
+        "output" : 0.17999999999999999
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 4096,
       "name" : "OpenAI: gpt-oss-120b",
       "provider" : "openrouter",
       "reasoning" : true
@@ -16659,52 +17448,6 @@
       ],
       "maxTokens" : 32768,
       "name" : "Poolside: Laguna XS 2.1 (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "poolside\/laguna-xs.2" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.20000000000000001
-      },
-      "id" : "poolside\/laguna-xs.2",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Poolside: Laguna XS.2",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "poolside\/laguna-xs.2:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "poolside\/laguna-xs.2:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Poolside: Laguna XS.2 (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -17556,7 +18299,7 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.111,
         "cacheWrite" : 0,
         "input" : 0.38500000000000001,
         "output" : 2.4500000000000002
@@ -17950,6 +18693,29 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "tencent\/hy3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.035000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.14000000000000001,
+        "output" : 0.57999999999999996
+      },
+      "id" : "tencent\/hy3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Tencent: Hy3",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "tencent\/hy3-preview" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -17970,6 +18736,29 @@
       ],
       "maxTokens" : 4096,
       "name" : "Tencent: Hy3 preview",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "tencent\/hy3:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "tencent\/hy3:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Tencent: Hy3 (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -18043,6 +18832,30 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "x-ai\/grok-4.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "x-ai\/grok-4.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "xAI: Grok 4.5",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "x-ai\/grok-4.20" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -18100,7 +18913,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
         "input" : 0.105,
         "output" : 0.28000000000000003
@@ -18379,10 +19192,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.16874,
+        "cacheRead" : 0.098799999999999999,
         "cacheWrite" : 0,
-        "input" : 0.90859999999999996,
-        "output" : 2.8555999999999999
+        "input" : 0.53200000000000003,
+        "output" : 1.6719999999999999
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
@@ -19671,6 +20484,7 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -19778,7 +20592,7 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "xhigh" : "max"
+        "max" : "max"
       }
     },
     "anthropic\/claude-opus-4.7" : {
@@ -19805,6 +20619,7 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -19832,6 +20647,7 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "max" : "max",
         "xhigh" : "xhigh"
       }
     },
@@ -19896,7 +20712,10 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "vercel-ai-gateway",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max"
+      }
     },
     "anthropic\/claude-sonnet-5" : {
       "api" : "anthropic-messages",
@@ -19919,7 +20738,11 @@
       "maxTokens" : 128000,
       "name" : "Claude Sonnet 5",
       "provider" : "vercel-ai-gateway",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
     },
     "arcee-ai\/trinity-large-preview" : {
       "api" : "anthropic-messages",
@@ -20156,7 +20979,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0028,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
         "input" : 0.14000000000000001,
         "output" : 0.28000000000000003
@@ -20679,6 +21502,26 @@
       "name" : "Llama 4 Scout 17B Instruct",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
+    },
+    "meta\/muse-spark-1.1" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.14999999999999999,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 4.25
+      },
+      "id" : "meta\/muse-spark-1.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "Muse Spark 1.1",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
     },
     "minimax\/minimax-m2" : {
       "api" : "anthropic-messages",
@@ -21999,6 +22842,75 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.6-luna" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.10000000000000001,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
+      },
+      "id" : "openai\/gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Luna",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-sol" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Sol",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-terra" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
+      },
+      "id" : "openai\/gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Terra",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-oss-20b" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -22291,6 +23203,26 @@
       ],
       "maxTokens" : 1000000,
       "name" : "Grok 4.3",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "xai\/grok-4.5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "xai\/grok-4.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.5",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -22875,6 +23807,31 @@
       "provider" : "xai",
       "reasoning" : true
     },
+    "grok-4.5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.x.ai\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "grok-4.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.5",
+      "provider" : "xai",
+      "reasoning" : true
+    },
     "grok-4.20-0309-non-reasoning" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
@@ -23118,30 +24075,6 @@
     }
   },
   "xiaomi-token-plan-ams" : {
-    "mimo-v2-omni" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.0028,
-        "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
-      },
-      "id" : "mimo-v2-omni",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Omni",
-      "provider" : "xiaomi-token-plan-ams",
-      "reasoning" : true
-    },
     "mimo-v2-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
@@ -23151,10 +24084,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2-pro",
       "input" : [
@@ -23174,10 +24107,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0028,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -23198,10 +24131,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
@@ -23209,58 +24142,11 @@
       ],
       "maxTokens" : 131072,
       "name" : "MiMo-V2.5-Pro",
-      "provider" : "xiaomi-token-plan-ams",
-      "reasoning" : true
-    },
-    "mimo-v2.5-pro-ultraspeed" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.010800000000000001,
-        "cacheWrite" : 0,
-        "input" : 1.3049999999999999,
-        "output" : 2.6099999999999999
-      },
-      "id" : "mimo-v2.5-pro-ultraspeed",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2.5-Pro-UltraSpeed",
       "provider" : "xiaomi-token-plan-ams",
       "reasoning" : true
     }
   },
   "xiaomi-token-plan-cn" : {
-    "mimo-v2-omni" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.0028,
-        "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
-      },
-      "id" : "mimo-v2-omni",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Omni",
-      "provider" : "xiaomi-token-plan-cn",
-      "reasoning" : true
-    },
     "mimo-v2-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
@@ -23270,10 +24156,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2-pro",
       "input" : [
@@ -23293,10 +24179,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0028,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -23317,10 +24203,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
@@ -23328,58 +24214,11 @@
       ],
       "maxTokens" : 131072,
       "name" : "MiMo-V2.5-Pro",
-      "provider" : "xiaomi-token-plan-cn",
-      "reasoning" : true
-    },
-    "mimo-v2.5-pro-ultraspeed" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.010800000000000001,
-        "cacheWrite" : 0,
-        "input" : 1.3049999999999999,
-        "output" : 2.6099999999999999
-      },
-      "id" : "mimo-v2.5-pro-ultraspeed",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2.5-Pro-UltraSpeed",
       "provider" : "xiaomi-token-plan-cn",
       "reasoning" : true
     }
   },
   "xiaomi-token-plan-sgp" : {
-    "mimo-v2-omni" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.0028,
-        "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
-      },
-      "id" : "mimo-v2-omni",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Omni",
-      "provider" : "xiaomi-token-plan-sgp",
-      "reasoning" : true
-    },
     "mimo-v2-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
@@ -23389,10 +24228,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2-pro",
       "input" : [
@@ -23412,10 +24251,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0028,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -23436,10 +24275,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0,
+        "output" : 0
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
@@ -23447,29 +24286,6 @@
       ],
       "maxTokens" : 131072,
       "name" : "MiMo-V2.5-Pro",
-      "provider" : "xiaomi-token-plan-sgp",
-      "reasoning" : true
-    },
-    "mimo-v2.5-pro-ultraspeed" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.010800000000000001,
-        "cacheWrite" : 0,
-        "input" : 1.3049999999999999,
-        "output" : 2.6099999999999999
-      },
-      "id" : "mimo-v2.5-pro-ultraspeed",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2.5-Pro-UltraSpeed",
       "provider" : "xiaomi-token-plan-sgp",
       "reasoning" : true
     }
@@ -23606,9 +24422,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : "high",
+        "max" : "max",
         "medium" : "high",
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "glm-5v-turbo" : {
@@ -23771,9 +24587,9 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : "high",
+        "max" : "max",
         "medium" : "high",
-        "minimal" : null,
-        "xhigh" : "max"
+        "minimal" : null
       }
     },
     "glm-5v-turbo" : {

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -555,6 +555,7 @@ extension Agent {
         case .medium: return .medium
         case .high: return .high
         case .xhigh: return .xhigh
+        case .max: return .max
         }
     }
 

--- a/Sources/KWWKAgent/AgentTypes.swift
+++ b/Sources/KWWKAgent/AgentTypes.swift
@@ -9,6 +9,7 @@ public enum ThinkingLevel: String, Sendable, Hashable {
     case medium
     case high
     case xhigh
+    case max
 }
 
 /// How the transcript UI should surface assistant thinking blocks. Orthogonal

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -40,7 +40,7 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
     ))
     registry.register(SlashCommand(
         name: "thinking",
-        description: "Show / set thinking level (off|minimal|low|medium|high|xhigh) or display (show|hide)",
+        description: "Show / set thinking level (off|minimal|low|medium|high|xhigh|max) or display (show|hide)",
         handler: handleThinkingCommand
     ))
     registry.register(SlashCommand(
@@ -554,7 +554,7 @@ private func handleVerboseCommand(_ ctx: SlashContext, _ args: String) async {
 // MARK: - /thinking
 
 /// `/thinking` (no args) — show current level.
-/// `/thinking off|minimal|low|medium|high|xhigh` — set it.
+/// `/thinking off|minimal|low|medium|high|xhigh|max` — set it.
 ///
 /// Extended thinking is auto-enabled at `.medium` on startup for
 /// reasoning-capable models so users see `[thinking]` blocks without
@@ -573,7 +573,7 @@ private func handleThinkingCommand(_ ctx: SlashContext, _ args: String) async {
         if level != .off && !model.reasoning {
             lines.append(Style.dimmed("    (current model \(model.id) is non-reasoning — level stored but won't be sent until `/model` switch)"))
         }
-        lines.append(Style.dimmed("    level: off, minimal, low, medium, high, xhigh"))
+        lines.append(Style.dimmed("    level: off, minimal, low, medium, high, xhigh, max"))
         lines.append(Style.dimmed("    display: show, hide"))
         ctx.notifyBlock(lines)
         return
@@ -590,7 +590,7 @@ private func handleThinkingCommand(_ ctx: SlashContext, _ args: String) async {
         return
     }
     guard let level = parseThinkingLevel(trimmed) else {
-        ctx.notify(Style.error("  /thinking: unknown arg '\(args)'. Levels: off|minimal|low|medium|high|xhigh. Display: show|hide"))
+        ctx.notify(Style.error("  /thinking: unknown arg '\(args)'. Levels: off|minimal|low|medium|high|xhigh|max. Display: show|hide"))
         return
     }
     let previous = ctx.agent.state.thinkingLevel
@@ -608,14 +608,15 @@ private func handleThinkingCommand(_ ctx: SlashContext, _ args: String) async {
     ctx.notifyBlock(lines)
 }
 
-private func parseThinkingLevel(_ s: String) -> ThinkingLevel? {
+func parseThinkingLevel(_ s: String) -> ThinkingLevel? {
     switch s {
     case "off": return .off
     case "minimal": return .minimal
     case "low": return .low
     case "medium", "med": return .medium
     case "high": return .high
-    case "xhigh", "x-high", "max": return .xhigh
+    case "xhigh", "x-high": return .xhigh
+    case "max": return .max
     default: return nil
     }
 }

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -14,7 +14,7 @@ import KWWKCli
 ///   kwwk --help             → usage
 ///
 /// Global flags (apply to both TUI and headless `-p`):
-///   `--thinking <off|minimal|low|medium|high|xhigh>` — reasoning effort,
+///   `--thinking <off|minimal|low|medium|high|xhigh|max>` — reasoning effort,
 ///                        defaulting to `medium`.
 ///   `--model <id>`     — override the resolved provider's default model id
 ///                        (e.g. `--model claude-opus-4-5`). Catalog metadata
@@ -84,7 +84,7 @@ struct KwwkCLI {
 
         global options:
           --thinking <level>          reasoning effort: off, minimal, low,
-                                      medium, high, xhigh
+                                      medium, high, xhigh, max
                                       (default: medium)
           --model <id>                override the provider's default model id
                                       (e.g. --model claude-opus-4-5)
@@ -120,7 +120,7 @@ struct KwwkCLI {
             if argv[i] == "--thinking" {
                 guard i + 1 < argv.count, let parsed = ThinkingLevel(rawValue: argv[i + 1]) else {
                     FileHandle.standardError.write(Data(
-                        "kwwk: --thinking needs one of: off, minimal, low, medium, high, xhigh\n".utf8
+                        "kwwk: --thinking needs one of: off, minimal, low, medium, high, xhigh, max\n".utf8
                     ))
                     Foundation.exit(2)
                 }

--- a/Tests/KWWKAITests/CursorProtoTests.swift
+++ b/Tests/KWWKAITests/CursorProtoTests.swift
@@ -554,8 +554,16 @@ struct CursorModelRoutingTests {
         )
         #expect(CursorAgentProvider.wireModelId(model: model, reasoning: nil) == "claude-4.5-sonnet")
         #expect(CursorAgentProvider.wireModelId(model: model, reasoning: .medium) == "claude-4.5-sonnet-thinking")
-        // xhigh not mapped — falls down the ladder to high.
+        // Neither extended level is mapped, so both clamp down to high.
         #expect(CursorAgentProvider.wireModelId(model: model, reasoning: .xhigh) == "claude-4.5-sonnet-thinking")
+        #expect(CursorAgentProvider.wireModelId(model: model, reasoning: .max) == "claude-4.5-sonnet-thinking")
+
+        var maxOnly = model
+        maxOnly.thinkingLevelMap = ["max": "claude-max"]
+        // Clamping searches upward first: legacy xhigh callers route to max
+        // when max is the model's only explicitly supported extended level.
+        #expect(CursorAgentProvider.wireModelId(model: maxOnly, reasoning: .xhigh) == "claude-max")
+        #expect(CursorAgentProvider.wireModelId(model: maxOnly, reasoning: .max) == "claude-max")
     }
 
     @Test("normalize applies curated capabilities and collapses -thinking variants")

--- a/Tests/KWWKAITests/MaxReasoningTests.swift
+++ b/Tests/KWWKAITests/MaxReasoningTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+
+@Suite("Max reasoning level")
+struct MaxReasoningTests {
+    private func model(
+        api: String = "openai-completions",
+        provider: String = "openai",
+        id: String = "reasoning-model",
+        map: [String: String?]
+    ) -> Model {
+        Model(
+            id: id,
+            api: api,
+            provider: provider,
+            baseURL: "https://api.openai.com",
+            reasoning: true,
+            thinkingLevelMap: map
+        )
+    }
+
+    @Test("max is ordered above xhigh and extended levels clamp in both directions")
+    func orderingAndClamping() {
+        let maxOnly = model(map: ["max": "max"])
+        #expect(supportedThinkingLevels(maxOnly) == [.off, .minimal, .low, .medium, .high, .max])
+        #expect(clampThinkingLevel(maxOnly, .xhigh) == .max)
+        #expect(resolveThinkingLevel(maxOnly, .xhigh) == "max")
+
+        let xhighOnly = model(map: ["xhigh": "xhigh"])
+        #expect(clampThinkingLevel(xhighOnly, .max) == .xhigh)
+        #expect(resolveThinkingLevel(xhighOnly, .max) == "xhigh")
+
+        let both = model(map: ["xhigh": "xhigh", "max": "max"])
+        #expect(resolveThinkingLevel(both, .xhigh) == "xhigh")
+        #expect(resolveThinkingLevel(both, .max) == "max")
+        #expect(ModelThinkingLevel(reasoning: .max) == .max)
+        #expect(ModelThinkingLevel.max.reasoningLevel == .max)
+    }
+
+    @Test("OpenAI Completions emits max and upgrades legacy xhigh on max-only models")
+    func openAICompletions() throws {
+        let maxOnly = model(map: ["max": "max"])
+        let context = Context(messages: [.user(UserMessage(text: "hi"))])
+
+        let exact = try OpenAICompletionsProvider.encodeBodyDict(
+            model: maxOnly,
+            context: context,
+            options: StreamOptions(reasoning: .max)
+        )
+        #expect(exact["reasoning_effort"] as? String == "max")
+
+        let legacy = try OpenAICompletionsProvider.encodeBodyDict(
+            model: maxOnly,
+            context: context,
+            options: StreamOptions(reasoning: .xhigh)
+        )
+        #expect(legacy["reasoning_effort"] as? String == "max")
+    }
+
+    @Test("OpenAI Responses emits max")
+    func openAIResponses() async throws {
+        let client = StubSSEClient(body: Self.openAIResponsesSSE)
+        let provider = OpenAIResponsesProvider(
+            client: client,
+            webSocketClient: nil,
+            defaultAPIKey: "key"
+        )
+        let responseModel = model(
+            api: "openai-responses",
+            provider: "openai",
+            map: ["max": "max"]
+        )
+        let stream = provider.stream(
+            model: responseModel,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(reasoning: .max)
+        )
+        for await _ in stream {}
+
+        let json = try JSONSerialization.jsonObject(
+            with: client.lastRequest?.body ?? Data()
+        ) as? [String: Any]
+        let reasoning = json?["reasoning"] as? [String: Any]
+        #expect(reasoning?["effort"] as? String == "max")
+    }
+
+    @Test("Anthropic adaptive thinking upgrades legacy xhigh to max")
+    func anthropic() async throws {
+        let client = StubSSEClient(body: Self.anthropicSSE)
+        let provider = AnthropicProvider(client: client, defaultAPIKey: "key")
+        var compat = ModelCompat()
+        compat.forceAdaptiveThinking = true
+        var anthropicModel = model(
+            api: "anthropic-messages",
+            provider: "anthropic",
+            id: "claude-opus-4-6",
+            map: ["max": "max"]
+        )
+        anthropicModel.compat = compat
+
+        let stream = provider.stream(
+            model: anthropicModel,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(reasoning: .xhigh)
+        )
+        for await _ in stream {}
+
+        let json = try JSONSerialization.jsonObject(
+            with: client.lastRequest?.body ?? Data()
+        ) as? [String: Any]
+        let outputConfig = json?["output_config"] as? [String: Any]
+        #expect(outputConfig?["effort"] as? String == "max")
+    }
+
+    @Test("Bedrock adaptive thinking upgrades legacy xhigh to max")
+    func bedrock() {
+        let bedrockModel = model(
+            api: "bedrock-converse-stream",
+            provider: "amazon-bedrock",
+            id: "anthropic.claude-opus-4-6-v1",
+            map: ["max": "max"]
+        )
+        let extras = BedrockProvider.buildAdditionalModelRequestFields(
+            model: bedrockModel,
+            options: StreamOptions(reasoning: .xhigh),
+            env: [:]
+        )
+        let outputConfig = extras?["output_config"] as? [String: Any]
+        #expect(outputConfig?["effort"] as? String == "max")
+    }
+
+    @Test("Gemini clamps max to its highest supported thinking level")
+    func gemini() async throws {
+        let client = StubSSEClient(body: Self.geminiSSE)
+        let provider = GoogleGeminiProvider(client: client, defaultAPIKey: "key")
+        let geminiModel = model(
+            api: "google-generative-ai",
+            provider: "google",
+            id: "gemini-3-pro-preview",
+            map: [:]
+        )
+        let stream = provider.stream(
+            model: geminiModel,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(reasoning: .max)
+        )
+        for await _ in stream {}
+
+        let json = try JSONSerialization.jsonObject(
+            with: client.lastRequest?.body ?? Data()
+        ) as? [String: Any]
+        let generationConfig = json?["generationConfig"] as? [String: Any]
+        let thinkingConfig = generationConfig?["thinkingConfig"] as? [String: Any]
+        #expect(thinkingConfig?["thinkingLevel"] as? String == "HIGH")
+    }
+
+    private static let openAIResponsesSSE = """
+    data: {"type":"response.completed","response":{"id":"response","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}
+
+    """
+
+    private static let anthropicSSE = """
+    event: message_start
+    data: {"type":"message_start","message":{"id":"message","role":"assistant","content":[],"model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":0}}}
+
+    event: message_delta
+    data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+    """
+
+    private static let geminiSSE = """
+    data: {"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}
+
+    """
+}

--- a/Tests/KWWKAITests/MessageTests.swift
+++ b/Tests/KWWKAITests/MessageTests.swift
@@ -65,4 +65,58 @@ struct CostTests {
         #expect(cost.cacheWrite == 0.375)
         #expect(cost.total == 10.95)
     }
+
+    @Test("calculateCost applies the highest request-wide tier above its input threshold")
+    func tieredCostCalc() {
+        let model = Model(
+            id: "tiered",
+            api: "faux",
+            provider: "faux",
+            cost: ModelCost(
+                input: 1,
+                output: 2,
+                cacheRead: 0.1,
+                cacheWrite: 1.25,
+                tiers: [
+                    ModelCostTier(
+                        inputTokensAbove: 200,
+                        input: 3,
+                        output: 6,
+                        cacheRead: 0.3,
+                        cacheWrite: 3.75
+                    ),
+                    ModelCostTier(
+                        inputTokensAbove: 100,
+                        input: 2,
+                        output: 4,
+                        cacheRead: 0.2,
+                        cacheWrite: 2.5
+                    ),
+                ]
+            )
+        )
+
+        let atThreshold = calculateCost(
+            model: model,
+            usage: Usage(input: 100, output: 1_000_000)
+        )
+        #expect(atThreshold.output == 2)
+
+        let firstTier = calculateCost(
+            model: model,
+            usage: Usage(input: 50, output: 1_000_000, cacheRead: 51)
+        )
+        #expect(firstTier.input == 0.0001)
+        #expect(firstTier.output == 4)
+        #expect(firstTier.cacheRead == 0.0000102)
+
+        let highestTier = calculateCost(
+            model: model,
+            usage: Usage(input: 50, output: 1_000_000, cacheRead: 51, cacheWrite: 100)
+        )
+        #expect(highestTier.input == 0.00015)
+        #expect(highestTier.output == 6)
+        #expect(highestTier.cacheRead == 0.0000153)
+        #expect(highestTier.cacheWrite == 0.000375)
+    }
 }

--- a/Tests/KWWKAITests/ModelsCatalogTests.swift
+++ b/Tests/KWWKAITests/ModelsCatalogTests.swift
@@ -57,10 +57,12 @@ struct ModelsCatalogTests {
 
     @Test("decodes thinkingLevelMap incl. explicit-null entries")
     func thinkingLevelMapDecoded() {
-        // amazon-bedrock Opus 4.6 maps xhigh -> "max".
+        // New catalogs expose max as a distinct level on Opus 4.6.
         let bedrock = ModelsCatalog.models(for: "amazon-bedrock").first { $0.id.contains("opus-4-6") }
-        if let map = bedrock?.thinkingLevelMap, let xhigh = map["xhigh"] {
-            #expect(xhigh == "max")
+        if let map = bedrock?.thinkingLevelMap, let max = map["max"] {
+            #expect(max == "max")
+        } else {
+            Issue.record("expected Bedrock Opus 4.6 to declare max thinking")
         }
         let withMap = ModelsCatalog.all.filter { $0.thinkingLevelMap != nil }
         #expect(withMap.count >= 100)
@@ -73,10 +75,14 @@ struct ModelsCatalogTests {
             #expect(supportedThinkingLevels(nonReasoning) == [.off])
             #expect(resolveThinkingLevel(nonReasoning, .high) == nil)
         }
-        // Bedrock Opus 4.6: requesting xhigh resolves to the mapped "max".
-        if let bedrock = ModelsCatalog.models(for: "amazon-bedrock").first(where: { $0.id.contains("opus-4-6") }),
-           bedrock.thinkingLevelMap?["xhigh"] != nil {
+        // Bedrock Opus 4.6 supports max but not native xhigh. Upstream clamping
+        // searches upward first, preserving old xhigh callers by routing them
+        // to the new max level.
+        if let bedrock = ModelsCatalog.models(for: "amazon-bedrock").first(where: { $0.id.contains("opus-4-6") }) {
+            #expect(resolveThinkingLevel(bedrock, .max) == "max")
             #expect(resolveThinkingLevel(bedrock, .xhigh) == "max")
+        } else {
+            Issue.record("expected Bedrock Opus 4.6 in the catalog")
         }
     }
 
@@ -89,5 +95,15 @@ struct ModelsCatalogTests {
             #expect(m.cost.input < 500)
             #expect(m.cost.output < 1000)
         }
+
+        let tiered = ModelsCatalog.all.filter { !($0.cost.tiers ?? []).isEmpty }
+        #expect(!tiered.isEmpty)
+        #expect(
+            ModelsCatalog.model(provider: "openai", id: "gpt-5.4")?
+                .cost.tiers?.first?.inputTokensAbove == 272_000
+        )
+        #expect(tiered.allSatisfy { model in
+            model.cost.tiers?.allSatisfy { $0.inputTokensAbove > 0 } == true
+        })
     }
 }

--- a/Tests/KWWKCliTests/ThinkingCommandTests.swift
+++ b/Tests/KWWKCliTests/ThinkingCommandTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import KWWKCli
+@testable import KWWKAgent
+
+@Suite("Thinking command")
+struct ThinkingCommandTests {
+    @Test("max and xhigh remain distinct parseable levels")
+    func parsesExtendedLevels() {
+        #expect(parseThinkingLevel("max") == .max)
+        #expect(parseThinkingLevel("xhigh") == .xhigh)
+        #expect(parseThinkingLevel("x-high") == .xhigh)
+    }
+}


### PR DESCRIPTION
## Summary

- regenerate the regular catalog from [earendil-works/pi@34582ef](https://github.com/earendil-works/pi/commit/34582ef34beec868b0df4fb969385b8af5960c45)
- refresh the bundled Cursor catalog from the live `GetUsableModels` RPC
- add runtime support for the upstream `max` reasoning level and request-wide pricing tiers
- preserve legacy `xhigh` behavior when a model now exposes only `max`

## Why

The upstream catalog added `thinkingLevelMap.max` and `cost.tiers`. Updating only the generated JSON would make some legacy `xhigh` requests fall back to `high` and would under-report costs above the new input-token thresholds.

## Impact

- regular catalog: 1,033 → 1,057 models across 35 providers (33 added, 9 removed)
- Cursor catalog: 143 → 183 models (42 added, 2 removed)
- `max` is now available through `--thinking` and `/thinking`
- tier selection uses total input usage and applies the highest matching rate to the full request
- newly discovered Cursor IDs retain the generator's existing conservative fallback metadata because the RPC does not publish capability details

## Validation

- `swift build --product kwwk`
- `swift test` — 937 tests passed
- JSON structure, model-ID uniqueness, and expected catalog counts
- `git diff --check`