### PR TITLE
Expand paste placeholders to raw text at submit (omp semantics)

### DIFF
--- a/Sources/KWWKCli/Attachments.swift
+++ b/Sources/KWWKCli/Attachments.swift
@@ -15,17 +15,10 @@ import KWWKAI
 final class AttachmentStore {
     /// A large pasted text block that we don't want to shove into a
     /// single-line editor. Shown in the input as `[pasted-text #id]`
-    /// and expanded to a `<pasted-text>` block at submit time.
+    /// and expanded back to the raw body at submit time.
     struct PastedText: Identifiable {
         let id: Int
         let body: String
-        /// Line count of the body, used for the placeholder label so
-        /// the user gets a sense of size without expanding it.
-        var lineCount: Int {
-            // `components(separatedBy:)` counts "a\nb" as 2, matching
-            // what a user would intuitively read off the paste.
-            body.components(separatedBy: "\n").count
-        }
     }
 
     /// A clipboard image captured at paste time. Rendered in the
@@ -61,6 +54,19 @@ final class AttachmentStore {
 
     func pastedText(id: Int) -> PastedText? {
         pastedTexts.first(where: { $0.id == id })
+    }
+
+    /// Expand `[pasted-text #N]` placeholders back to their raw bodies
+    /// (omp's `expandPasteMarkers`). The placeholder exists only while
+    /// composing in the input line; everything downstream of submit —
+    /// the recall history, the transcript echo, the LLM prompt — sees
+    /// the original pasted text.
+    func expandPastedTextPlaceholders(in text: String) -> String {
+        var out = text
+        for pasted in pastedTexts {
+            out = out.replacingOccurrences(of: "[pasted-text #\(pasted.id)]", with: pasted.body)
+        }
+        return out
     }
 
     /// Register a clipboard-sourced image (e.g. macOS ⌘V where
@@ -318,13 +324,9 @@ func buildPromptWithAttachments(
     cwd: String,
     modelSupportsImages: Bool
 ) -> BuiltPrompt {
-    // 1. Expand pasted-text placeholders.
-    var expanded = inputText
-    for pasted in store.pastedTexts {
-        let placeholder = "[pasted-text #\(pasted.id)]"
-        let block = "<pasted-text id=\"\(pasted.id)\" lines=\"\(pasted.lineCount)\">\n\(pasted.body)\n</pasted-text>"
-        expanded = expanded.replacingOccurrences(of: placeholder, with: block)
-    }
+    // 1. Expand pasted-text placeholders to their raw bodies — the
+    //    prompt reads exactly as if the user had typed the paste inline.
+    let expanded = store.expandPastedTextPlaceholders(in: inputText)
 
     var images: [ImageContent] = []
     var attachBlocks: [String] = []

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -836,8 +836,10 @@ func runCodingTUIInternal(
                 // queued-but-undrained steer).
                 retry.trackedActive = true
                 goalStore.resetAutoContinue()
+                // Recall ring gets the paste bodies expanded (omp semantics):
+                // after clear() the placeholder would be a dead reference.
+                frame.input.addToHistory(attachments.expandPastedTextPlaceholders(in: text))
                 attachments.clear()
-                frame.input.addToHistory(text)
                 frame.input.value = ""
                 // No scrollback notice: the queued prompt now shows live in
                 // the pending list above the input box (updateFrameStatus
@@ -874,9 +876,10 @@ func runCodingTUIInternal(
                     runner.tui.requestRender()
                 }
             case .prompt:
-                // Recall ring: store the raw submission so Up/Down can bring
-                // it back (input was already cleared above).
-                frame.input.addToHistory(text)
+                // Recall ring: store the submission with paste bodies expanded
+                // (omp semantics) so Up/Down brings back the original text —
+                // the `[pasted-text #N]` placeholder dies with attachments.clear().
+                frame.input.addToHistory(attachments.expandPastedTextPlaceholders(in: text))
                 // Rebuild with attachments — the raw `text` may carry
                 // `@path` tokens and `[pasted-text #N]` placeholders
                 // from earlier paste events.

--- a/Tests/KWWKCliTests/AttachmentsTests.swift
+++ b/Tests/KWWKCliTests/AttachmentsTests.swift
@@ -81,7 +81,15 @@ struct AttachmentStoreTests {
         #expect(store.pastedTexts.count == 1)
         let entry = store.pastedText(id: 1)
         #expect(entry?.body == "line1\nline2\nline3")
-        #expect(entry?.lineCount == 3)
+    }
+
+    @MainActor
+    @Test("expandPastedTextPlaceholders substitutes raw bodies, leaves unknown ids alone")
+    func expandPlaceholders() {
+        let store = AttachmentStore()
+        let token = store.addPastedText("one\ntwo")
+        let expanded = store.expandPastedTextPlaceholders(in: "see \(token) and [pasted-text #9]")
+        #expect(expanded == "see one\ntwo and [pasted-text #9]")
     }
 
     @MainActor
@@ -135,7 +143,7 @@ struct BuildPromptTests {
     }
 
     @MainActor
-    @Test("pasted-text placeholder expanded inline, @text-file appended as <attachments>")
+    @Test("pasted-text placeholder expanded to its raw body, @text-file appended as <attachments>")
     func textFileAndPasted() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -151,8 +159,8 @@ struct BuildPromptTests {
             cwd: "/tmp",
             modelSupportsImages: true
         )
-        #expect(built.text.contains("<pasted-text id=\"1\" lines=\"2\">"))
-        #expect(built.text.contains("one\ntwo"))
+        #expect(!built.text.contains("<pasted-text"), "paste expands to raw text, no XML wrapper")
+        #expect(built.text.contains("see one\ntwo and @"))
         #expect(built.text.contains("<attachments>"))
         #expect(built.text.contains("<file path=\"\(filePath)\""))
         #expect(built.text.contains("GREETINGS"))


### PR DESCRIPTION
## Problem

Pasting a large block showed `[pasted-text #1]` in the input as intended, but everything downstream leaked the machine-facing wrapper:

- the submitted prompt (and thus the transcript echo) carried a `<pasted-text id="1" lines="1">…</pasted-text>` XML block
- Up/Down history stored the **unexpanded** placeholder, which became a dead reference after `attachments.clear()`

## Fix

Follow omp's `expandPasteMarkers` semantics (editor.ts `submitValue()`): the placeholder lives only in the input line. At submit it expands to the raw pasted body, so the LLM prompt, transcript echo, and recall history all see the original text.

- `AttachmentStore.expandPastedTextPlaceholders(in:)` replaces `[pasted-text #N]` with the raw body; `buildPromptWithAttachments` uses it instead of emitting the XML wrapper
- both submit paths (idle + busy steer) expand before `addToHistory`, prior to clearing the store
- dropped the now-dead `lineCount` (only served the wrapper label)

## Verified

- 938 tests pass, incl. new unit test for the expansion (unknown ids left verbatim)
- tmux-driven TUI run: multi-line paste → `[pasted-text #1]` in input → submit echoes the raw three lines, no tags → Up recalls the raw multi-line original

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ExcHrmeqGonzPaP4XgAtx