### PR TITLE
Normalize image payloads and add per-provider image budgets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,33 @@
 {
-  "originHash" : "cfb508a800d4e1c50b10b6ab23181bab3865c6174640ed1c4e4942c7c64fb8cd",
+  "originHash" : "9558d15d50ed38ae93d3f1b26947faa7e32ae9c0aec0fd0c210765a285750bd8",
   "pins" : [
+    {
+      "identity" : "cstb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/troughton/Cstb.git",
+      "state" : {
+        "revision" : "a47f4ecf3a139ac2f53ed27a984853c9f98097f1",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "libpng",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/the-swift-collective/libpng.git",
+      "state" : {
+        "revision" : "0eff23aca92a086b7892831f5cb4f58e15be9449",
+        "version" : "1.6.45"
+      }
+    },
+    {
+      "identity" : "libwebp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/the-swift-collective/libwebp.git",
+      "state" : {
+        "revision" : "5f745a17b9a5c2a4283f17c2cde4517610ab5f99",
+        "version" : "1.4.1"
+      }
+    },
     {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
@@ -71,6 +98,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "zlib",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/the-swift-collective/zlib.git",
+      "state" : {
+        "revision" : "f1d153b90420f9fcc6ef916cd67ea96f0e68d137",
+        "version" : "1.3.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,8 @@ let package = Package(
         // keeps writing heartbeats / exec results while the server streams).
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.0"),
+        .package(url: "https://github.com/troughton/Cstb.git", from: "1.0.6"),
+        .package(url: "https://github.com/the-swift-collective/libwebp.git", from: "1.4.1"),
     ],
     targets: [
         .target(
@@ -40,6 +42,11 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .product(name: "stb_image", package: "Cstb"),
+                .product(name: "stb_image_resize", package: "Cstb"),
+                .product(name: "stb_image_write", package: "Cstb"),
+                .product(name: "WebP", package: "libwebp"),
+                .product(name: "libwebp", package: "libwebp"),
             ],
             path: "Sources/KWWKAI",
             resources: [.process("Resources")]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Inside the TUI, `/help` lists slash commands (`/model`, `/thinking`,
 `/clear`, …). The agent ships with Bash, Read, Write, Edit, Grep, Find,
 LS, and background-task tools out of the box.
 
+Image inputs are resized and recompressed before entering the conversation.
+Set `KWWK_NO_WEBP=1` when the target backend cannot decode WebP (for example,
+llama.cpp builds that use stb_image).
+
 ---
 
 ## 2. The agent SDK

--- a/Sources/KWWKAI/APIRegistry.swift
+++ b/Sources/KWWKAI/APIRegistry.swift
@@ -168,7 +168,8 @@ public func stream(
     guard let provider = await registry.provider(scope: model.provider, api: model.api) else {
         throw ProviderNotFoundError.api(model.api)
     }
-    return provider.stream(model: model, context: context, options: options)
+    let outboundContext = ProviderImageBudget.clamp(context, for: model)
+    return provider.stream(model: model, context: outboundContext, options: options)
 }
 
 /// Convenience: run a stream to completion and return the final message.

--- a/Sources/KWWKAI/ImageNormalizer.swift
+++ b/Sources/KWWKAI/ImageNormalizer.swift
@@ -1,0 +1,764 @@
+import Foundation
+import WebP
+import libwebp
+import stb_image
+import stb_image_resize
+import stb_image_write
+
+public enum ImageNormalizationError: Error, LocalizedError, Sendable, Equatable {
+    case unsupportedFormat
+    case sourceTooLarge(byteCount: Int, maximumBytes: Int)
+    case dimensionsTooLarge(width: Int, height: Int, maximumPixels: Int)
+    case decodeFailed
+    case resizeFailed
+    case encodeFailed(format: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            return "unsupported image format"
+        case .sourceTooLarge(let byteCount, let maximumBytes):
+            return "image file is too large (\(byteCount) bytes; limit \(maximumBytes))"
+        case .dimensionsTooLarge(let width, let height, let maximumPixels):
+            return "image dimensions are too large (\(width)x\(height); limit \(maximumPixels) pixels)"
+        case .decodeFailed:
+            return "failed to decode image"
+        case .resizeFailed:
+            return "failed to resize image"
+        case .encodeFailed(let format):
+            return "failed to encode image as \(format)"
+        }
+    }
+}
+
+public struct NormalizedImage: Sendable, Hashable {
+    public let content: ImageContent
+    public let byteCount: Int
+    public let originalWidth: Int
+    public let originalHeight: Int
+    public let width: Int
+    public let height: Int
+    public let wasReencoded: Bool
+
+    public var coordinateMappingNote: String? {
+        guard width != originalWidth || height != originalHeight else { return nil }
+
+        let xScale = Double(originalWidth) / Double(width)
+        let yScale = Double(originalHeight) / Double(height)
+        let mapping: String
+        if abs(xScale - yScale) < 0.005 {
+            mapping = "Multiply coordinates by \(Self.formatScale(xScale))"
+        } else {
+            mapping = "Multiply x coordinates by \(Self.formatScale(xScale)) and y coordinates by \(Self.formatScale(yScale))"
+        }
+        return "[Image: original \(originalWidth)x\(originalHeight), displayed at \(width)x\(height). \(mapping) to map to the original image.]"
+    }
+
+    private static func formatScale(_ scale: Double) -> String {
+        String(format: "%.2f", scale)
+    }
+}
+
+public enum ImageNormalizer {
+    public static func normalize(
+        _ data: Data,
+        excludingWebP: Bool? = nil
+    ) throws -> NormalizedImage {
+        try normalize(
+            data,
+            options: .default(
+                excludingWebP: excludingWebP
+                    ?? excludesWebP(in: ProcessInfo.processInfo.environment)
+            )
+        )
+    }
+
+    static func excludesWebP(in environment: [String: String]) -> Bool {
+        guard let raw = environment["KWWK_NO_WEBP"] else { return false }
+        return raw == "1" || raw.lowercased() == "true"
+    }
+
+    static func normalize(
+        _ data: Data,
+        options: ImageNormalizationOptions
+    ) throws -> NormalizedImage {
+        guard let sourceFormat = ImageFileFormat(data: data) else {
+            throw ImageNormalizationError.unsupportedFormat
+        }
+        guard data.count <= options.maximumSourceBytes else {
+            throw ImageNormalizationError.sourceTooLarge(
+                byteCount: data.count,
+                maximumBytes: options.maximumSourceBytes
+            )
+        }
+        // Reject decompression bombs before decoding: the decoder expands the
+        // source into width * height * 4 bytes of RGBA regardless of file size.
+        let probed = try probeDimensions(data, format: sourceFormat)
+        guard probed.width * probed.height <= options.maximumSourcePixels else {
+            throw ImageNormalizationError.dimensionsTooLarge(
+                width: probed.width,
+                height: probed.height,
+                maximumPixels: options.maximumSourcePixels
+            )
+        }
+
+        let orientation = sourceFormat == .jpeg
+            ? EXIFOrientation(jpegData: data) ?? .identity
+            : .identity
+        let source = try decode(data, format: sourceFormat).applying(orientation)
+        let minimumDimension = min(options.minimumDimension, options.maximumWidth, options.maximumHeight)
+        let isComfortablyWithinLimits = source.width >= minimumDimension
+            && source.height >= minimumDimension
+            && source.width <= options.maximumWidth
+            && source.height <= options.maximumHeight
+            && data.count <= options.maximumBytes / 4
+            && orientation == .identity
+            && !(options.excludeWebP && sourceFormat == .webp)
+
+        if isComfortablyWithinLimits {
+            return NormalizedImage(
+                content: ImageContent(
+                    data: data.base64EncodedString(),
+                    mimeType: sourceFormat.mimeType
+                ),
+                byteCount: data.count,
+                originalWidth: source.width,
+                originalHeight: source.height,
+                width: source.width,
+                height: source.height,
+                wasReencoded: false
+            )
+        }
+
+        let targetSize = targetSize(
+            width: source.width,
+            height: source.height,
+            minimumDimension: minimumDimension,
+            maximumWidth: options.maximumWidth,
+            maximumHeight: options.maximumHeight
+        )
+        let target = try resize(source, width: targetSize.width, height: targetSize.height)
+
+        var best = try encodeSmallest(
+            target,
+            quality: options.initialQuality,
+            excludingWebP: options.excludeWebP
+        )
+        if best.data.count <= options.maximumBytes {
+            return normalizedImage(best, source: source)
+        }
+
+        for quality in options.qualitySteps {
+            let candidate = try encodeSmallestLossy(
+                target,
+                quality: quality,
+                excludingWebP: options.excludeWebP
+            )
+            if candidate.data.count < best.data.count {
+                best = candidate
+            }
+            if candidate.data.count <= options.maximumBytes {
+                return normalizedImage(candidate, source: source)
+            }
+        }
+
+        for scale in options.scaleSteps {
+            let width = Int((Double(target.width) * scale).rounded())
+            let height = Int((Double(target.height) * scale).rounded())
+            if width < options.minimumFallbackDimension || height < options.minimumFallbackDimension {
+                break
+            }
+
+            let scaled = try resize(source, width: width, height: height)
+            for quality in options.qualitySteps {
+                let candidate = try encodeSmallestLossy(
+                    scaled,
+                    quality: quality,
+                    excludingWebP: options.excludeWebP
+                )
+                if candidate.data.count < best.data.count {
+                    best = candidate
+                }
+                if candidate.data.count <= options.maximumBytes {
+                    return normalizedImage(candidate, source: source)
+                }
+            }
+        }
+
+        return normalizedImage(best, source: source)
+    }
+
+    private static func normalizedImage(
+        _ encoded: EncodedImage,
+        source: RasterImage
+    ) -> NormalizedImage {
+        NormalizedImage(
+            content: ImageContent(
+                data: encoded.data.base64EncodedString(),
+                mimeType: encoded.format.mimeType
+            ),
+            byteCount: encoded.data.count,
+            originalWidth: source.width,
+            originalHeight: source.height,
+            width: encoded.width,
+            height: encoded.height,
+            wasReencoded: true
+        )
+    }
+
+    private static func targetSize(
+        width originalWidth: Int,
+        height originalHeight: Int,
+        minimumDimension: Int,
+        maximumWidth: Int,
+        maximumHeight: Int
+    ) -> (width: Int, height: Int) {
+        var width = originalWidth
+        var height = originalHeight
+
+        if width > maximumWidth {
+            height = Int((Double(height) * Double(maximumWidth) / Double(width)).rounded())
+            width = maximumWidth
+        }
+        if height > maximumHeight {
+            width = Int((Double(width) * Double(maximumHeight) / Double(height)).rounded())
+            height = maximumHeight
+        }
+
+        if width < minimumDimension || height < minimumDimension {
+            let shortEdge = min(width, height)
+            let upscale = min(
+                Double(minimumDimension) / Double(shortEdge),
+                Double(maximumWidth) / Double(width),
+                Double(maximumHeight) / Double(height)
+            )
+            if upscale > 1 {
+                width = Int((Double(width) * upscale).rounded())
+                height = Int((Double(height) * upscale).rounded())
+            }
+            width = min(maximumWidth, max(minimumDimension, width))
+            height = min(maximumHeight, max(minimumDimension, height))
+        }
+
+        return (width, height)
+    }
+
+    private static func probeDimensions(
+        _ data: Data,
+        format: ImageFileFormat
+    ) throws -> (width: Int, height: Int) {
+        var width: Int32 = 0
+        var height: Int32 = 0
+        let didProbe = data.withUnsafeBytes { bytes -> Bool in
+            let base = bytes.bindMemory(to: UInt8.self).baseAddress
+            if format == .webp {
+                return WebPGetInfo(base, bytes.count, &width, &height) != 0
+            }
+            var channels: Int32 = 0
+            return stbi_info_from_memory(
+                base,
+                Int32(bytes.count),
+                &width,
+                &height,
+                &channels
+            ) != 0
+        }
+        guard didProbe, width > 0, height > 0 else {
+            throw ImageNormalizationError.decodeFailed
+        }
+        return (Int(width), Int(height))
+    }
+
+    private static func decode(_ data: Data, format: ImageFileFormat) throws -> RasterImage {
+        if format == .webp {
+            do {
+                let image = try WebP.decode(Array(data))
+                return RasterImage(width: image.width, height: image.height, rgba: image.rgba)
+            } catch {
+                throw ImageNormalizationError.decodeFailed
+            }
+        }
+
+        var width: Int32 = 0
+        var height: Int32 = 0
+        var sourceChannels: Int32 = 0
+        let decoded = data.withUnsafeBytes { bytes in
+            stbi_load_from_memory(
+                bytes.bindMemory(to: UInt8.self).baseAddress,
+                Int32(bytes.count),
+                &width,
+                &height,
+                &sourceChannels,
+                4
+            )
+        }
+        guard let decoded else {
+            throw ImageNormalizationError.decodeFailed
+        }
+        defer { stbi_image_free(decoded) }
+
+        let pixelCount = Int(width) * Int(height) * 4
+        return RasterImage(
+            width: Int(width),
+            height: Int(height),
+            rgba: Array(UnsafeBufferPointer(start: decoded, count: pixelCount))
+        )
+    }
+
+    private static func resize(
+        _ image: RasterImage,
+        width: Int,
+        height: Int
+    ) throws -> RasterImage {
+        guard image.width != width || image.height != height else { return image }
+
+        var rgba = [UInt8](repeating: 0, count: width * height * 4)
+        let didResize = image.rgba.withUnsafeBufferPointer { source in
+            rgba.withUnsafeMutableBufferPointer { destination in
+                stbir_resize_uint8_srgb(
+                    source.baseAddress,
+                    Int32(image.width),
+                    Int32(image.height),
+                    0,
+                    destination.baseAddress,
+                    Int32(width),
+                    Int32(height),
+                    0,
+                    4,
+                    3,
+                    0
+                )
+            }
+        }
+        guard didResize != 0 else {
+            throw ImageNormalizationError.resizeFailed
+        }
+        return RasterImage(width: width, height: height, rgba: rgba)
+    }
+
+    private static func encodeSmallest(
+        _ image: RasterImage,
+        quality: Int,
+        excludingWebP: Bool
+    ) throws -> EncodedImage {
+        var candidates = try [
+            encodePNG(image),
+            encodeJPEG(image, quality: quality),
+        ]
+        if !excludingWebP {
+            candidates.append(try encodeWebP(image, quality: quality))
+        }
+        return candidates.min(by: { $0.data.count < $1.data.count })!
+    }
+
+    private static func encodeSmallestLossy(
+        _ image: RasterImage,
+        quality: Int,
+        excludingWebP: Bool
+    ) throws -> EncodedImage {
+        let jpeg = try encodeJPEG(image, quality: quality)
+        guard !excludingWebP else { return jpeg }
+        let webP = try encodeWebP(image, quality: quality)
+        return jpeg.data.count < webP.data.count ? jpeg : webP
+    }
+
+    private static func encodePNG(_ image: RasterImage) throws -> EncodedImage {
+        let sink = ImageDataSink()
+        let context = Unmanaged.passUnretained(sink).toOpaque()
+        let didEncode = image.rgba.withUnsafeBytes { pixels in
+            stbi_write_png_to_func(
+                appendImageData,
+                context,
+                Int32(image.width),
+                Int32(image.height),
+                4,
+                pixels.baseAddress!,
+                Int32(image.width * 4)
+            )
+        }
+        guard didEncode != 0 else {
+            throw ImageNormalizationError.encodeFailed(format: ImageFileFormat.png.mimeType)
+        }
+        return EncodedImage(data: sink.data, format: .png, width: image.width, height: image.height)
+    }
+
+    private static func encodeJPEG(
+        _ image: RasterImage,
+        quality: Int
+    ) throws -> EncodedImage {
+        let sink = ImageDataSink()
+        let context = Unmanaged.passUnretained(sink).toOpaque()
+        let didEncode = image.rgba.withUnsafeBytes { pixels in
+            stbi_write_jpg_to_func(
+                appendImageData,
+                context,
+                Int32(image.width),
+                Int32(image.height),
+                4,
+                pixels.baseAddress!,
+                Int32(quality)
+            )
+        }
+        guard didEncode != 0 else {
+            throw ImageNormalizationError.encodeFailed(format: ImageFileFormat.jpeg.mimeType)
+        }
+        return EncodedImage(data: sink.data, format: .jpeg, width: image.width, height: image.height)
+    }
+
+    private static func encodeWebP(
+        _ image: RasterImage,
+        quality: Int
+    ) throws -> EncodedImage {
+        do {
+            let encoded = try WebP(
+                width: image.width,
+                height: image.height,
+                rgba: image.rgba
+            ).encode(quality: Float(quality))
+            return EncodedImage(
+                data: Data(encoded),
+                format: .webp,
+                width: image.width,
+                height: image.height
+            )
+        } catch {
+            throw ImageNormalizationError.encodeFailed(format: ImageFileFormat.webp.mimeType)
+        }
+    }
+}
+
+struct ImageNormalizationOptions: Sendable {
+    let maximumWidth: Int
+    let maximumHeight: Int
+    let minimumDimension: Int
+    let maximumBytes: Int
+    /// Hard cap on the encoded source size, checked before any decoding.
+    var maximumSourceBytes: Int = 100 * 1024 * 1024
+    /// Hard cap on decoded pixel count, checked against header dimensions
+    /// before decoding. 64 megapixels decodes into 256 MB of RGBA.
+    var maximumSourcePixels: Int = 64 * 1024 * 1024
+    let initialQuality: Int
+    let qualitySteps: [Int]
+    let scaleSteps: [Double]
+    let minimumFallbackDimension: Int
+    let excludeWebP: Bool
+
+    static func `default`(excludingWebP: Bool = false) -> ImageNormalizationOptions {
+        ImageNormalizationOptions(
+            maximumWidth: 1568,
+            maximumHeight: 1568,
+            minimumDimension: 200,
+            maximumBytes: 500 * 1024,
+            initialQuality: 80,
+            qualitySteps: [70, 60, 50, 40],
+            scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
+            minimumFallbackDimension: 100,
+            excludeWebP: excludingWebP
+        )
+    }
+}
+
+private enum ImageFileFormat: Sendable {
+    case png
+    case jpeg
+    case gif
+    case webp
+
+    init?(data: Data) {
+        if data.starts(with: [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+            self = .png
+        } else if data.starts(with: [0xFF, 0xD8, 0xFF]) {
+            self = .jpeg
+        } else if data.starts(with: Array("GIF87a".utf8)) || data.starts(with: Array("GIF89a".utf8)) {
+            self = .gif
+        } else if data.count >= 12
+            && data.starts(with: Array("RIFF".utf8))
+            && data[8..<12].elementsEqual("WEBP".utf8) {
+            self = .webp
+        } else {
+            return nil
+        }
+    }
+
+    var mimeType: String {
+        switch self {
+        case .png: return "image/png"
+        case .jpeg: return "image/jpeg"
+        case .gif: return "image/gif"
+        case .webp: return "image/webp"
+        }
+    }
+}
+
+struct RasterImage {
+    let width: Int
+    let height: Int
+    let rgba: [UInt8]
+
+    func applying(_ orientation: EXIFOrientation) -> RasterImage {
+        guard orientation != .identity else { return self }
+
+        let outputWidth = orientation.swapsAxes ? height : width
+        let outputHeight = orientation.swapsAxes ? width : height
+        var output = [UInt8](repeating: 0, count: rgba.count)
+
+        rgba.withUnsafeBufferPointer { source in
+            output.withUnsafeMutableBufferPointer { destination in
+                for sourceY in 0..<height {
+                    for sourceX in 0..<width {
+                        let destinationPoint = orientation.destination(
+                            sourceX: sourceX,
+                            sourceY: sourceY,
+                            sourceWidth: width,
+                            sourceHeight: height
+                        )
+                        let sourceOffset = (sourceY * width + sourceX) * 4
+                        let destinationOffset = (
+                            destinationPoint.y * outputWidth + destinationPoint.x
+                        ) * 4
+                        destination[destinationOffset] = source[sourceOffset]
+                        destination[destinationOffset + 1] = source[sourceOffset + 1]
+                        destination[destinationOffset + 2] = source[sourceOffset + 2]
+                        destination[destinationOffset + 3] = source[sourceOffset + 3]
+                    }
+                }
+            }
+        }
+
+        return RasterImage(width: outputWidth, height: outputHeight, rgba: output)
+    }
+}
+
+enum EXIFOrientation: UInt16, Sendable, CaseIterable {
+    case identity = 1
+    case mirroredHorizontally = 2
+    case rotated180 = 3
+    case mirroredVertically = 4
+    case transposed = 5
+    case rotated90Clockwise = 6
+    case mirroredAcrossAntiDiagonal = 7
+    case rotated90Counterclockwise = 8
+
+    init?(jpegData: Data) {
+        guard let orientation = jpegData.withUnsafeBytes(Self.readJPEGOrientation) else {
+            return nil
+        }
+        self = orientation
+    }
+
+    var swapsAxes: Bool {
+        switch self {
+        case .transposed,
+             .rotated90Clockwise,
+             .mirroredAcrossAntiDiagonal,
+             .rotated90Counterclockwise:
+            return true
+        case .identity,
+             .mirroredHorizontally,
+             .rotated180,
+             .mirroredVertically:
+            return false
+        }
+    }
+
+    func destination(
+        sourceX: Int,
+        sourceY: Int,
+        sourceWidth: Int,
+        sourceHeight: Int
+    ) -> (x: Int, y: Int) {
+        switch self {
+        case .identity:
+            return (sourceX, sourceY)
+        case .mirroredHorizontally:
+            return (sourceWidth - 1 - sourceX, sourceY)
+        case .rotated180:
+            return (sourceWidth - 1 - sourceX, sourceHeight - 1 - sourceY)
+        case .mirroredVertically:
+            return (sourceX, sourceHeight - 1 - sourceY)
+        case .transposed:
+            return (sourceY, sourceX)
+        case .rotated90Clockwise:
+            return (sourceHeight - 1 - sourceY, sourceX)
+        case .mirroredAcrossAntiDiagonal:
+            return (sourceHeight - 1 - sourceY, sourceWidth - 1 - sourceX)
+        case .rotated90Counterclockwise:
+            return (sourceY, sourceWidth - 1 - sourceX)
+        }
+    }
+
+    private enum TIFFByteOrder {
+        case littleEndian
+        case bigEndian
+    }
+
+    private static let exifSignature: [UInt8] = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00]
+
+    private static func readJPEGOrientation(
+        _ bytes: UnsafeRawBufferPointer
+    ) -> EXIFOrientation? {
+        guard bytes.count >= 4, bytes[0] == 0xFF, bytes[1] == 0xD8 else {
+            return nil
+        }
+
+        var offset = 2
+        while offset < bytes.count {
+            while offset < bytes.count, bytes[offset] != 0xFF {
+                offset += 1
+            }
+            while offset < bytes.count, bytes[offset] == 0xFF {
+                offset += 1
+            }
+            guard offset < bytes.count else { return nil }
+
+            let marker = bytes[offset]
+            offset += 1
+            if marker == 0xD9 || marker == 0xDA {
+                return nil
+            }
+            if marker == 0x01 || marker == 0xD8 || (0xD0...0xD7).contains(marker) {
+                continue
+            }
+
+            guard let segmentLength = readUInt16BigEndian(bytes, at: offset),
+                  segmentLength >= 2
+            else {
+                return nil
+            }
+            let payloadStart = offset + 2
+            let payloadEnd = payloadStart + Int(segmentLength) - 2
+            guard payloadEnd <= bytes.count else { return nil }
+
+            if marker == 0xE1,
+               let orientation = readEXIFOrientation(
+                   bytes,
+                   payloadStart: payloadStart,
+                   payloadEnd: payloadEnd
+               ) {
+                return orientation
+            }
+            offset = payloadEnd
+        }
+        return nil
+    }
+
+    private static func readEXIFOrientation(
+        _ bytes: UnsafeRawBufferPointer,
+        payloadStart: Int,
+        payloadEnd: Int
+    ) -> EXIFOrientation? {
+        guard payloadEnd - payloadStart >= exifSignature.count + 8 else { return nil }
+        for (index, byte) in exifSignature.enumerated() {
+            guard bytes[payloadStart + index] == byte else { return nil }
+        }
+
+        let tiffStart = payloadStart + exifSignature.count
+        let byteOrder: TIFFByteOrder
+        switch (bytes[tiffStart], bytes[tiffStart + 1]) {
+        case (0x49, 0x49):
+            byteOrder = .littleEndian
+        case (0x4D, 0x4D):
+            byteOrder = .bigEndian
+        default:
+            return nil
+        }
+        guard readUInt16(bytes, at: tiffStart + 2, byteOrder: byteOrder) == 42,
+              let firstIFDOffset = readUInt32(
+                  bytes,
+                  at: tiffStart + 4,
+                  byteOrder: byteOrder
+              )
+        else {
+            return nil
+        }
+
+        let firstIFD = tiffStart + Int(firstIFDOffset)
+        guard firstIFD + 2 <= payloadEnd,
+              let entryCount = readUInt16(bytes, at: firstIFD, byteOrder: byteOrder)
+        else {
+            return nil
+        }
+
+        for entryIndex in 0..<Int(entryCount) {
+            let entry = firstIFD + 2 + entryIndex * 12
+            guard entry + 12 <= payloadEnd else { return nil }
+            guard readUInt16(bytes, at: entry, byteOrder: byteOrder) == 0x0112 else {
+                continue
+            }
+            guard readUInt16(bytes, at: entry + 2, byteOrder: byteOrder) == 3,
+                  readUInt32(bytes, at: entry + 4, byteOrder: byteOrder) == 1,
+                  let rawOrientation = readUInt16(
+                      bytes,
+                      at: entry + 8,
+                      byteOrder: byteOrder
+                  )
+            else {
+                return nil
+            }
+            return EXIFOrientation(rawValue: rawOrientation)
+        }
+        return nil
+    }
+
+    private static func readUInt16BigEndian(
+        _ bytes: UnsafeRawBufferPointer,
+        at offset: Int
+    ) -> UInt16? {
+        guard offset + 2 <= bytes.count else { return nil }
+        return UInt16(bytes[offset]) << 8 | UInt16(bytes[offset + 1])
+    }
+
+    private static func readUInt16(
+        _ bytes: UnsafeRawBufferPointer,
+        at offset: Int,
+        byteOrder: TIFFByteOrder
+    ) -> UInt16? {
+        guard offset + 2 <= bytes.count else { return nil }
+        switch byteOrder {
+        case .littleEndian:
+            return UInt16(bytes[offset]) | UInt16(bytes[offset + 1]) << 8
+        case .bigEndian:
+            return UInt16(bytes[offset]) << 8 | UInt16(bytes[offset + 1])
+        }
+    }
+
+    private static func readUInt32(
+        _ bytes: UnsafeRawBufferPointer,
+        at offset: Int,
+        byteOrder: TIFFByteOrder
+    ) -> UInt32? {
+        guard offset + 4 <= bytes.count else { return nil }
+        switch byteOrder {
+        case .littleEndian:
+            return UInt32(bytes[offset])
+                | UInt32(bytes[offset + 1]) << 8
+                | UInt32(bytes[offset + 2]) << 16
+                | UInt32(bytes[offset + 3]) << 24
+        case .bigEndian:
+            return UInt32(bytes[offset]) << 24
+                | UInt32(bytes[offset + 1]) << 16
+                | UInt32(bytes[offset + 2]) << 8
+                | UInt32(bytes[offset + 3])
+        }
+    }
+}
+
+private struct EncodedImage {
+    let data: Data
+    let format: ImageFileFormat
+    let width: Int
+    let height: Int
+}
+
+private final class ImageDataSink: @unchecked Sendable {
+    var data = Data()
+}
+
+private func appendImageData(
+    context: UnsafeMutableRawPointer?,
+    data: UnsafeMutableRawPointer?,
+    size: Int32
+) {
+    let sink = Unmanaged<ImageDataSink>.fromOpaque(context!).takeUnretainedValue()
+    sink.data.append(data!.assumingMemoryBound(to: UInt8.self), count: Int(size))
+}

--- a/Sources/KWWKAI/ProviderImageBudget.swift
+++ b/Sources/KWWKAI/ProviderImageBudget.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+enum ProviderImageBudget {
+    static let defaultLimit = 5
+
+    private static let limits: [String: Int] = [
+        "anthropic": 90,
+        "amazon-bedrock": 90,
+        "openai": 200,
+        "openai-codex": 200,
+        "chatgpt-codex": 200,
+        "google": 200,
+        "google-vertex": 200,
+        "google-gemini-cli": 200,
+        "openrouter": 90,
+        "umans": 10,
+    ]
+
+    private static let imageOmissionText = "[image omitted: provider image limit]"
+
+    private static let userImageOmission = UserBlock.text(
+        TextContent(text: imageOmissionText)
+    )
+
+    private static let toolResultImageOmission = ToolResultBlock.text(
+        TextContent(text: imageOmissionText)
+    )
+
+    static func limit(for provider: String) -> Int {
+        limits[provider] ?? defaultLimit
+    }
+
+    static func clamp(_ context: Context, for model: Model) -> Context {
+        guard model.input.contains(.image) else { return context }
+
+        let imageCount = countImages(in: context.messages)
+        var remainingImageCountToDrop = imageCount - limit(for: model.provider)
+        guard remainingImageCountToDrop > 0 else { return context }
+
+        var clamped = context
+        clamped.messages = context.messages.map { message in
+            clamp(message, remainingImageCountToDrop: &remainingImageCountToDrop)
+        }
+        return clamped
+    }
+
+    private static func countImages(in messages: [Message]) -> Int {
+        var count = 0
+        for message in messages {
+            switch message {
+            case .user(let user):
+                count += user.content.reduce(into: 0) { count, block in
+                    if case .image = block { count += 1 }
+                }
+            case .toolResult(let result):
+                count += result.content.reduce(into: 0) { count, block in
+                    if case .image = block { count += 1 }
+                }
+            case .assistant:
+                break
+            }
+        }
+        return count
+    }
+
+    private static func clamp(
+        _ message: Message,
+        remainingImageCountToDrop: inout Int
+    ) -> Message {
+        guard remainingImageCountToDrop > 0 else { return message }
+
+        switch message {
+        case .user(var user):
+            let content = droppingOldestImages(
+                from: user.content,
+                remainingImageCountToDrop: &remainingImageCountToDrop
+            )
+            guard content.count != user.content.count else { return message }
+            user.content = content.isEmpty ? [userImageOmission] : content
+            return .user(user)
+        case .toolResult(var result):
+            let content = droppingOldestImages(
+                from: result.content,
+                remainingImageCountToDrop: &remainingImageCountToDrop
+            )
+            guard content.count != result.content.count else { return message }
+            result.content = content.isEmpty ? [toolResultImageOmission] : content
+            return .toolResult(result)
+        case .assistant:
+            return message
+        }
+    }
+
+    private static func droppingOldestImages(
+        from content: [UserBlock],
+        remainingImageCountToDrop: inout Int
+    ) -> [UserBlock] {
+        content.filter { block in
+            guard case .image = block, remainingImageCountToDrop > 0 else { return true }
+            remainingImageCountToDrop -= 1
+            return false
+        }
+    }
+
+    private static func droppingOldestImages(
+        from content: [ToolResultBlock],
+        remainingImageCountToDrop: inout Int
+    ) -> [ToolResultBlock] {
+        content.filter { block in
+            guard case .image = block, remainingImageCountToDrop > 0 else { return true }
+            remainingImageCountToDrop -= 1
+            return false
+        }
+    }
+}

--- a/Sources/KWWKAgent/AgentContextCompactor.swift
+++ b/Sources/KWWKAgent/AgentContextCompactor.swift
@@ -388,7 +388,9 @@ public enum AgentContextCompactor {
     /// is left alone so repeated `/shake` calls don't recount or re-elide.
     static let shakePlaceholderPrefix = "[tool result elided to reclaim context"
 
-    /// Strip heavy tool-result output from a live transcript without any LLM
+    private static let removedImagePlaceholder = "[image removed]"
+
+    /// Strip heavy tool-result output from a transcript without any LLM
     /// call (unlike `compactMessages`, which summarizes via the model). Walks
     /// `messages`; for each `.toolResult` whose joined `.text` blocks exceed
     /// `limit`, the text is replaced by a single short placeholder. Every
@@ -418,7 +420,7 @@ public enum AgentContextCompactor {
             guard joined.count > limit else { return message }
 
             // Collapse the bulky text into one placeholder block; carry any
-            // images through unchanged (they don't hold the bulk).
+            // images through unchanged for the explicit `/shake images` mode.
             var rebuilt: [ToolResultBlock] = [
                 .text(TextContent(text: "\(shakePlaceholderPrefix) — was \(joined.count) chars]"))
             ]
@@ -430,6 +432,54 @@ public enum AgentContextCompactor {
             return .toolResult(result)
         }
         return (rewritten, elidedCount)
+    }
+
+    /// Remove every image block from user and tool-result messages. Messages
+    /// that contained only images receive a text placeholder so providers
+    /// never see an empty content array. All message metadata and surviving
+    /// text blocks retain their original order.
+    ///
+    /// Pure and idempotent: callers use this same transformation for the live
+    /// agent context and every persisted session projection.
+    public static func removingImages(
+        from messages: [Message]
+    ) -> (messages: [Message], removedCount: Int) {
+        var removedCount = 0
+        let rewritten = messages.map { message -> Message in
+            switch message {
+            case .user(var user):
+                let originalCount = user.content.count
+                user.content.removeAll { block in
+                    if case .image = block { return true }
+                    return false
+                }
+                let removed = originalCount - user.content.count
+                guard removed > 0 else { return message }
+                if user.content.isEmpty {
+                    user.content = [.text(TextContent(text: removedImagePlaceholder))]
+                }
+                removedCount += removed
+                return .user(user)
+
+            case .toolResult(var result):
+                let originalCount = result.content.count
+                result.content.removeAll { block in
+                    if case .image = block { return true }
+                    return false
+                }
+                let removed = originalCount - result.content.count
+                guard removed > 0 else { return message }
+                if result.content.isEmpty {
+                    result.content = [.text(TextContent(text: removedImagePlaceholder))]
+                }
+                removedCount += removed
+                return .toolResult(result)
+
+            case .assistant:
+                return message
+            }
+        }
+        return (rewritten, removedCount)
     }
 
     private static func isShakePlaceholder(_ content: [ToolResultBlock]) -> Bool {

--- a/Sources/KWWKAgent/ReadTool.swift
+++ b/Sources/KWWKAgent/ReadTool.swift
@@ -69,7 +69,7 @@ public func createReadTool(
     var tool = AgentTool(
         name: "read",
         label: "read",
-        description: "Read the contents of a text or image file. Long outputs are truncated — use offset/limit for large files. Images are inlined at full size with no downscaling, so a large image spends its full encoded byte count.",
+        description: "Read the contents of a text or image file. Long outputs are truncated — use offset/limit for large files. Images are resized and recompressed before they enter the conversation.",
         parameters: parameters,
         execute: { _, args, cancellation, _ in
             try cancellation?.throwIfCancelled()
@@ -96,17 +96,18 @@ public func createReadTool(
             )
             try await ops.access(absolutePath)
 
-            // Image path. The image is base64-inlined as-is: there is no
-            // resizing or downscaling, so a large image contributes its full
-            // encoded byte count to the request.
-            if let mimeType = try await ops.detectImageMimeType(absolutePath) {
+            // Image path.
+            if try await ops.detectImageMimeType(absolutePath) != nil {
                 let buffer = try await ops.readFile(absolutePath)
-                let base64 = buffer.base64EncodedString()
-                let note = "Read image file [\(mimeType)]"
+                let normalized = try ImageNormalizer.normalize(buffer)
+                var note = "Read image file [\(normalized.content.mimeType), \(normalized.width)x\(normalized.height), \(normalized.byteCount) bytes]"
+                if let coordinateMappingNote = normalized.coordinateMappingNote {
+                    note += "\n\(coordinateMappingNote)"
+                }
                 return AgentToolResult(
                     content: [
                         .text(TextContent(text: note)),
-                        .image(ImageContent(data: base64, mimeType: mimeType)),
+                        .image(normalized.content),
                     ]
                 )
             }

--- a/Sources/KWWKAgent/SessionRecorder.swift
+++ b/Sources/KWWKAgent/SessionRecorder.swift
@@ -6,13 +6,15 @@ import KWWKAI
 /// session's JSONL log as they land, so a crashed or aborted run still
 /// leaves a resumable transcript on disk.
 ///
-/// The recorder is *additive* and non-invasive — attach it to any agent and
-/// detach when done. It persists on every message-bearing event
+/// Event recording is additive — attach the recorder to any agent and detach
+/// when done. It persists on every message-bearing event
 /// (`messageEnd`, `turnEnd`, `agentEnd`) by diffing the agent's current
 /// transcript against the count already written, then appending only the new
-/// tail. That keeps writes append-only even when the loop produces several
-/// messages between events. Compaction is persisted as its own append-only
-/// marker and resets the live-message baseline to the compacted context.
+/// tail. That keeps ordinary writes append-only even when the loop produces
+/// several messages between events. Compaction is persisted as its own marker
+/// and resets the live-message baseline to the compacted context. Explicit
+/// `/shake` rewrites share the same serialized persistence queue, so a rewrite
+/// can never overtake a pending message or compaction write.
 public final class SessionRecorder: @unchecked Sendable {
     private struct PendingCompaction: Sendable {
         let replacementMessages: [Message]
@@ -23,10 +25,67 @@ public final class SessionRecorder: @unchecked Sendable {
         let reason: SessionStore.CompactionReason
     }
 
+    private enum TranscriptRewrite: Sendable {
+        case shakeToolOutputs(keepingUnder: Int)
+        case removeImages
+
+        func apply(to messages: [Message]) -> SessionStore.MessageRewrite {
+            switch self {
+            case .shakeToolOutputs(let limit):
+                let rewrite = AgentContextCompactor.shakeToolOutputs(
+                    messages,
+                    keepingUnder: limit
+                )
+                return SessionStore.MessageRewrite(
+                    messages: rewrite.messages,
+                    changedCount: rewrite.elidedCount
+                )
+            case .removeImages:
+                let rewrite = AgentContextCompactor.removingImages(from: messages)
+                return SessionStore.MessageRewrite(
+                    messages: rewrite.messages,
+                    changedCount: rewrite.removedCount
+                )
+            }
+        }
+    }
+
+    private final class RewriteResult: @unchecked Sendable {
+        private enum State {
+            case pending
+            case succeeded(Int)
+            case failed
+        }
+
+        private let lock = NSLock()
+        private var state = State.pending
+
+        var value: Int? {
+            lock.withLock {
+                guard case .succeeded(let value) = state else { return nil }
+                return value
+            }
+        }
+
+        func resolve(_ value: Int) {
+            lock.withLock { state = .succeeded(value) }
+        }
+
+        func fail() {
+            lock.withLock { state = .failed }
+        }
+    }
+
+    private struct PendingRewrite: Sendable {
+        let rewrite: TranscriptRewrite
+        let result: RewriteResult
+    }
+
     private enum PersistenceOperation: Sendable {
         case ensureCreated
         case messages([Message])
         case compaction(PendingCompaction)
+        case rewrite(PendingRewrite)
         case title(String)
     }
 
@@ -41,19 +100,22 @@ public final class SessionRecorder: @unchecked Sendable {
     private var persistedCount: Int
     /// Usage snapshot from the latest compactStart, consumed by compactEnd.
     private var pendingCompactionUsage: AgentContextUsage?
-    /// Failed operations remain queued so a later recorder event can retry
-    /// them before any newer write reaches disk.
+    /// Failed append/compaction/meta operations remain queued so a later
+    /// recorder event can retry them before any newer write reaches disk.
+    /// Explicit rewrites queued behind a failure are cancelled as one-shot
+    /// transactions because their callers keep the live transcript unchanged.
     private var pendingOperations: [PersistenceOperation] = []
     /// Protects the first queued operation from snapshot coalescing while its
     /// async store call is in flight.
     private var isPersistingFirstOperation = false
     private var _lastPersistenceError: String?
-    /// Tail of the serialized append chain. Each flush enqueues its write after
-    /// the previous one so concurrent events can't reorder the on-disk JSONL.
-    private var appendChain: Task<Void, Never>?
+    /// Tail of the serialized persistence chain. Each operation waits for the
+    /// previous one so appends, compactions, metadata, and rewrites stay ordered.
+    private var persistenceChain: Task<Void, Never>?
 
-    /// Most recent persistence failure. The failed operation remains queued;
-    /// this value clears once a later retry succeeds.
+    /// Most recent persistence failure. Failed append-style operations remain
+    /// queued; explicit rewrites are cancelled so they cannot run after their
+    /// callers kept the live transcript unchanged.
     public var lastPersistenceError: String? {
         lock.withLock { _lastPersistenceError }
     }
@@ -170,15 +232,35 @@ public final class SessionRecorder: @unchecked Sendable {
         await enqueue(.title(title))
     }
 
+    /// Permanently elide oversized tool output in every persisted transcript
+    /// entry. The rewrite is ordered with ordinary recorder writes.
+    public func rewriteShakenToolOutputs(
+        keepingUnder limit: Int = AgentContextCompactor.shakeToolOutputCharacterLimit
+    ) async -> Int? {
+        await rewriteTranscript(.shakeToolOutputs(keepingUnder: limit))
+    }
+
+    /// Permanently remove image blocks from every persisted transcript entry.
+    /// The rewrite is ordered with ordinary recorder writes.
+    public func rewriteRemovingImages() async -> Int? {
+        await rewriteTranscript(.removeImages)
+    }
+
+    private func rewriteTranscript(_ rewrite: TranscriptRewrite) async -> Int? {
+        let result = RewriteResult()
+        await enqueue(.rewrite(PendingRewrite(rewrite: rewrite, result: result)))
+        return result.value
+    }
+
     private func enqueue(_ operation: PersistenceOperation) async {
         let work: Task<Void, Never> = lock.withLock {
             enqueueCoalescingMessageSnapshots(operation)
-            let previous = appendChain
+            let previous = persistenceChain
             let next = Task<Void, Never> { [weak self] in
                 await previous?.value
                 await self?.drainPendingOperations()
             }
-            appendChain = next
+            persistenceChain = next
             return next
         }
         await work.value
@@ -198,10 +280,20 @@ public final class SessionRecorder: @unchecked Sendable {
                     _lastPersistenceError = nil
                 }
             } catch {
-                lock.withLock {
+                let cancelledRewrites = lock.withLock { () -> [RewriteResult] in
+                    var results: [RewriteResult] = []
+                    pendingOperations.removeAll { pendingOperation in
+                        guard case .rewrite(let pending) = pendingOperation else {
+                            return false
+                        }
+                        results.append(pending.result)
+                        return true
+                    }
                     isPersistingFirstOperation = false
                     _lastPersistenceError = String(describing: error)
+                    return results
                 }
+                cancelledRewrites.forEach { $0.fail() }
                 return
             }
         }
@@ -251,6 +343,13 @@ public final class SessionRecorder: @unchecked Sendable {
             lock.withLock {
                 persistedCount = compaction.replacementMessages.count
             }
+
+        case .rewrite(let pending):
+            let rewrite = pending.rewrite
+            let changedCount = try await store.rewriteMessages(id: sessionId) { messages in
+                rewrite.apply(to: messages)
+            }
+            pending.result.resolve(changedCount)
 
         case .title(let title):
             try await store.setTitle(id: sessionId, cwd: cwd, title: title)

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -591,14 +591,10 @@ public actor SessionStore {
         ) else {
             throw SessionStoreError.writeFailed(path: url.path)
         }
-        do {
-            _ = try FileManager.default.replaceItemAt(
-                url,
-                withItemAt: temporaryURL,
-                backupItemName: nil,
-                options: .usingNewMetadataOnly
-            )
-        } catch {
+        // POSIX rename(2) atomically replaces the destination on macOS and
+        // Linux alike. FileManager.replaceItemAt is not usable here: on
+        // swift-corelibs-foundation it can leave the destination missing.
+        guard rename(temporaryURL.path, url.path) == 0 else {
             try? FileManager.default.removeItem(at: temporaryURL)
             throw SessionStoreError.writeFailed(path: url.path)
         }

--- a/Sources/KWWKAgent/SessionStore.swift
+++ b/Sources/KWWKAgent/SessionStore.swift
@@ -6,16 +6,17 @@ import KWWKAI
 /// `defaultDirectory()`.
 ///
 /// Mirrors pi's `packages/agent/src/harness/session` storage in spirit but
-/// keeps a flat append-only log instead of pi's branching entry tree: each
+/// keeps a flat append-oriented log instead of pi's branching entry tree: each
 /// session file is a versioned header line followed by one JSON entry per
 /// line. Entries are transcript messages (`user` / `assistant` /
 /// `toolResult`), sparse metadata updates (model / thinking-level changes),
 /// or compaction markers that describe the projected resumable context.
 ///
-/// The store never rewrites the file — every `append(...)` is an `O(1)` write
-/// to the end of the file, so persisting on every message is cheap. Loading
-/// replays the log to reconstruct the projected context plus the latest
-/// metadata.
+/// Ordinary persistence is append-only, so recording each message is cheap.
+/// Explicit transcript maintenance such as `/shake` atomically rewrites the
+/// existing entries so removed payloads do not remain buried in older JSONL
+/// lines. Loading replays the log to reconstruct the projected context plus
+/// the latest metadata.
 ///
 /// File layout (one JSON object per line):
 /// ```
@@ -340,6 +341,11 @@ public actor SessionStore {
     }()
     private static let decoder = JSONDecoder()
 
+    struct MessageRewrite: Sendable {
+        let messages: [Message]
+        let changedCount: Int
+    }
+
     // MARK: - Create / append
 
     /// Create a new session file with a versioned header. Overwrites any
@@ -499,6 +505,103 @@ public actor SessionStore {
         defer { try? handle.close() }
         try handle.seekToEnd()
         handle.write(line)
+    }
+
+    /// Atomically rewrite every persisted transcript-bearing entry with one
+    /// canonical message transformation. Both ordinary message lines and the
+    /// replacement context inside compaction markers are rewritten; headers,
+    /// metadata, timestamps, and compaction bookkeeping remain unchanged.
+    ///
+    /// Returns the number of transformed payloads across the physical JSONL
+    /// entries. A zero result leaves the file untouched.
+    func rewriteMessages(
+        id: String,
+        using transform: @Sendable ([Message]) -> MessageRewrite
+    ) throws -> Int {
+        let url = try path(for: id)
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
+            throw SessionStoreError.notFound(id)
+        }
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: true)
+        guard let first = lines.first else {
+            throw SessionStoreError.missingHeader(url.path)
+        }
+        _ = try parseHeader(String(first), path: url.path)
+
+        var rewrittenEntries: [Entry] = []
+        rewrittenEntries.reserveCapacity(max(0, lines.count - 1))
+        var changedCount = 0
+
+        for (offset, line) in lines.dropFirst().enumerated() {
+            let lineNumber = offset + 2
+            guard let data = String(line).data(using: .utf8) else {
+                throw SessionStoreError.undecodableEntry(path: url.path, line: lineNumber)
+            }
+            let entry: Entry
+            do {
+                entry = try Self.decoder.decode(Entry.self, from: data)
+            } catch {
+                throw SessionStoreError.undecodableEntry(path: url.path, line: lineNumber)
+            }
+
+            switch entry {
+            case .message(let timestamp, let message):
+                let rewrite = transform([message])
+                changedCount += rewrite.changedCount
+                rewrittenEntries.append(.message(
+                    timestamp: timestamp,
+                    message: rewrite.messages[0]
+                ))
+
+            case .compaction(let timestamp, var compaction):
+                let rewrite = transform(compaction.replacementMessages)
+                changedCount += rewrite.changedCount
+                compaction.replacementMessages = rewrite.messages
+                rewrittenEntries.append(.compaction(
+                    timestamp: timestamp,
+                    compaction: compaction
+                ))
+
+            case .meta:
+                rewrittenEntries.append(entry)
+            }
+        }
+
+        guard changedCount > 0 else { return 0 }
+
+        var data = Data()
+        data.append(contentsOf: first.utf8)
+        data.append(0x0A)
+        for entry in rewrittenEntries {
+            data.append(try Self.encoder.encode(entry))
+            data.append(0x0A)
+        }
+        try replaceAtomically(url: url, data: data)
+        return changedCount
+    }
+
+    private func replaceAtomically(url: URL, data: Data) throws {
+        let temporaryURL = directory.appendingPathComponent(
+            ".\(url.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        guard FileManager.default.createFile(
+            atPath: temporaryURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw SessionStoreError.writeFailed(path: url.path)
+        }
+        do {
+            _ = try FileManager.default.replaceItemAt(
+                url,
+                withItemAt: temporaryURL,
+                backupItemName: nil,
+                options: .usingNewMetadataOnly
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw SessionStoreError.writeFailed(path: url.path)
+        }
     }
 
     // MARK: - Load

--- a/Sources/KWWKCli/Attachments.swift
+++ b/Sources/KWWKCli/Attachments.swift
@@ -16,7 +16,7 @@ final class AttachmentStore {
     /// A large pasted text block that we don't want to shove into a
     /// single-line editor. Shown in the input as `[pasted-text #id]`
     /// and expanded back to the raw body at submit time.
-    struct PastedText: Identifiable {
+    struct PastedText: Identifiable, Sendable {
         let id: Int
         let body: String
     }
@@ -24,7 +24,7 @@ final class AttachmentStore {
     /// A clipboard image captured at paste time. Rendered in the
     /// input as `[image #id]` and expanded to an `ImageContent` block
     /// on submit.
-    struct ClipboardImage: Identifiable {
+    struct ClipboardImage: Identifiable, Sendable {
         let id: Int
         let data: Data
         let mimeType: String
@@ -69,6 +69,21 @@ final class AttachmentStore {
         return out
     }
 
+    func promptSnapshot(for text: String) -> AttachmentPromptSnapshot {
+        AttachmentPromptSnapshot(
+            expandedText: expandPastedTextPlaceholders(in: text),
+            pastedTextIDs: Set(pastedTexts.map(\.id)),
+            clipboardImages: clipboardImages
+        )
+    }
+
+    func consume(_ snapshot: AttachmentPromptSnapshot) {
+        pastedTexts.removeAll { snapshot.pastedTextIDs.contains($0.id) }
+        clipboardImages.removeAll { snapshot.clipboardImageIDs.contains($0.id) }
+        if pastedTexts.isEmpty { nextPastedTextId = 1 }
+        if clipboardImages.isEmpty { nextClipboardImageId = 1 }
+    }
+
     /// Register a clipboard-sourced image (e.g. macOS ⌘V where
     /// NSPasteboard holds a screenshot). Returns the placeholder token.
     func addClipboardImage(data: Data, mimeType: String) -> String {
@@ -76,6 +91,16 @@ final class AttachmentStore {
         nextClipboardImageId += 1
         clipboardImages.append(ClipboardImage(id: id, data: data, mimeType: mimeType))
         return "[image #\(id)]"
+    }
+}
+
+struct AttachmentPromptSnapshot: Sendable {
+    let expandedText: String
+    let pastedTextIDs: Set<Int>
+    let clipboardImages: [AttachmentStore.ClipboardImage]
+
+    var clipboardImageIDs: Set<Int> {
+        Set(clipboardImages.map(\.id))
     }
 }
 
@@ -227,7 +252,7 @@ private func resolveSinglePath(_ raw: String, cwd: String) -> ResolvedAttachment
         return .folder(path: path, listing: renderFolderListing(path))
     }
     let size = (try? fm.attributesOfItem(atPath: path)[.size] as? Int) ?? 0
-    if let (data, mime) = loadImageIfSupported(path: path, maxBytes: 10 * 1024 * 1024) {
+    if let (data, mime) = loadImageIfSupported(path: path) {
         return .image(path: path, data: data, mimeType: mime)
     }
     if size > textFileMaxBytes {
@@ -240,15 +265,11 @@ private func resolveSinglePath(_ raw: String, cwd: String) -> ResolvedAttachment
     return .binaryFile(path: path, byteSize: size)
 }
 
-private func loadImageIfSupported(path: String, maxBytes: Int) -> (Data, String)? {
+private func loadImageIfSupported(path: String) -> (Data, String)? {
     let mime = imageMimeType(forPath: path)
     guard let mime else { return nil }
     let url = URL(fileURLWithPath: path)
-    guard let data = try? Data(contentsOf: url) else { return nil }
-    if data.count > maxBytes {
-        return nil  // drops through to binaryFile which surfaces as metadata
-    }
-    return (data, mime)
+    return (try? Data(contentsOf: url)).map { ($0, mime) }
 }
 
 private func imageMimeType(forPath path: String) -> String? {
@@ -301,8 +322,9 @@ private func renderFolderListing(_ path: String) -> String {
 /// substring replacement; `@path` references are kept in the text
 /// verbatim (so the LLM can see that the user pointed at something) and
 /// the resolved content is appended in a single `<attachments>` block.
-struct BuiltPrompt {
+struct BuiltPrompt: Sendable {
     let text: String
+    let recallText: String
     let images: [ImageContent]
     /// Short human-readable summary ("attached: 1 image, 2 files") of
     /// everything that got attached, including the happy-path items.
@@ -323,10 +345,35 @@ func buildPromptWithAttachments(
     store: AttachmentStore,
     cwd: String,
     modelSupportsImages: Bool
-) -> BuiltPrompt {
-    // 1. Expand pasted-text placeholders to their raw bodies — the
-    //    prompt reads exactly as if the user had typed the paste inline.
-    let expanded = store.expandPastedTextPlaceholders(in: inputText)
+) async throws -> BuiltPrompt {
+    let snapshot = store.promptSnapshot(for: inputText)
+    return try await buildPromptWithAttachments(
+        snapshot: snapshot,
+        cwd: cwd,
+        modelSupportsImages: modelSupportsImages
+    )
+}
+
+func buildPromptWithAttachments(
+    snapshot: AttachmentPromptSnapshot,
+    cwd: String,
+    modelSupportsImages: Bool
+) async throws -> BuiltPrompt {
+    try await Task.detached(priority: .userInitiated) {
+        try buildPrompt(
+            snapshot: snapshot,
+            cwd: cwd,
+            modelSupportsImages: modelSupportsImages
+        )
+    }.value
+}
+
+private func buildPrompt(
+    snapshot: AttachmentPromptSnapshot,
+    cwd: String,
+    modelSupportsImages: Bool
+) throws -> BuiltPrompt {
+    let expanded = snapshot.expandedText
 
     var images: [ImageContent] = []
     var attachBlocks: [String] = []
@@ -342,13 +389,17 @@ func buildPromptWithAttachments(
     //    they typed in the input box; the LLM maps it back to the
     //    attachment via the matching `id="N"` in the `<attachments>`
     //    block below.
-    for clip in store.clipboardImages {
+    for clip in snapshot.clipboardImages {
         if modelSupportsImages {
-            images.append(ImageContent(
-                data: clip.data.base64EncodedString(),
-                mimeType: clip.mimeType
+            let normalized = try ImageNormalizer.normalize(clip.data)
+            images.append(normalized.content)
+            attachBlocks.append(imageAttachmentBlock(
+                attributes: [
+                    "source=\"clipboard\"",
+                    "id=\"\(clip.id)\"",
+                ],
+                normalized: normalized
             ))
-            attachBlocks.append("<image source=\"clipboard\" id=\"\(clip.id)\" mime=\"\(clip.mimeType)\" bytes=\"\(clip.data.count)\" />")
             counts.image += 1
         } else {
             attachBlocks.append("<image source=\"clipboard\" id=\"\(clip.id)\" mime=\"\(clip.mimeType)\" note=\"skipped: this model does not accept image input\" />")
@@ -363,11 +414,12 @@ func buildPromptWithAttachments(
         switch r {
         case .image(let path, let data, let mime):
             if modelSupportsImages {
-                images.append(ImageContent(
-                    data: data.base64EncodedString(),
-                    mimeType: mime
+                let normalized = try ImageNormalizer.normalize(data)
+                images.append(normalized.content)
+                attachBlocks.append(imageAttachmentBlock(
+                    attributes: ["path=\"\(xmlEscape(path))\""],
+                    normalized: normalized
                 ))
-                attachBlocks.append("<image path=\"\(xmlEscape(path))\" mime=\"\(mime)\" />")
                 counts.image += 1
             } else {
                 // Model can't see images. Preserve the reference + size
@@ -414,8 +466,9 @@ func buildPromptWithAttachments(
     if counts.folder > 0 { parts.append("\(counts.folder) folder\(counts.folder == 1 ? "" : "s")") }
     if counts.missing > 0 { parts.append("\(counts.missing) missing") }
     if counts.skippedImage > 0 { parts.append("\(counts.skippedImage) image skipped (text-only model)") }
-    if store.pastedTexts.count > 0 {
-        parts.append("\(store.pastedTexts.count) pasted text\(store.pastedTexts.count == 1 ? "" : "s")")
+    if !snapshot.pastedTextIDs.isEmpty {
+        let count = snapshot.pastedTextIDs.count
+        parts.append("\(count) pasted text\(count == 1 ? "" : "s")")
     }
     let summary = parts.isEmpty ? nil : "attached: " + parts.joined(separator: ", ")
 
@@ -433,7 +486,30 @@ func buildPromptWithAttachments(
     }
     let issues = issueParts.isEmpty ? nil : issueParts.joined(separator: ", ")
 
-    return BuiltPrompt(text: out, images: images, summary: summary, issues: issues)
+    return BuiltPrompt(
+        text: out,
+        recallText: expanded,
+        images: images,
+        summary: summary,
+        issues: issues
+    )
+}
+
+private func imageAttachmentBlock(
+    attributes: [String],
+    normalized: NormalizedImage
+) -> String {
+    let imageAttributes = attributes + [
+        "mime=\"\(normalized.content.mimeType)\"",
+        "bytes=\"\(normalized.byteCount)\"",
+        "original_dimensions=\"\(normalized.originalWidth)x\(normalized.originalHeight)\"",
+        "displayed_dimensions=\"\(normalized.width)x\(normalized.height)\"",
+    ]
+    let openingTag = "<image \(imageAttributes.joined(separator: " "))"
+    guard let note = normalized.coordinateMappingNote else {
+        return openingTag + " />"
+    }
+    return "\(openingTag)>\n\(note)\n</image>"
 }
 
 private func xmlEscape(_ s: String) -> String {

--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -36,7 +36,7 @@ func registerBuiltinSlashCommands(_ registry: SlashCommandRegistry) {
     ))
     registry.register(SlashCommand(
         name: "shake",
-        description: "Trim heavy tool output from context (no LLM)",
+        description: "Trim heavy tool output or remove images from the session (no LLM)",
         handler: handleShakeCommand
     ))
     registry.register(SlashCommand(
@@ -920,55 +920,100 @@ private func handleContextCommand(_ ctx: SlashContext, _ args: String) async {
 
 // MARK: - /shake
 
-/// `/shake` — a non-LLM context trim. Unlike `/compact` (which spends a
-/// model round-trip to summarize the transcript), `/shake` just walks the
-/// live conversation and collapses oversized tool-result output into a short
-/// placeholder, reclaiming context window with no LLM call. Idempotent:
-/// re-running skips results already collapsed.
-///
-/// LIMITATION: this trims the IN-MEMORY transcript only — it is not
-/// re-persisted to the session file, so a later `/resume` reloads the
-/// original tool output. That's acceptable for a "reclaim live context"
-/// tool; the saving lands on the next request's prompt, not on disk.
-///
-/// The before→after token figures come from `currentUsage`, which reflects
-/// the most recent *recorded* request, so the window number only moves on the
-/// next turn after the trimmed messages are actually sent. The reclaimed-chars
-/// line is the immediate, concrete win.
+/// `/shake` mechanically trims context without an LLM call. Bare `/shake`
+/// (or `/shake elide`) collapses oversized tool results; `/shake images`
+/// permanently removes image blocks. Both modes rewrite the persisted JSONL,
+/// replace the live agent context with the same pure transformation, and close
+/// provider-side session chains so the next request replays the new history.
 @MainActor
 private func handleShakeCommand(_ ctx: SlashContext, _ args: String) async {
-    let before = AgentContextCompactor.currentUsage(
-        messages: ctx.agent.state.messages,
-        model: ctx.agent.state.model
-    )
-    let beforeChars = toolResultTextChars(ctx.agent.state.messages)
-
-    let result = AgentContextCompactor.shakeToolOutputs(ctx.agent.state.messages)
-    if result.elidedCount == 0 {
-        ctx.notify(Style.dimmed("  /shake: nothing to trim"))
+    let mode: ShakeMode
+    switch args.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "", "elide":
+        mode = .elide
+    case "images":
+        mode = .images
+    default:
+        ctx.notify(Style.dimmed("  usage: /shake [elide|images]"))
         return
     }
 
-    ctx.agent.state.messages = result.messages
-    ctx.refreshTranscript()
+    let shakeAgent = ctx.agent
+    ctx.setShaking(true)
+    defer { ctx.setShaking(false) }
+    do {
+        try await shakeAgent.withMaintenance { @MainActor in
+            let originalMessages = shakeAgent.state.messages
+            let rewrittenMessages: [Message]
+            let liveChangedCount: Int
 
-    let after = AgentContextCompactor.currentUsage(
-        messages: ctx.agent.state.messages,
-        model: ctx.agent.state.model
-    )
-    let afterChars = toolResultTextChars(result.messages)
-    let reclaimed = max(0, beforeChars - afterChars)
+            switch mode {
+            case .elide:
+                let rewrite = AgentContextCompactor.shakeToolOutputs(originalMessages)
+                rewrittenMessages = rewrite.messages
+                liveChangedCount = rewrite.elidedCount
+            case .images:
+                let rewrite = AgentContextCompactor.removingImages(from: originalMessages)
+                rewrittenMessages = rewrite.messages
+                liveChangedCount = rewrite.removedCount
+            }
 
-    let n = result.elidedCount
-    var lines = [
-        Style.dimmed("  /shake: elided \(n) heavy tool \(n == 1 ? "result" : "results") (no LLM)"),
-        Style.dimmed("    reclaimed ~\(reclaimed) chars of tool output"),
-    ]
-    if before.window > 0 {
-        lines.append(Style.dimmed("    context: \(before.tokens) → \(after.tokens) tokens of \(before.window) (refreshes next turn)"))
+            guard let persistedChangedCount = await ctx.persistShake(mode) else {
+                ctx.notify(Style.error("  /shake: failed to rewrite the session"))
+                return
+            }
+            let changedCount = liveChangedCount > 0
+                ? liveChangedCount
+                : persistedChangedCount
+            guard changedCount > 0 else {
+                let message = mode == .images
+                    ? "  /shake images: no images found"
+                    : "  /shake: nothing to trim"
+                ctx.notify(Style.dimmed(message))
+                return
+            }
+
+            shakeAgent.state.messages = rewrittenMessages
+            await shakeAgent.closeSession()
+            ctx.refreshTranscript()
+
+            switch mode {
+            case .images:
+                ctx.notify(Style.dimmed(
+                    "  /shake images: dropped \(changedCount) image\(changedCount == 1 ? "" : "s") from this session"
+                ))
+            case .elide:
+                let before = AgentContextCompactor.currentUsage(
+                    messages: originalMessages,
+                    model: shakeAgent.state.model
+                )
+                let after = AgentContextCompactor.currentUsage(
+                    messages: rewrittenMessages,
+                    model: shakeAgent.state.model
+                )
+                let reclaimed = max(
+                    0,
+                    toolResultTextChars(originalMessages)
+                        - toolResultTextChars(rewrittenMessages)
+                )
+                var lines = [
+                    Style.dimmed("  /shake: elided \(changedCount) heavy tool \(changedCount == 1 ? "result" : "results") (no LLM)"),
+                    Style.dimmed("    reclaimed ~\(reclaimed) chars of tool output"),
+                ]
+                if before.window > 0 {
+                    lines.append(Style.dimmed(
+                        "    context: \(before.tokens) → \(after.tokens) tokens of \(before.window)"
+                    ))
+                }
+                ctx.notifyBlock(lines)
+            }
+        }
+    } catch AgentError.alreadyRunning {
+        ctx.notify(Style.error("  /shake: agent is busy; stop it first (Esc)"))
+    } catch {
+        ctx.notify(Style.error("  /shake: \(error)"))
     }
-    lines.append(Style.dimmed("    (in-memory only — /resume reloads the original output)"))
-    ctx.notifyBlock(lines)
+    shakeAgent.resumeQueuedWork()
 }
 
 /// Total character count of every `.text` block across all tool-result

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -219,6 +219,7 @@ func runCodingTUIInternal(
     let frameStatus = FrameStatusState()
 
     let updateFrameStatus: @MainActor @Sendable () -> Void = {
+        frameStatus.reconcileMode(messageCount: agent.state.messages.count)
         let capacityHint = formatCapacityHint(
             usage: AgentContextCompactor.currentUsage(
                 messages: agent.state.messages,
@@ -250,6 +251,8 @@ func runCodingTUIInternal(
         frame.isBusy = agent.state.isStreaming
             || frameStatus.isAutoCompacting
             || frameStatus.isManualCompacting
+            || frameStatus.isShaking
+            || frameStatus.isPreparingAttachments
             || frameStatus.isRewinding
             || frameStatus.isSessionSwitching
         // Keep the re-renderable welcome header in sync with live login/model
@@ -619,19 +622,17 @@ func runCodingTUIInternal(
     }
     agentBox.eventUnsubscribe = subscribeToAgentEvents(agent)
 
+    let setSessionSwitching: @MainActor @Sendable (Bool) -> Void = { active in
+        frameStatus.isSessionSwitching = active
+        updateFrameStatus()
+        runner.tui.requestRender()
+    }
+
     /// Replace every session-scoped runtime component as one idle-only
     /// transaction. In particular, tools and the background delivery consumer
     /// are rebuilt with `newSessionId`; none retain the outgoing task namespace.
     let replaceSessionAgent: @MainActor @Sendable (String, [Message]) async -> Agent = {
         newSessionId, messages in
-        frameStatus.isSessionSwitching = true
-        updateFrameStatus()
-        runner.tui.requestRender()
-        defer {
-            frameStatus.isSessionSwitching = false
-            updateFrameStatus()
-            runner.tui.requestRender()
-        }
         let outgoingCodingAgent = agentBox.codingAgent
         let outgoing = outgoingCodingAgent.agent
         let outgoingSessionId = outgoing.sessionId
@@ -770,6 +771,7 @@ func runCodingTUIInternal(
     registerSessionSlashCommands(slashRegistry, ctx: SessionCommandContext(
         agentProvider: { agent },
         replaceSessionAgent: replaceSessionAgent,
+        setSessionSwitching: setSessionSwitching,
         modal: modal,
         frame: frame,
         cwd: cwd,
@@ -838,6 +840,14 @@ func runCodingTUIInternal(
                 reason: .compact
             )
         },
+        persistShake: { mode in
+            switch mode {
+            case .elide:
+                return await recorderBox.recorder.rewriteShakenToolOutputs()
+            case .images:
+                return await recorderBox.recorder.rewriteRemovingImages()
+            }
+        },
         setSessionTitle: { title in
             await recorderBox.recorder.recordTitle(title)
         },
@@ -865,6 +875,12 @@ func runCodingTUIInternal(
             frameStatus.mode = active ? .compacting(messageCount: agent.state.messages.count) : .idle
             updateFrameStatus()
             runner.tui.requestRender()
+        },
+        setShaking: { active in
+            frameStatus.isShaking = active
+            frameStatus.mode = active ? .shaking : .idle
+            updateFrameStatus()
+            runner.tui.requestRender()
         }
     )
 
@@ -874,12 +890,8 @@ func runCodingTUIInternal(
     //   1. modal open → forward to modal's confirm handler.
     //   2. input starts with `/` → slash command dispatch.
     //   3. LLM prompt while the agent is idle → submit.
-    //   4. LLM prompt while the agent is streaming → steer as a user
-    //      message so it runs at the next turn boundary. We do NOT
-    //      drop the typed text: starting a second agent.prompt while
-    //      the first is streaming would throw `alreadyRunning` and
-    //      blow the input away. Steering lets the user queue a
-    //      follow-up without racing the current turn.
+    //   4. LLM prompt while the agent is streaming → prepare its
+    //      attachments off-main, then steer it at the next turn boundary.
     runner.bind(.init("enter", shift: false)) { _ in
         Task { @MainActor in
             if modal.isOpen {
@@ -895,9 +907,15 @@ func runCodingTUIInternal(
             guard !text.isEmpty else { return }
 
             let parsed = SlashInput.parse(text)
+            guard !frameStatus.isPreparingAttachments else { return }
+            if case .prompt = parsed,
+               frameStatus.isSessionSwitching || frameStatus.isRewinding {
+                return
+            }
             let busy = agent.state.isStreaming
                 || frameStatus.isAutoCompacting
                 || frameStatus.isManualCompacting
+                || frameStatus.isShaking
                 || frameStatus.isRewinding
                 || frameStatus.isSessionSwitching
                 || retry.trackedActive
@@ -917,72 +935,23 @@ func runCodingTUIInternal(
                 return
             }
 
-            // Slash commands are idle-only. If the agent is mid-turn
-            // we can't reliably run them (some mutate agent state, all
-            // would need to interleave output with streaming). Keeping
-            // the gate simple means we never need a floating
-            // "notification block" to surface their output — they
-            // always append to history on a quiet moment.
-            if case .command = parsed, busy {
-                runner.tui.commit([
-                    "",
-                    Style.error("  slash commands run only when the agent is idle — stop it first (Esc) or wait"),
-                    "",
-                ])
-                updateFrameStatus()
-                runner.tui.requestRender()
-                return
-            }
-
-            // LLM prompt while the agent is busy: steer as a queued
-            // user message so it runs at the next turn boundary. We
-            // do NOT drop the typed text — starting a second
-            // agent.prompt while the first is streaming would throw
-            // `alreadyRunning`.
-            if case .prompt = parsed, busy {
-                let built = buildPromptWithAttachments(
-                    text: text,
-                    store: attachments,
-                    cwd: cwd,
-                    modelSupportsImages: agent.state.model.input.contains(.image)
-                )
-                var blocks: [UserBlock] = [.text(TextContent(text: built.text))]
-                for img in built.images { blocks.append(.image(img)) }
-                agent.steer(.user(UserMessage(content: blocks)))
-                // A steered follow-up is still a user-initiated turn eligible for
-                // /retry. Mark it tracked, but do NOT record a retry target here —
-                // it's derived at arm time from the message actually executing, so
-                // an Esc-abort resubmits the real in-flight prompt (never the
-                // queued-but-undrained steer).
-                retry.trackedActive = true
-                goalStore.resetAutoContinue()
-                // Recall ring gets the paste bodies expanded (omp semantics):
-                // after clear() the placeholder would be a dead reference.
-                frame.input.addToHistory(attachments.expandPastedTextPlaceholders(in: text))
-                attachments.clear()
-                frame.input.value = ""
-                // No scrollback notice: the queued prompt now shows live in
-                // the pending list above the input box (updateFrameStatus
-                // syncs frame.queuedPrompts), where it can be edited (Alt+↑)
-                // or dropped (/queue clear) until the agent drains it.
-                // Surface only attach problems.
-                if let issues = built.issues {
-                    runner.tui.commit([
-                        "",
-                        Style.error("  attach: " + issues),
-                    ])
-                }
-                updateFrameStatus()
-                runner.tui.requestRender()
-                return
-            }
-
-            frame.input.value = ""
-            updateFrameStatus()
-            runner.tui.requestRender()
-
             switch parsed {
             case .command(let name, let args):
+                // Commands mutate shared session state and therefore remain
+                // idle-only.
+                guard !busy else {
+                    runner.tui.commit([
+                        "",
+                        Style.error("  slash commands run only when the agent is idle — stop it first (Esc) or wait"),
+                        "",
+                    ])
+                    updateFrameStatus()
+                    runner.tui.requestRender()
+                    return
+                }
+                frame.input.value = ""
+                updateFrameStatus()
+                runner.tui.requestRender()
                 if let cmd = slashRegistry.find(name) {
                     await cmd.handler(slashContext, args)
                     runner.tui.requestRender()
@@ -996,20 +965,57 @@ func runCodingTUIInternal(
                     runner.tui.requestRender()
                 }
             case .prompt:
-                // Recall ring: store the submission with paste bodies expanded
-                // (omp semantics) so Up/Down brings back the original text —
-                // the `[pasted-text #N]` placeholder dies with attachments.clear().
-                frame.input.addToHistory(attachments.expandPastedTextPlaceholders(in: text))
-                // Rebuild with attachments — the raw `text` may carry
-                // `@path` tokens and `[pasted-text #N]` placeholders
-                // from earlier paste events.
-                let built = buildPromptWithAttachments(
-                    text: text,
-                    store: attachments,
-                    cwd: cwd,
-                    modelSupportsImages: agent.state.model.input.contains(.image)
-                )
-                attachments.clear()
+                // Release the editor immediately so the user can start the
+                // next draft while image decoding and encoding run off-main.
+                let submittedAgent = agent
+                let submittedGeneration = agentBox.generation
+                let attachmentSnapshot = attachments.promptSnapshot(for: text)
+                frame.input.value = ""
+                frameStatus.isPreparingAttachments = true
+                frameStatus.mode = .preparingAttachments
+                updateFrameStatus()
+                runner.tui.requestRender()
+
+                let built: BuiltPrompt
+                do {
+                    built = try await buildPromptWithAttachments(
+                        snapshot: attachmentSnapshot,
+                        cwd: cwd,
+                        modelSupportsImages: submittedAgent.state.model.input.contains(.image)
+                    )
+                } catch {
+                    frameStatus.isPreparingAttachments = false
+                    if case .preparingAttachments = frameStatus.mode {
+                        frameStatus.mode = .idle
+                    }
+                    guard agentBox.isCurrent(
+                        agent: submittedAgent,
+                        generation: submittedGeneration
+                    ) else { return }
+                    let nextDraft = frame.input.value
+                    frame.input.value = nextDraft.isEmpty
+                        ? text
+                        : text + "\n" + nextDraft
+                    frame.input.moveEnd()
+                    runner.tui.commit([
+                        "",
+                        Style.error("  attach: \(error.localizedDescription)"),
+                        "",
+                    ])
+                    updateFrameStatus()
+                    runner.tui.requestRender()
+                    return
+                }
+                frameStatus.isPreparingAttachments = false
+                if case .preparingAttachments = frameStatus.mode {
+                    frameStatus.mode = .idle
+                }
+                guard agentBox.isCurrent(
+                    agent: submittedAgent,
+                    generation: submittedGeneration
+                ) else { return }
+                attachments.consume(attachmentSnapshot)
+                frame.input.addToHistory(built.recallText)
                 if let issues = built.issues {
                     runner.tui.commit([
                         "",
@@ -1019,7 +1025,26 @@ func runCodingTUIInternal(
                     updateFrameStatus()
                     runner.tui.requestRender()
                 }
-                submitBuiltPrompt(built.text, built.images)
+
+                let shouldSteer = submittedAgent.state.isStreaming
+                    || frameStatus.isAutoCompacting
+                    || frameStatus.isManualCompacting
+                    || frameStatus.isShaking
+                    || frameStatus.isRewinding
+                    || frameStatus.isSessionSwitching
+                    || retry.trackedActive
+                if shouldSteer {
+                    var blocks: [UserBlock] = [.text(TextContent(text: built.text))]
+                    blocks.append(contentsOf: built.images.map(UserBlock.image))
+                    submittedAgent.steer(.user(UserMessage(content: blocks)))
+                    submittedAgent.resumeQueuedWork()
+                    retry.trackedActive = true
+                    goalStore.resetAutoContinue()
+                    updateFrameStatus()
+                    runner.tui.requestRender()
+                } else {
+                    submitBuiltPrompt(built.text, built.images)
+                }
             }
         }
     }
@@ -1225,6 +1250,8 @@ func runCodingTUIInternal(
                   !agent.state.isStreaming,
                   !frameStatus.isAutoCompacting,
                   !frameStatus.isManualCompacting,
+                  !frameStatus.isShaking,
+                  !frameStatus.isPreparingAttachments,
                   !frameStatus.isRewinding,
                   !frameStatus.isSessionSwitching
             else {
@@ -1357,8 +1384,29 @@ private final class FrameStatusState {
     var runningBackgroundTasks = 0
     var isAutoCompacting = false
     var isManualCompacting = false
+    var isShaking = false
+    var isPreparingAttachments = false
     var isRewinding = false
     var isSessionSwitching = false
+
+    func reconcileMode(messageCount: Int) {
+        switch mode {
+        case .aborting, .retrying:
+            return
+        default:
+            break
+        }
+
+        if isPreparingAttachments {
+            mode = .preparingAttachments
+        } else if isShaking {
+            mode = .shaking
+        } else if isAutoCompacting || isManualCompacting {
+            mode = .compacting(messageCount: messageCount)
+        } else {
+            mode = .idle
+        }
+    }
 }
 
 /// Tracks the last idle no-op Esc press so a second press within `window`
@@ -1476,6 +1524,13 @@ final class TurnRetryState {
     /// can't arm `/retry` with a stale internal prompt. Consumed (reset to
     /// false) at every `.agentEnd` and on Esc-abort.
     var trackedActive = false
+
+    func clear() {
+        lastText = nil
+        lastImages.removeAll(keepingCapacity: false)
+        failed = false
+        trackedActive = false
+    }
 }
 
 /// Concatenated text of a queued user message's text blocks (image blocks
@@ -1506,6 +1561,8 @@ private enum CodingFrameMode {
     case idle
     case aborting
     case compacting(messageCount: Int)
+    case shaking
+    case preparingAttachments
     case retrying(attempt: Int, until: Date, reason: String)
 
     /// True whenever the state line is showing a spinner (anything but plain
@@ -1610,7 +1667,7 @@ func promptPreservingContention(
 
 /// Reset the per-session transient state that must not survive a session swap
 /// (`/new` or `/resume`): drain the steering queue, clear the `/retry` record,
-/// drop pending attachments, and forget the Alt+↑ dequeue cursor. Shared by both
+/// drop outgoing attachments, and forget the Alt+↑ dequeue cursor. Shared by both
 /// session-swap paths so neither leaks stale state into the incoming session
 /// (e.g. a `failed`/`lastText` record that `/retry` would resubmit into the
 /// wrong transcript). Does NOT touch `agent.state.messages` or the input
@@ -1620,21 +1677,25 @@ func resetSessionTransientState(
     agent: Agent,
     retry: TurnRetryState,
     attachments: AttachmentStore,
-    dequeueCycle: DequeueCycleState
+    dequeueCycle: DequeueCycleState,
+    discardingAttachments snapshot: AttachmentPromptSnapshot? = nil
 ) {
     agent.clearSteeringQueue()
-    retry.failed = false
-    retry.lastText = nil
-    retry.lastImages = []
-    retry.trackedActive = false
-    attachments.clear()
+    retry.clear()
+    if let snapshot {
+        attachments.consume(snapshot)
+    } else {
+        attachments.clear()
+    }
     dequeueCycle.last = nil
 }
 
 /// Start a fresh, empty session in place: repoint persistence at a brand-new
 /// session file, clear the live agent context + steering queue, reset retry and
-/// attachment state, and commit a labeled separator to scrollback. Extracted
-/// from the `/new` handler so the reset is unit-testable.
+/// attachment state, and commit a labeled separator to scrollback. A draft
+/// composed while the async handoff is running belongs to the new session and
+/// is preserved. This helper is extracted from the `/new` handler so the reset
+/// is unit-testable.
 @MainActor
 func performNewSession(
     newId: String = UUID().uuidString,
@@ -1653,6 +1714,9 @@ func performNewSession(
     updateStatus: () -> Void,
     requestRender: () -> Void
 ) async {
+    let inputBeforeSwitch = frame.input.value
+    let attachmentsBeforeSwitch = attachments.promptSnapshot(for: inputBeforeSwitch)
+
     // Stop the outgoing recorder before the runtime replacement so a late
     // callback cannot append to the new session file.
     recorderBox.unsubscribe()
@@ -1685,9 +1749,12 @@ func performNewSession(
         agent: sessionAgent,
         retry: retry,
         attachments: attachments,
-        dequeueCycle: dequeueCycle
+        dequeueCycle: dequeueCycle,
+        discardingAttachments: attachmentsBeforeSwitch
     )
-    frame.input.value = ""
+    if frame.input.value == inputBeforeSwitch {
+        frame.input.value = ""
+    }
 
     commit([
         "",
@@ -1798,6 +1865,10 @@ private func codingFrameStateLine(
         parts.append(Theme.paint("\(spinner) compacting \(count)", Theme.warn, bold: true))
         parts.append(Theme.faintText("new prompts queue"))
         parts.append(Theme.faintText("Esc to cancel"))
+    case .shaking:
+        parts.append(Theme.paint("\(spinner) shaking context", Theme.warn, bold: true))
+    case .preparingAttachments:
+        parts.append(Theme.paint("\(spinner) preparing attachments", Theme.accent, bold: true))
     case .aborting:
         parts.append(Theme.paint("\(spinner) aborting", Theme.warn, bold: true))
         parts.append(Theme.faintText("Ctrl-C to force quit"))

--- a/Sources/KWWKCli/SessionSlashCommands.swift
+++ b/Sources/KWWKCli/SessionSlashCommands.swift
@@ -13,6 +13,9 @@ struct SessionCommandContext {
     let agentProvider: @MainActor @Sendable () -> Agent
     /// Replace the complete session-scoped runtime and return the new Agent.
     let replaceSessionAgent: @MainActor @Sendable (String, [Message]) async -> Agent
+    /// Hold the TUI's session-switch busy gate for an entire `/new` or
+    /// `/resume` transaction, including persistence rewiring after Agent swap.
+    let setSessionSwitching: @MainActor @Sendable (Bool) -> Void
     var agent: Agent { agentProvider() }
     let modal: ModalHost
     let frame: CodingFrame
@@ -75,6 +78,7 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
     let kickGoalContinuation = ctx.kickGoalContinuation
     let submitBuiltPrompt = ctx.submitBuiltPrompt
     let openRewindSelector = ctx.openRewindSelector
+    let setSessionSwitching = ctx.setSessionSwitching
 
     // `/resume` — restore a previous session into the running TUI. Opens an
     // arrow-key picker; on confirm it repoints persistence at the chosen
@@ -84,12 +88,15 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
         name: "resume",
         description: "Restore a previous session",
         handler: { _, _ in
+            setSessionSwitching(true)
+            let outgoingAttachments = attachments.promptSnapshot(for: frame.input.value)
             let sessions = await sessionStore.list()
             let picker = SessionResumeModal(
                 sessions: sessions,
                 currentSessionId: recorderBox.sessionId,
                 onSelect: { info in
                     Task { @MainActor in
+                        defer { setSessionSwitching(false) }
                         // `info.id` comes from the on-disk listing, so its
                         // format is always valid; `try?` only guards the
                         // (unreachable here) invalid-id throw.
@@ -127,7 +134,8 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
                             agent: restoredAgent,
                             retry: retry,
                             attachments: attachments,
-                            dequeueCycle: dequeueCycle
+                            dequeueCycle: dequeueCycle,
+                            discardingAttachments: outgoingAttachments
                         )
                         // Close first: the modal's restore hook drains any
                         // commits queued behind it, and the replace below must
@@ -151,7 +159,10 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
                         requestRender()
                     }
                 },
-                onCancel: { modal.close() }
+                onCancel: {
+                    modal.close()
+                    setSessionSwitching(false)
+                }
             )
             modal.open(picker)
         }
@@ -165,6 +176,8 @@ func registerSessionSlashCommands(_ registry: SlashCommandRegistry, ctx: Session
         description: "Start a fresh session",
         aliases: ["clear"],
         handler: { _, _ in
+            setSessionSwitching(true)
+            defer { setSessionSwitching(false) }
             // A fresh session starts with no goal — drop any active one (and its
             // <goal_context>) before minting the new id so it can't carry over.
             goalStore.stop()

--- a/Sources/KWWKCli/SlashCommand.swift
+++ b/Sources/KWWKCli/SlashCommand.swift
@@ -32,6 +32,11 @@ enum SlashInput: Equatable {
     }
 }
 
+enum ShakeMode: Sendable, Equatable {
+    case elide
+    case images
+}
+
 /// Ambient context a slash-command handler receives: the live Agent (for
 /// reading/updating model, messages, etc.), the modal host (to open
 /// selectors), the background-task manager + sessionId (so commands like
@@ -69,6 +74,9 @@ final class SlashContext {
     /// Persist a successful manual compaction. Automatic compaction uses
     /// AgentEvent subscriptions; slash commands need an explicit hook.
     let recordCompaction: @MainActor (_ messagesCompacted: Int) async -> Void
+    /// Persist a `/shake` transcript rewrite through the live recorder's
+    /// serialized operation queue. Nil means the rewrite failed.
+    let persistShake: @MainActor (_ mode: ShakeMode) async -> Int?
     /// Persist a user-set session title to the live session file. Backed by
     /// the SessionRecorder in the TUI; a no-op in headless/test contexts.
     let setSessionTitle: @MainActor (_ title: String) async -> Void
@@ -95,6 +103,8 @@ final class SlashContext {
     /// starting a competing turn before the revision-checked projection is
     /// committed. A no-op in headless / test contexts.
     let setCompacting: @MainActor (_ active: Bool) -> Void
+    /// Mark the TUI busy while `/shake` owns and rewrites the session.
+    let setShaking: @MainActor (_ active: Bool) -> Void
 
     init(
         agent: Agent,
@@ -105,12 +115,14 @@ final class SlashContext {
         commitScrollback: @MainActor @escaping ((Int) -> [String]) -> Void,
         refreshTranscript: @MainActor @escaping () -> Void,
         recordCompaction: @MainActor @escaping (_ messagesCompacted: Int) async -> Void = { _ in },
+        persistShake: @MainActor @escaping (_ mode: ShakeMode) async -> Int? = { _ in nil },
         setSessionTitle: @MainActor @escaping (_ title: String) async -> Void = { _ in },
         sessionProviders: SessionProviders = SessionProviders(),
         authResolvers: SessionAuthResolvers? = nil,
         context1m: Bool = false,
         withSuspendedTUI: @MainActor @escaping (_ body: @escaping @MainActor () async -> Void) async -> Void = { body in await body() },
-        setCompacting: @MainActor @escaping (_ active: Bool) -> Void = { _ in }
+        setCompacting: @MainActor @escaping (_ active: Bool) -> Void = { _ in },
+        setShaking: @MainActor @escaping (_ active: Bool) -> Void = { _ in }
     ) {
         self.agentProvider = { agent }
         self.modal = modal
@@ -120,12 +132,14 @@ final class SlashContext {
         self.commitScrollback = commitScrollback
         self.refreshTranscript = refreshTranscript
         self.recordCompaction = recordCompaction
+        self.persistShake = persistShake
         self.setSessionTitle = setSessionTitle
         self.sessionProviders = sessionProviders
         self.authResolvers = authResolvers
         self.context1m = context1m
         self.withSuspendedTUI = withSuspendedTUI
         self.setCompacting = setCompacting
+        self.setShaking = setShaking
     }
 
     /// Runtime-backed variant used by the interactive TUI, whose `/new` and
@@ -139,12 +153,14 @@ final class SlashContext {
         commitScrollback: @MainActor @escaping ((Int) -> [String]) -> Void,
         refreshTranscript: @MainActor @escaping () -> Void,
         recordCompaction: @MainActor @escaping (_ messagesCompacted: Int) async -> Void = { _ in },
+        persistShake: @MainActor @escaping (_ mode: ShakeMode) async -> Int? = { _ in nil },
         setSessionTitle: @MainActor @escaping (_ title: String) async -> Void = { _ in },
         sessionProviders: SessionProviders = SessionProviders(),
         authResolvers: SessionAuthResolvers? = nil,
         context1m: Bool = false,
         withSuspendedTUI: @MainActor @escaping (_ body: @escaping @MainActor () async -> Void) async -> Void = { body in await body() },
-        setCompacting: @MainActor @escaping (_ active: Bool) -> Void = { _ in }
+        setCompacting: @MainActor @escaping (_ active: Bool) -> Void = { _ in },
+        setShaking: @MainActor @escaping (_ active: Bool) -> Void = { _ in }
     ) {
         self.agentProvider = agentProvider
         self.modal = modal
@@ -154,12 +170,14 @@ final class SlashContext {
         self.commitScrollback = commitScrollback
         self.refreshTranscript = refreshTranscript
         self.recordCompaction = recordCompaction
+        self.persistShake = persistShake
         self.setSessionTitle = setSessionTitle
         self.sessionProviders = sessionProviders
         self.authResolvers = authResolvers
         self.context1m = context1m
         self.withSuspendedTUI = withSuspendedTUI
         self.setCompacting = setCompacting
+        self.setShaking = setShaking
     }
 
     /// Single-line convenience: one-off status messages (`/model switched

--- a/Tests/KWWKAITests/ImageNormalizerTests.swift
+++ b/Tests/KWWKAITests/ImageNormalizerTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+
+@Suite("Image normalization")
+struct ImageNormalizerTests {
+    @Test("upscales undersized images to the 200px floor")
+    func minimumDimension() throws {
+        let result = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+
+        #expect(result.originalWidth == 1)
+        #expect(result.originalHeight == 1)
+        #expect(result.width == 200)
+        #expect(result.height == 200)
+        #expect(result.wasReencoded)
+        #expect(result.byteCount <= 500 * 1024)
+        #expect(result.coordinateMappingNote?.contains("original 1x1, displayed at 200x200") == true)
+    }
+
+    @Test("caps the long edge and records coordinate mapping")
+    func maximumDimension() throws {
+        let options = ImageNormalizationOptions(
+            maximumWidth: 8,
+            maximumHeight: 8,
+            minimumDimension: 1,
+            maximumBytes: 500 * 1024,
+            initialQuality: 80,
+            qualitySteps: [70, 60, 50, 40],
+            scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
+            minimumFallbackDimension: 1,
+            excludeWebP: false
+        )
+        let result = try ImageNormalizer.normalize(sixteenByOnePNG, options: options)
+
+        #expect(ImageNormalizationOptions.default().maximumWidth == 1568)
+        #expect(ImageNormalizationOptions.default().maximumHeight == 1568)
+        #expect(result.originalWidth == 16)
+        #expect(result.originalHeight == 1)
+        #expect(result.width == 8)
+        #expect(result.height == 1)
+        #expect(result.byteCount <= 500 * 1024)
+        #expect(result.coordinateMappingNote?.contains("Multiply x coordinates") == true)
+        #expect(result.coordinateMappingNote?.contains("y coordinates") == true)
+    }
+
+    @Test("keeps normalized images unchanged on the comfortable-size fast path")
+    func fastPath() throws {
+        let first = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+        let firstBytes = try #require(Data(base64Encoded: first.content.data))
+        let second = try ImageNormalizer.normalize(firstBytes, excludingWebP: false)
+
+        #expect(!second.wasReencoded)
+        #expect(second.content == first.content)
+        #expect(second.byteCount == first.byteCount)
+        #expect(second.width == 200)
+        #expect(second.height == 200)
+    }
+
+    @Test("chooses the smallest of PNG, JPEG, and WebP")
+    func choosesSmallestFormat() throws {
+        let result = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+
+        #expect(result.content.mimeType == "image/webp")
+        #expect(Data(base64Encoded: result.content.data)?.starts(with: Array("RIFF".utf8)) == true)
+    }
+
+    @Test("can exclude WebP and re-encodes WebP sources on the fast path")
+    func excludesWebP() throws {
+        let webP = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+        let webPBytes = try #require(Data(base64Encoded: webP.content.data))
+
+        let result = try ImageNormalizer.normalize(webPBytes, excludingWebP: true)
+
+        #expect(webP.content.mimeType == "image/webp")
+        #expect(result.content.mimeType != "image/webp")
+        #expect(result.wasReencoded)
+        #expect(result.width == 200)
+        #expect(result.height == 200)
+    }
+
+    @Test("KWWK_NO_WEBP accepts only 1 or true")
+    func webPEnvironmentFlag() {
+        #expect(ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "1"]))
+        #expect(ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "TRUE"]))
+        #expect(!ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "0"]))
+        #expect(!ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": ""]))
+        #expect(!ImageNormalizer.excludesWebP(in: [:]))
+    }
+
+    @Test("walks the quality and scale ladders when the target cannot be met")
+    func qualityAndScaleLadders() throws {
+        let options = ImageNormalizationOptions(
+            maximumWidth: 1568,
+            maximumHeight: 1568,
+            minimumDimension: 200,
+            maximumBytes: 1,
+            initialQuality: 80,
+            qualitySteps: [70, 60, 50, 40],
+            scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
+            minimumFallbackDimension: 100,
+            excludeWebP: false
+        )
+
+        let result = try ImageNormalizer.normalize(redPixelPNG, options: options)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+        #expect(result.byteCount > options.maximumBytes)
+    }
+
+    @Test("applies every EXIF orientation to RGBA pixels")
+    func exifPixelOrientations() {
+        let source = RasterImage(
+            width: 2,
+            height: 3,
+            rgba: [
+                rgba(1), rgba(2),
+                rgba(3), rgba(4),
+                rgba(5), rgba(6),
+            ].flatMap { $0 }
+        )
+        let expectations: [(EXIFOrientation, Int, Int, [UInt8])] = [
+            (.identity, 2, 3, [1, 2, 3, 4, 5, 6]),
+            (.mirroredHorizontally, 2, 3, [2, 1, 4, 3, 6, 5]),
+            (.rotated180, 2, 3, [6, 5, 4, 3, 2, 1]),
+            (.mirroredVertically, 2, 3, [5, 6, 3, 4, 1, 2]),
+            (.transposed, 3, 2, [1, 3, 5, 2, 4, 6]),
+            (.rotated90Clockwise, 3, 2, [5, 3, 1, 6, 4, 2]),
+            (.mirroredAcrossAntiDiagonal, 3, 2, [6, 4, 2, 5, 3, 1]),
+            (.rotated90Counterclockwise, 3, 2, [2, 4, 6, 1, 3, 5]),
+        ]
+
+        for (orientation, width, height, expectedPixels) in expectations {
+            let result = source.applying(orientation)
+            let pixels = stride(from: 0, to: result.rgba.count, by: 4).map {
+                result.rgba[$0]
+            }
+
+            #expect(result.width == width)
+            #expect(result.height == height)
+            #expect(pixels == expectedPixels)
+        }
+    }
+
+    @Test("reads every EXIF orientation value from JPEG metadata")
+    func parsesEXIFOrientations() {
+        for orientation in EXIFOrientation.allCases {
+            #expect(
+                EXIFOrientation(jpegData: jpegWithEXIFOrientation(orientation)) == orientation
+            )
+        }
+        #expect(
+            EXIFOrientation(
+                jpegData: jpegWithBigEndianEXIFOrientation(.rotated90Counterclockwise)
+            ) == .rotated90Counterclockwise
+        )
+    }
+
+    @Test("matches OMP orientation-6 landscape dimensions and bakes the transform")
+    func orientationSixLandscapeSemantics() throws {
+        let orientedJPEG = jpegWithEXIFOrientation(.rotated90Clockwise)
+
+        let result = try ImageNormalizer.normalize(orientedJPEG, excludingWebP: false)
+
+        #expect(result.originalWidth == 3)
+        #expect(result.originalHeight == 2)
+        #expect(result.width == 300)
+        #expect(result.height == 200)
+        #expect(result.wasReencoded)
+
+        let output = try #require(Data(base64Encoded: result.content.data))
+        let secondPass = try ImageNormalizer.normalize(output, excludingWebP: false)
+        #expect(secondPass.originalWidth == 300)
+        #expect(secondPass.originalHeight == 200)
+        #expect(!secondPass.wasReencoded)
+    }
+
+    @Test("rejects oversized source files before decoding")
+    func rejectsOversizedSourceBytes() {
+        var options = ImageNormalizationOptions.default()
+        options.maximumSourceBytes = redPixelPNG.count - 1
+
+        #expect(throws: ImageNormalizationError.sourceTooLarge(
+            byteCount: redPixelPNG.count,
+            maximumBytes: options.maximumSourceBytes
+        )) {
+            try ImageNormalizer.normalize(redPixelPNG, options: options)
+        }
+    }
+
+    @Test("rejects decompression bombs by header dimensions before decoding")
+    func rejectsOversizedDimensions() {
+        var options = ImageNormalizationOptions.default()
+        options.maximumSourcePixels = 8
+
+        #expect(throws: ImageNormalizationError.dimensionsTooLarge(
+            width: 16,
+            height: 1,
+            maximumPixels: 8
+        )) {
+            try ImageNormalizer.normalize(sixteenByOnePNG, options: options)
+        }
+    }
+
+    @Test("throws instead of retaining undecodable source bytes")
+    func invalidImageThrows() {
+        #expect(throws: ImageNormalizationError.unsupportedFormat) {
+            try ImageNormalizer.normalize(Data("not an image".utf8), excludingWebP: false)
+        }
+        #expect(throws: ImageNormalizationError.decodeFailed) {
+            try ImageNormalizer.normalize(
+                Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+                excludingWebP: false
+            )
+        }
+    }
+}
+
+private let redPixelPNG = Data(base64Encoded:
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+)!
+
+private let sixteenByOnePNG = Data(base64Encoded:
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAABBAMAAAAlVzNsAAAAAXNSR0IDN8dNUwAAADBQTFRF////v7//gID/QED//7+/v5+/gIC/QGC//4CAv4CAgICAQICA/0BAv2BAgIBAQJ9AHjSTbgAAACx0RVh0Q29weXJpZ2h0AKkgMjAxMywyMDE1IEpvaG4gQ3VubmluZ2hhbSBCb3dsZXJ9dHP+AAAAdGlUWHRMaWNlbnNpbmcAAQBlbgAACNctjE0OgyAQha/y4gEcu22XeBGEl0oiDIGxC0+vCV1/PytjCt4YYQrbiXpuRwqImn0qqGxwjd7Sj3Cas5aOh7N0YnJuwWtepg92s9rfIuHvhqHO2r4yjmMoF5vK08gNMzIqgtiYrSYAAAAMSURBVAjXY2RUggAAA9IA8clsiM8AAAAASUVORK5CYII="
+)!
+
+private let twoByThreeJPEG = Data(base64Encoded:
+    "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAADAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD8X6KKK/ynP+/g/9k="
+)!
+
+private func rgba(_ value: UInt8) -> [UInt8] {
+    [value, 0, 0, 255]
+}
+
+private func jpegWithEXIFOrientation(_ orientation: EXIFOrientation) -> Data {
+    let applicationSegment: [UInt8] = [
+        0xFF, 0xE1, 0x00, 0x22,
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00,
+        0x49, 0x49, 0x2A, 0x00,
+        0x08, 0x00, 0x00, 0x00,
+        0x01, 0x00,
+        0x12, 0x01, 0x03, 0x00,
+        0x01, 0x00, 0x00, 0x00,
+        UInt8(orientation.rawValue), 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ]
+    var bytes = Array(twoByThreeJPEG)
+    bytes.insert(contentsOf: applicationSegment, at: 2)
+    return Data(bytes)
+}
+
+private func jpegWithBigEndianEXIFOrientation(_ orientation: EXIFOrientation) -> Data {
+    let applicationSegment: [UInt8] = [
+        0xFF, 0xE1, 0x00, 0x22,
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00,
+        0x4D, 0x4D, 0x00, 0x2A,
+        0x00, 0x00, 0x00, 0x08,
+        0x00, 0x01,
+        0x01, 0x12, 0x00, 0x03,
+        0x00, 0x00, 0x00, 0x01,
+        0x00, UInt8(orientation.rawValue), 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ]
+    var bytes = Array(twoByThreeJPEG)
+    bytes.insert(contentsOf: applicationSegment, at: 2)
+    return Data(bytes)
+}

--- a/Tests/KWWKAITests/ProviderImageBudgetTests.swift
+++ b/Tests/KWWKAITests/ProviderImageBudgetTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+
+@Suite("Provider image budget")
+struct ProviderImageBudgetTests {
+    @Test("provider limits match OMP policy and the KWWK Codex scope")
+    func providerLimits() {
+        let expectedLimits = [
+            "anthropic": 90,
+            "amazon-bedrock": 90,
+            "openai": 200,
+            "openai-codex": 200,
+            "chatgpt-codex": 200,
+            "google": 200,
+            "google-vertex": 200,
+            "google-gemini-cli": 200,
+            "openrouter": 90,
+            "umans": 10,
+        ]
+
+        for (provider, expectedLimit) in expectedLimits {
+            #expect(ProviderImageBudget.limit(for: provider) == expectedLimit)
+        }
+        #expect(ProviderImageBudget.limit(for: "some-new-provider") == 5)
+    }
+
+    @Test("drops the oldest images while preserving text and stored context")
+    func dropsOldestImages() {
+        let context = Context(messages: (0..<8).map { index in
+            .user(UserMessage(content: [
+                .text(TextContent(text: "text-\(index)")),
+                image("image-\(index)"),
+            ]))
+        })
+
+        let clamped = ProviderImageBudget.clamp(context, for: visionModel(provider: "unknown"))
+
+        #expect(imageData(in: clamped) == (3..<8).map { "image-\($0)" })
+        #expect(textData(in: clamped) == (0..<8).map { "text-\($0)" })
+        #expect(imageData(in: context) == (0..<8).map { "image-\($0)" })
+    }
+
+    @Test("keeps an image-only tool result meaningful when its image is dropped")
+    func preservesImageOnlyToolResultMeaning() {
+        let context = Context(messages: (0..<6).map { index in
+            .toolResult(ToolResultMessage(
+                toolCallId: "call-\(index)",
+                toolName: "inspect_image",
+                content: [toolResultImage("image-\(index)")]
+            ))
+        })
+
+        let clamped = ProviderImageBudget.clamp(context, for: visionModel(provider: "unknown"))
+
+        #expect(imageData(in: clamped) == (1..<6).map { "image-\($0)" })
+        guard case .toolResult(let first) = clamped.messages[0] else {
+            Issue.record("expected a tool result")
+            return
+        }
+        #expect(first.content == [
+            .text(TextContent(text: "[image omitted: provider image limit]")),
+        ])
+    }
+
+    @Test("keeps an image-only user message meaningful when its image is dropped")
+    func preservesImageOnlyUserMessageMeaning() {
+        let context = Context(messages: (0..<6).map { index in
+            .user(UserMessage(content: [image("image-\(index)")]))
+        })
+
+        let clamped = ProviderImageBudget.clamp(context, for: visionModel(provider: "unknown"))
+
+        #expect(imageData(in: clamped) == (1..<6).map { "image-\($0)" })
+        guard case .user(let first) = clamped.messages[0] else {
+            Issue.record("expected a user message")
+            return
+        }
+        #expect(first.content == [
+            .text(TextContent(text: "[image omitted: provider image limit]")),
+        ])
+    }
+
+    @Test("does not clamp images for a text-only model")
+    func textOnlyModelIsUnchanged() {
+        let context = Context(messages: [
+            .user(UserMessage(content: (0..<6).map { image("image-\($0)") })),
+        ])
+        let model = Model(
+            id: "text-only",
+            api: "provider-image-budget-test",
+            provider: "unknown",
+            input: [.text]
+        )
+
+        #expect(ProviderImageBudget.clamp(context, for: model) == context)
+    }
+
+    @Test("recomputes the transient view when the active model changes")
+    func modelSwitchRecomputesBudget() {
+        let context = Context(messages: [
+            .user(UserMessage(content: (0..<6).map { image("image-\($0)") })),
+        ])
+
+        let unknownView = ProviderImageBudget.clamp(
+            context,
+            for: visionModel(provider: "unknown")
+        )
+        let openAIView = ProviderImageBudget.clamp(
+            context,
+            for: visionModel(provider: "openai")
+        )
+
+        #expect(imageData(in: unknownView) == (1..<6).map { "image-\($0)" })
+        #expect(imageData(in: openAIView) == (0..<6).map { "image-\($0)" })
+        #expect(imageData(in: context) == (0..<6).map { "image-\($0)" })
+    }
+
+    @Test("top-level stream clamps the context before provider dispatch")
+    func streamClampsBeforeDispatch() async throws {
+        let provider = RecordingImageContextProvider()
+        let registry = APIRegistry()
+        await registry.register(provider, scope: "unknown")
+        let context = Context(messages: [
+            .user(UserMessage(content: (0..<6).map { image("image-\($0)") })),
+        ])
+
+        _ = try await stream(
+            model: visionModel(provider: "unknown"),
+            context: context,
+            registry: registry
+        )
+
+        let received = try #require(provider.receivedContext)
+        #expect(imageData(in: received) == (1..<6).map { "image-\($0)" })
+        #expect(imageData(in: context) == (0..<6).map { "image-\($0)" })
+    }
+
+    private func visionModel(provider: String) -> Model {
+        Model(
+            id: "vision",
+            api: "provider-image-budget-test",
+            provider: provider,
+            input: [.text, .image]
+        )
+    }
+
+    private func image(_ data: String) -> UserBlock {
+        .image(ImageContent(data: data, mimeType: "image/png"))
+    }
+
+    private func toolResultImage(_ data: String) -> ToolResultBlock {
+        .image(ImageContent(data: data, mimeType: "image/png"))
+    }
+
+    private func imageData(in context: Context) -> [String] {
+        context.messages.flatMap { message -> [String] in
+            switch message {
+            case .user(let user):
+                return user.content.compactMap { block in
+                    if case .image(let image) = block { return image.data }
+                    return nil
+                }
+            case .toolResult(let result):
+                return result.content.compactMap { block in
+                    if case .image(let image) = block { return image.data }
+                    return nil
+                }
+            case .assistant:
+                return []
+            }
+        }
+    }
+
+    private func textData(in context: Context) -> [String] {
+        context.messages.flatMap { message -> [String] in
+            switch message {
+            case .user(let user):
+                return user.content.compactMap { block in
+                    if case .text(let text) = block { return text.text }
+                    return nil
+                }
+            case .toolResult(let result):
+                return result.content.compactMap { block in
+                    if case .text(let text) = block { return text.text }
+                    return nil
+                }
+            case .assistant:
+                return []
+            }
+        }
+    }
+}
+
+private final class RecordingImageContextProvider: APIProvider, @unchecked Sendable {
+    let api = "provider-image-budget-test"
+
+    private let lock = NSLock()
+    private var context: Context?
+
+    var receivedContext: Context? {
+        lock.withLock { context }
+    }
+
+    func stream(
+        model: Model,
+        context: Context,
+        options: StreamOptions?
+    ) -> AssistantMessageStream {
+        lock.withLock { self.context = context }
+        return AssistantMessageStream()
+    }
+}

--- a/Tests/KWWKAgentTests/AgentContextCompactorTests.swift
+++ b/Tests/KWWKAgentTests/AgentContextCompactorTests.swift
@@ -124,6 +124,67 @@ struct AgentContextCompactorTests {
         #expect(hasImage)
     }
 
+    @Test("removingImages strips user and tool-result images with non-empty placeholders")
+    func removingImagesStripsSupportedMessageBlocks() {
+        let userTimestamp: Int64 = 101
+        let toolTimestamp: Int64 = 202
+        let messages: [Message] = [
+            .user(UserMessage(
+                content: [
+                    .image(ImageContent(data: "user-a", mimeType: "image/png")),
+                    .text(TextContent(text: "keep me")),
+                    .image(ImageContent(data: "user-b", mimeType: "image/jpeg")),
+                ],
+                timestamp: userTimestamp
+            )),
+            .user(UserMessage(
+                content: [.image(ImageContent(data: "user-only", mimeType: "image/webp"))]
+            )),
+            .toolResult(ToolResultMessage(
+                toolCallId: "shot",
+                toolName: "read",
+                content: [.image(ImageContent(data: "tool", mimeType: "image/png"))],
+                details: .object(["path": .string("screenshot.png")]),
+                timestamp: toolTimestamp
+            )),
+            .assistant(AssistantMessage(
+                content: [.text(TextContent(text: "unchanged"))],
+                api: "faux",
+                provider: "faux",
+                model: "faux"
+            )),
+        ]
+
+        let rewrite = AgentContextCompactor.removingImages(from: messages)
+
+        #expect(rewrite.removedCount == 4)
+        guard case .user(let user) = rewrite.messages[0] else {
+            Issue.record("expected user message")
+            return
+        }
+        #expect(user.content == [.text(TextContent(text: "keep me"))])
+        #expect(user.timestamp == userTimestamp)
+
+        guard case .user(let imageOnlyUser) = rewrite.messages[1] else {
+            Issue.record("expected image-only user message")
+            return
+        }
+        #expect(imageOnlyUser.content == [.text(TextContent(text: "[image removed]"))])
+
+        guard case .toolResult(let tool) = rewrite.messages[2] else {
+            Issue.record("expected tool result")
+            return
+        }
+        #expect(tool.content == [.text(TextContent(text: "[image removed]"))])
+        #expect(tool.details == .object(["path": .string("screenshot.png")]))
+        #expect(tool.timestamp == toolTimestamp)
+        #expect(rewrite.messages[3] == messages[3])
+
+        let repeated = AgentContextCompactor.removingImages(from: rewrite.messages)
+        #expect(repeated.removedCount == 0)
+        #expect(repeated.messages == rewrite.messages)
+    }
+
     private func toolResultChars(_ messages: [Message]) -> Int {
         messages.reduce(0) { total, message in
             guard case .toolResult(let result) = message else { return total }

--- a/Tests/KWWKAgentTests/ReadToolTests.swift
+++ b/Tests/KWWKAgentTests/ReadToolTests.swift
@@ -139,7 +139,7 @@ struct ReadToolTests {
         #expect(trunc["outputLines"] == .int(2000))
     }
 
-    @Test("detects PNG images by magic bytes and returns an image block")
+    @Test("normalizes detected images and includes coordinate mapping")
     func pngDetection() async throws {
         let dir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -150,10 +150,31 @@ struct ReadToolTests {
         let tool = createReadTool(cwd: dir.path)
         let result = try await tool.execute("call-7", ["path": .string(file.path)], nil, nil)
 
-        let hasImage = result.content.contains { block in
-            if case .image(let img) = block { return img.mimeType == "image/png" } else { return false }
+        let image = try #require(result.content.compactMap { block -> ImageContent? in
+            if case .image(let image) = block { return image }
+            return nil
+        }.first)
+        #expect(["image/png", "image/jpeg", "image/webp"].contains(image.mimeType))
+        #expect(Data(base64Encoded: image.data) != nil)
+
+        let note = textOutput(result)
+        #expect(note.contains(image.mimeType))
+        #expect(note.contains("200x200"))
+        #expect(note.contains("original 1x1, displayed at 200x200"))
+        #expect(note.contains("Multiply coordinates by 0.01"))
+    }
+
+    @Test("surfaces image decode failure")
+    func invalidImageThrows() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("invalid.png")
+        try Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]).write(to: file)
+
+        let tool = createReadTool(cwd: dir.path)
+        await #expect(throws: ImageNormalizationError.decodeFailed) {
+            _ = try await tool.execute("call-invalid-image", ["path": .string(file.path)], nil, nil)
         }
-        #expect(hasImage)
     }
 
     @Test("unreadable file reports a permission error, not file-not-found")

--- a/Tests/KWWKAgentTests/SessionStoreTests.swift
+++ b/Tests/KWWKAgentTests/SessionStoreTests.swift
@@ -39,6 +39,25 @@ struct SessionStoreTests {
         ))
     }
 
+    private func imageCount(in messages: [Message]) -> Int {
+        messages.reduce(0) { count, message in
+            switch message {
+            case .user(let user):
+                return count + user.content.count { block in
+                    if case .image = block { return true }
+                    return false
+                }
+            case .toolResult(let result):
+                return count + result.content.count { block in
+                    if case .image = block { return true }
+                    return false
+                }
+            case .assistant:
+                return count
+            }
+        }
+    }
+
     @Test("default store is disabled and does not touch disk")
     func defaultStoreDisabled() async throws {
         let store = SessionStore()
@@ -600,6 +619,106 @@ struct SessionStoreTests {
         #expect(loaded.messages.count == 2)
     }
 
+    @Test("SessionRecorder atomically removes images from messages and compaction projections")
+    func recorderRewritesImagesPermanently() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-rec-remove-images"
+        let cwd = "/w"
+        let user = Message.user(UserMessage(content: [
+            .text(TextContent(text: "look")),
+            .image(ImageContent(data: "USER_BASE64_SENTINEL", mimeType: "image/png")),
+        ]))
+        let tool = Message.toolResult(ToolResultMessage(
+            toolCallId: "image-read",
+            toolName: "read",
+            content: [
+                .image(ImageContent(data: "TOOL_BASE64_SENTINEL", mimeType: "image/jpeg")),
+            ]
+        ))
+        try await store.append(id: id, cwd: cwd, messages: [user, tool])
+        try await store.appendCompaction(
+            id: id,
+            cwd: cwd,
+            replacementMessages: [user, tool],
+            messagesCompacted: 0,
+            reason: .compact
+        )
+        try await store.setTitle(id: id, cwd: cwd, title: "Images")
+
+        let file = dir.appendingPathComponent("\(id).jsonl")
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644],
+            ofItemAtPath: file.path
+        )
+
+        let recorder = SessionRecorder(
+            store: store,
+            sessionId: id,
+            cwd: cwd,
+            persistedCount: 2
+        )
+        let removed = await recorder.rewriteRemovingImages()
+
+        #expect(removed == 4, "raw messages and compaction replacements are both rewritten")
+        let loaded = try await store.load(id: id)
+        #expect(imageCount(in: loaded.messages) == 0)
+        #expect(imageCount(in: loaded.displayMessages) == 0)
+        #expect(loaded.title == "Images")
+        guard case .toolResult(let rewrittenTool) = loaded.messages[1] else {
+            Issue.record("expected tool result")
+            return
+        }
+        #expect(rewrittenTool.content == [.text(TextContent(text: "[image removed]"))])
+
+        let raw = try String(contentsOf: file, encoding: .utf8)
+        #expect(!raw.contains("USER_BASE64_SENTINEL"))
+        #expect(!raw.contains("TOOL_BASE64_SENTINEL"))
+        #expect(raw.contains(#""type":"compaction""#))
+        #expect(raw.contains(#""title":"Images""#))
+
+        let after = assistantMsg("after rewrite")
+        await recorder.flush(messages: loaded.messages + [after])
+        let appended = try await store.load(id: id)
+        #expect(appended.messages == loaded.messages + [after])
+
+        let mode = try #require(
+            (try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions]) as? Int
+        )
+        #expect(mode == 0o600)
+    }
+
+    @Test("SessionRecorder persists tool-output shake rewrites")
+    func recorderRewritesShakenToolOutput() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-rec-shake-output"
+        let heavy = "HEAVY_OUTPUT_SENTINEL" + String(repeating: "x", count: 2_000)
+        let message = toolResultMsg(heavy)
+        try await store.append(id: id, cwd: "/w", message: message)
+        let recorder = SessionRecorder(
+            store: store,
+            sessionId: id,
+            cwd: "/w",
+            persistedCount: 1
+        )
+
+        let changed = await recorder.rewriteShakenToolOutputs(keepingUnder: 100)
+
+        #expect(changed == 1)
+        let loaded = try await store.load(id: id)
+        #expect(text(from: loaded.messages.first).hasPrefix(
+            "[tool result elided to reclaim context"
+        ))
+        let raw = try String(
+            contentsOf: dir.appendingPathComponent("\(id).jsonl"),
+            encoding: .utf8
+        )
+        #expect(!raw.contains("HEAVY_OUTPUT_SENTINEL"))
+    }
+
     @Test("SessionRecorder retries a failed append without skipping a message")
     func recorderRetriesFailedAppend() async throws {
         let (store, dir) = tempStore()
@@ -631,6 +750,44 @@ struct SessionStoreTests {
         #expect(recorder.lastPersistenceError == nil)
         let loaded = try await store.load(id: id)
         #expect(loaded.messages == [first, second])
+    }
+
+    @Test("SessionRecorder cancels a rewrite queued behind a failed append")
+    func recorderCancelsRewriteBehindFailedAppend() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = "sess-rec-cancel-rewrite"
+        let image = Message.user(UserMessage(content: [
+            .image(ImageContent(data: "KEEP_IMAGE", mimeType: "image/png")),
+        ]))
+        try await store.append(id: id, cwd: "/w", message: image)
+        let recorder = SessionRecorder(
+            store: store,
+            sessionId: id,
+            cwd: "/w",
+            persistedCount: 1
+        )
+
+        let after = assistantMsg("after")
+        let file = dir.appendingPathComponent("\(id).jsonl")
+        let backup = dir.appendingPathComponent("\(id).backup")
+        try FileManager.default.moveItem(at: file, to: backup)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+
+        await recorder.flush(messages: [image, after])
+        #expect(recorder.lastPersistenceError != nil)
+        let removed = await recorder.rewriteRemovingImages()
+        #expect(removed == nil)
+
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.moveItem(at: backup, to: file)
+        await recorder.flush(messages: [image, after])
+
+        #expect(recorder.lastPersistenceError == nil)
+        let loaded = try await store.load(id: id)
+        #expect(loaded.messages == [image, after])
+        #expect(imageCount(in: loaded.messages) == 1)
     }
 
     @Test("SessionRecorder redacts a hidden goal message when a failed append retries")

--- a/Tests/KWWKCliTests/AttachmentsTests.swift
+++ b/Tests/KWWKCliTests/AttachmentsTests.swift
@@ -120,6 +120,25 @@ struct AttachmentStoreTests {
         store.clear()
         #expect(store.clipboardImages.isEmpty)
     }
+
+    @MainActor
+    @Test("consuming a prompt snapshot preserves attachments added for the next draft")
+    func snapshotConsumptionPreservesNextDraft() {
+        let store = AttachmentStore()
+        let firstText = store.addPastedText("first")
+        let firstImage = store.addClipboardImage(data: Data([1]), mimeType: "image/png")
+        let snapshot = store.promptSnapshot(for: "\(firstText) \(firstImage)")
+
+        let nextText = store.addPastedText("next")
+        let nextImage = store.addClipboardImage(data: Data([2]), mimeType: "image/png")
+        store.consume(snapshot)
+
+        #expect(snapshot.expandedText == "first [image #1]")
+        #expect(store.pastedTexts.map(\.id) == [2])
+        #expect(store.clipboardImages.map(\.id) == [2])
+        #expect(store.expandPastedTextPlaceholders(in: nextText) == "next")
+        #expect(nextImage == "[image #2]")
+    }
 }
 
 // MARK: - buildPromptWithAttachments
@@ -129,9 +148,9 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("no attachments → text unchanged, no summary")
-    func passthrough() {
+    func passthrough() async throws {
         let store = AttachmentStore()
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "hello world",
             store: store,
             cwd: "/tmp",
@@ -144,7 +163,7 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("pasted-text placeholder expanded to its raw body, @text-file appended as <attachments>")
-    func textFileAndPasted() throws {
+    func textFileAndPasted() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let filePath = dir.appendingPathComponent("hello.txt").path
@@ -153,7 +172,7 @@ struct BuildPromptTests {
         let store = AttachmentStore()
         let placeholder = store.addPastedText("one\ntwo")
 
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "see \(placeholder) and @\(filePath).",
             store: store,
             cwd: "/tmp",
@@ -171,9 +190,9 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("missing path surfaces as a <missing> tag + 'missing' summary entry")
-    func missingPath() {
+    func missingPath() async throws {
         let store = AttachmentStore()
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "look at @/definitely/not/here.png",
             store: store,
             cwd: "/tmp",
@@ -186,7 +205,7 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("folder renders a truncated listing")
-    func folderListing() throws {
+    func folderListing() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         for name in ["a.txt", "b.md", "sub"] {
@@ -197,7 +216,7 @@ struct BuildPromptTests {
             }
         }
         let store = AttachmentStore()
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "inspect @\(dir.path)",
             store: store,
             cwd: "/tmp",
@@ -212,31 +231,35 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("image bytes attached when model supports images")
-    func imageAttached() throws {
+    func imageAttached() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let pngHeader: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
         let imagePath = dir.appendingPathComponent("shot.png")
-        try Data(pngHeader).write(to: imagePath)
+        try attachmentTestPNG.write(to: imagePath)
         let store = AttachmentStore()
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "@\(imagePath.path) what is this?",
             store: store,
             cwd: "/tmp",
             modelSupportsImages: true
         )
         #expect(built.images.count == 1)
-        #expect(built.images.first?.mimeType == "image/png")
+        let mimeType = try #require(built.images.first?.mimeType)
+        #expect(["image/png", "image/jpeg", "image/webp"].contains(mimeType))
+        #expect(built.text.contains("mime=\"\(mimeType)\""))
+        #expect(built.text.contains("original_dimensions=\"1x1\""))
+        #expect(built.text.contains("displayed_dimensions=\"200x200\""))
+        #expect(built.text.contains("Multiply coordinates by 0.01"))
         #expect(built.summary?.contains("1 image") == true)
     }
 
     @MainActor
     @Test("clipboard-image keeps its [image #N] token in the prose and attaches bytes")
-    func clipboardImageExpands() {
+    func clipboardImageExpands() async throws {
         let store = AttachmentStore()
-        let bytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+        let bytes = attachmentTestPNG
         let token = store.addClipboardImage(data: bytes, mimeType: "image/png")
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "what is this: \(token) any ideas?",
             store: store,
             cwd: "/tmp",
@@ -252,16 +275,19 @@ struct BuildPromptTests {
         #expect(built.text.contains("source=\"clipboard\""))
         #expect(built.text.contains("id=\"1\""))
         #expect(built.images.count == 1)
-        #expect(built.images.first?.mimeType == "image/png")
+        let mimeType = try #require(built.images.first?.mimeType)
+        #expect(["image/png", "image/jpeg", "image/webp"].contains(mimeType))
+        #expect(built.text.contains("mime=\"\(mimeType)\""))
+        #expect(built.text.contains("original_dimensions=\"1x1\""))
         #expect(built.summary?.contains("1 image") == true)
     }
 
     @MainActor
     @Test("clipboard-image on a text-only model is skipped with a note")
-    func clipboardImageSkippedOnTextOnly() {
+    func clipboardImageSkippedOnTextOnly() async throws {
         let store = AttachmentStore()
         let token = store.addClipboardImage(data: Data([1, 2, 3]), mimeType: "image/png")
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "\(token)",
             store: store,
             cwd: "/tmp",
@@ -274,13 +300,13 @@ struct BuildPromptTests {
 
     @MainActor
     @Test("image is dropped + noted when model can't accept images")
-    func imageSkippedOnTextOnlyModel() throws {
+    func imageSkippedOnTextOnlyModel() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let imagePath = dir.appendingPathComponent("shot.png")
         try Data([0x89, 0x50, 0x4E, 0x47]).write(to: imagePath)
         let store = AttachmentStore()
-        let built = buildPromptWithAttachments(
+        let built = try await buildPromptWithAttachments(
             text: "@\(imagePath.path)",
             store: store,
             cwd: "/tmp",
@@ -298,3 +324,7 @@ private func makeTempDir() throws -> URL {
     try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     return dir
 }
+
+private let attachmentTestPNG = Data(base64Encoded:
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+)!

--- a/Tests/KWWKCliTests/NewSessionResetTests.swift
+++ b/Tests/KWWKCliTests/NewSessionResetTests.swift
@@ -70,7 +70,7 @@ struct NewSessionResetTests {
     }
 
     @MainActor
-    @Test("production replacement path records only the new Agent identity")
+    @Test("production replacement uses the new Agent and preserves a draft composed during handoff")
     func replacementUsesFreshAgentIdentity() async throws {
         let faux = await registerFauxProvider()
         defer { faux.unregister() }
@@ -106,6 +106,10 @@ struct NewSessionResetTests {
             sessionId: "old-session"
         )
         defer { recorderBox.unsubscribe() }
+        let attachments = AttachmentStore()
+        _ = attachments.addPastedText("outgoing paste")
+        _ = attachments.addClipboardImage(data: Data([1]), mimeType: "image/png")
+        let frame = CodingFrame()
 
         await performNewSession(
             newId: "new-session",
@@ -115,13 +119,19 @@ struct NewSessionResetTests {
             replaceSessionAgent: { id, messages in
                 #expect(id == "new-session")
                 replacement.state.messages = messages
+                let text = attachments.addPastedText("new-session paste")
+                let image = attachments.addClipboardImage(
+                    data: Data([2]),
+                    mimeType: "image/png"
+                )
+                frame.input.value = "\(text) \(image)"
                 return replacement
             },
             cwd: dir.path,
-            attachments: AttachmentStore(),
+            attachments: attachments,
             retry: TurnRetryState(),
             dequeueCycle: DequeueCycleState(),
-            frame: CodingFrame(),
+            frame: frame,
             width: 60,
             commit: { _ in },
             recompute: {},
@@ -134,6 +144,9 @@ struct NewSessionResetTests {
         #expect(replacement.sessionId == "new-session")
         #expect(replacement.state.messages.isEmpty)
         #expect(recorderBox.sessionId == "new-session")
+        #expect(frame.input.value == "[pasted-text #2] [image #2]")
+        #expect(attachments.pastedTexts.map(\.body) == ["new-session paste"])
+        #expect(attachments.clipboardImages.map(\.data) == [Data([2])])
 
         try await replacement.prompt("belongs to new session")
         let loaded = try await store.resolveResume(.id("new-session"), cwd: dir.path)

--- a/Tests/KWWKCliTests/SlashCommandTests.swift
+++ b/Tests/KWWKCliTests/SlashCommandTests.swift
@@ -207,6 +207,159 @@ struct ShakeCommandTests {
         #expect(shake?.description.contains("no LLM") == true)
         #expect(registry.all.contains { $0.name == "shake" })
     }
+
+    @MainActor
+    @Test("images mode persists, replaces live messages, and closes provider session state")
+    func imagesModeRewritesSessionAndLiveState() async {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let lifecycle = ShakeLifecycleProvider(api: "shake-lifecycle-\(UUID().uuidString)")
+        let sourceId = "shake-lifecycle-source-\(UUID().uuidString)"
+        await APIRegistry.shared.register(lifecycle, sourceId: sourceId)
+
+        let sessionId = "shake-images-session"
+        let agent = Agent(options: AgentOptions(
+            initialState: AgentInitialState(
+                model: faux.getModel(),
+                messages: [
+                    .user(UserMessage(content: [
+                        .image(ImageContent(data: "user-image", mimeType: "image/png")),
+                    ])),
+                    .toolResult(ToolResultMessage(
+                        toolCallId: "image-tool",
+                        toolName: "read",
+                        content: [
+                            .text(TextContent(text: "keep")),
+                            .image(ImageContent(data: "tool-image", mimeType: "image/jpeg")),
+                        ]
+                    )),
+                ]
+            ),
+            sessionId: sessionId
+        ))
+        let notifier = SlashNotifyRecorder()
+        let persistence = ShakePersistenceRecorder(result: 4)
+        let refresh = ShakeRefreshRecorder()
+        let activity = ShakeActivityRecorder()
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-shake-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let ctx = SlashContext(
+            agent: agent,
+            modal: makeShakeModalHost(),
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: sessionId,
+            notifyBlock: { lines in for line in lines { notifier.append(line) } },
+            commitScrollback: { _ in },
+            refreshTranscript: { refresh.count += 1 },
+            persistShake: { mode in persistence.record(mode) },
+            setShaking: { active in activity.record(active) }
+        )
+        let registry = SlashCommandRegistry()
+        registerBuiltinSlashCommands(registry)
+
+        await registry.find("shake")?.handler(ctx, "images")
+
+        #expect(persistence.modes == [.images])
+        #expect(refresh.count == 1)
+        #expect(activity.states == [true, false])
+        #expect(notifier.joined.contains("dropped 2 images"))
+        guard case .user(let user) = agent.state.messages[0] else {
+            Issue.record("expected user message")
+            await APIRegistry.shared.unregisterSource(sourceId)
+            return
+        }
+        #expect(user.content == [.text(TextContent(text: "[image removed]"))])
+        guard case .toolResult(let tool) = agent.state.messages[1] else {
+            Issue.record("expected tool result")
+            await APIRegistry.shared.unregisterSource(sourceId)
+            return
+        }
+        #expect(tool.content == [.text(TextContent(text: "keep"))])
+        #expect(lifecycle.closedSessions.contains(sessionId))
+        await APIRegistry.shared.unregisterSource(sourceId)
+    }
+
+    @MainActor
+    @Test("bare mode persists the existing tool-output elision")
+    func bareModePersistsElision() async {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let agent = Agent(initialState: AgentInitialState(
+            model: faux.getModel(),
+            messages: [.toolResult(ToolResultMessage(
+                toolCallId: "heavy",
+                toolName: "bash",
+                content: [.text(TextContent(text: String(repeating: "x", count: 2_000)))]
+            ))]
+        ))
+        let notifier = SlashNotifyRecorder()
+        let persistence = ShakePersistenceRecorder(result: 1)
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-shake-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let ctx = SlashContext(
+            agent: agent,
+            modal: makeShakeModalHost(),
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: "shake-elide-session",
+            notifyBlock: { lines in for line in lines { notifier.append(line) } },
+            commitScrollback: { _ in },
+            refreshTranscript: {},
+            persistShake: { mode in persistence.record(mode) }
+        )
+        let registry = SlashCommandRegistry()
+        registerBuiltinSlashCommands(registry)
+
+        await registry.find("shake")?.handler(ctx, "")
+
+        #expect(persistence.modes == [.elide])
+        guard case .toolResult(let result) = agent.state.messages[0],
+              case .text(let text)? = result.content.first else {
+            Issue.record("expected rewritten tool result")
+            return
+        }
+        #expect(text.text.hasPrefix("[tool result elided to reclaim context"))
+        #expect(notifier.joined.contains("elided 1 heavy tool result"))
+        #expect(!notifier.joined.contains("in-memory only"))
+    }
+
+    @MainActor
+    @Test("unknown mode prints usage without rewriting")
+    func unknownModePrintsUsage() async {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let original = Message.user(UserMessage(content: [
+            .image(ImageContent(data: "unchanged", mimeType: "image/png")),
+        ]))
+        let agent = Agent(initialState: AgentInitialState(
+            model: faux.getModel(),
+            messages: [original]
+        ))
+        let notifier = SlashNotifyRecorder()
+        let persistence = ShakePersistenceRecorder(result: 1)
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-shake-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let ctx = SlashContext(
+            agent: agent,
+            modal: makeShakeModalHost(),
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: "shake-usage-session",
+            notifyBlock: { lines in for line in lines { notifier.append(line) } },
+            commitScrollback: { _ in },
+            refreshTranscript: {},
+            persistShake: { mode in persistence.record(mode) }
+        )
+        let registry = SlashCommandRegistry()
+        registerBuiltinSlashCommands(registry)
+
+        await registry.find("shake")?.handler(ctx, "bogus")
+
+        #expect(agent.state.messages == [original])
+        #expect(persistence.modes.isEmpty)
+        #expect(notifier.joined.contains("usage: /shake [elide|images]"))
+    }
 }
 
 @Suite("SlashCommandRegistry alias resolution")
@@ -295,4 +448,68 @@ private final class SlashNotifyRecorder {
     func append(_ s: String) { lines.append(s) }
     func clear() { lines.removeAll() }
     var joined: String { lines.joined(separator: "\n") }
+}
+
+@MainActor
+private final class ShakePersistenceRecorder {
+    private let result: Int?
+    private(set) var modes: [ShakeMode] = []
+
+    init(result: Int?) {
+        self.result = result
+    }
+
+    func record(_ mode: ShakeMode) -> Int? {
+        modes.append(mode)
+        return result
+    }
+}
+
+@MainActor
+private final class ShakeRefreshRecorder {
+    var count = 0
+}
+
+@MainActor
+private final class ShakeActivityRecorder {
+    private(set) var states: [Bool] = []
+
+    func record(_ active: Bool) {
+        states.append(active)
+    }
+}
+
+@MainActor
+private func makeShakeModalHost() -> ModalHost {
+    ModalHost(
+        renderModalLines: { _ in },
+        restoreTranscript: {},
+        requestRender: {}
+    )
+}
+
+private final class ShakeLifecycleProvider:
+    APIProvider,
+    APIProviderSessionLifecycle,
+    @unchecked Sendable
+{
+    let api: String
+    private let lock = NSLock()
+    private var sessions: [String] = []
+
+    init(api: String) {
+        self.api = api
+    }
+
+    var closedSessions: [String] {
+        lock.withLock { sessions }
+    }
+
+    func stream(model: Model, context: Context, options: StreamOptions?) -> AssistantMessageStream {
+        AssistantMessageStream()
+    }
+
+    func closeSession(sessionId: String) async {
+        lock.withLock { sessions.append(sessionId) }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ImageNormalizer` (stb + libwebp): images are resized (200px floor, 1568px cap), EXIF-orientation-baked, and recompressed to the smallest of PNG/JPEG/WebP (≤500KB) before entering the conversation; `KWWK_NO_WEBP=1` opts out of WebP for backends that cannot decode it. Pre-decode byte (100MB) and pixel (64MP) caps reject decompression bombs before the RGBA expansion.
- Add `ProviderImageBudget`: outbound contexts are clamped to per-provider image limits at `stream()` dispatch, dropping oldest images first; image-only user/tool-result messages get an omission placeholder so providers never see empty content.
- `/shake` gains an `images` mode that permanently removes image blocks from both the live context and the persisted session JSONL via an atomic rewrite ordered through the recorder's serialized persistence queue; bare `/shake` elision is now persisted too.
- Prompt attachment building moves off the main thread with snapshot/consume semantics, so the editor is released immediately and a draft composed during preparation or a session switch is preserved.

## Test plan
- [x] `swift test` — 1225 tests pass
- [x] New suites: `ImageNormalizerTests`, `ProviderImageBudgetTests`; extended `ReadToolTests`, `SessionStoreTests`, `AttachmentsTests`, `SlashCommandTests`, `NewSessionResetTests`

Made with [Cursor](https://cursor.com)