### PR TITLE
fix(tui): add unit to compacting spinner count

### DIFF
--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -1795,7 +1795,7 @@ private func codingFrameStateLine(
 
     switch mode {
     case .compacting(let count):
-        parts.append(Theme.paint("\(spinner) compacting \(count)", Theme.warn, bold: true))
+        parts.append(Theme.paint("\(spinner) compacting \(count) messages", Theme.warn, bold: true))
         parts.append(Theme.faintText("new prompts queue"))
         parts.append(Theme.faintText("Esc to cancel"))
     case .aborting:


### PR DESCRIPTION
The compacting spinner rendered `compacting 34` — a bare number with no unit, so it read as ambiguous (seconds? messages?). The count is the number of transcript messages being compacted; label it `compacting 34 messages`, matching the existing `auto-compacting N messages…` transcript line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNQumaqLQDNxQH4YFaacwY