### PR TITLE
Deflake wall-clock assertions in provider and agent tests

### DIFF
--- a/Tests/KWWKAITests/GoogleGeminiTests.swift
+++ b/Tests/KWWKAITests/GoogleGeminiTests.swift
@@ -224,9 +224,11 @@ struct GoogleGeminiTests {
     static func encodedBody(model: Model, context: Context, options: StreamOptions?) async throws -> [String: Any] {
         let client = StubSSEClient(body: Self.textSSE)
         let provider = GoogleGeminiProvider(client: client, defaultAPIKey: "k")
-        _ = provider.stream(model: model, context: context, options: options)
-        try? await Task.sleep(nanoseconds: 30_000_000)
-        return try JSONSerialization.jsonObject(with: client.lastRequest!.body!) as! [String: Any]
+        // Awaiting the settled result is deterministic: the stub records the
+        // request before it starts streaming, so no fixed sleep is needed.
+        _ = await provider.stream(model: model, context: context, options: options).result()
+        let body = try #require(client.lastRequest?.body)
+        return try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
     }
 
     // MARK: - Feature 1: default thinking budgets

--- a/Tests/KWWKAgentTests/AgentLoopPolicyTests.swift
+++ b/Tests/KWWKAgentTests/AgentLoopPolicyTests.swift
@@ -335,6 +335,12 @@ struct AgentLoopPolicyTests {
 
     @Test("a blocking task poll mixed with another tool rejects the entire batch")
     func mixedBlockingPollBatchIsRejected() async throws {
+        try await withRetries { _ in
+            try await runMixedBlockingPollBatchIsRejected()
+        }
+    }
+
+    private func runMixedBlockingPollBatchIsRejected() async throws {
         let faux = await registerFauxProvider()
         defer { faux.unregister() }
         faux.setResponses([
@@ -379,7 +385,11 @@ struct AgentLoopPolicyTests {
         let startedAt = Date()
         try await agent.prompt("emit a mixed blocking batch")
 
-        #expect(Date().timeIntervalSince(startedAt) < 1)
+        // The rejection must return without paying for the 2s slow tool or
+        // the 600s poll. Wall-clock timing flakes under CI load, so a slow
+        // early attempt retries instead of failing the test.
+        let elapsed = Date().timeIntervalSince(startedAt)
+        try retryCheck(elapsed < 1.75, "rejection took \(elapsed)s, expected < 1.75s")
         #expect(await executions.snapshot().isEmpty)
         for id in ["mixed-poll", "mixed-slow"] {
             let result = toolResult(in: agent.state.messages, id: id)

--- a/Tests/KWWKAgentTests/SubagentHardeningTests.swift
+++ b/Tests/KWWKAgentTests/SubagentHardeningTests.swift
@@ -845,9 +845,16 @@ struct SubagentHardeningTests {
         #expect(provider.didFinish == false)
 
         #expect(await awaitUntil(3_000) { provider.didFinish })
-        let third = Task { try? await executeMini(tool, callId: "after-zombie-exit") }
-        #expect(await awaitUntil(750) { provider.callCount == 2 })
-        _ = await third.value
+        // The runner releases its permit shortly *after* the zombie's stream
+        // finishes, so a single follow-up launch can race the release and be
+        // rejected. Retry the launch until it is admitted — a rejected
+        // attempt throws before charging the maxTotal budget.
+        let admitted = await awaitUntil(3_000) {
+            if provider.callCount >= 2 { return true }
+            _ = try? await executeMini(tool, callId: "after-zombie-exit")
+            return provider.callCount >= 2
+        }
+        #expect(admitted)
     }
 
     @Test("an update callback can synchronously cancel its own subagent")


### PR DESCRIPTION
## Summary
- `GoogleGeminiTests.encodedBody` awaited a fixed 30ms sleep and then force-unwrapped `client.lastRequest!.body!`, which crashed the whole test process on a slow CI runner. It now awaits the settled stream result (the stub records the request before streaming), so no sleep or force-unwrap is needed.
- `mixedBlockingPollBatchIsRejected` asserted the batch rejection returned in under 1 wall-clock second, which flaked under CI load (observed 1.1–1.2s). The timing check now uses the existing `withRetries` + `retryCheck` pattern with the same 1.75s bound used by sibling tests; deterministic assertions stay as `#expect`.
- `nonCooperativeTimeoutRetainsCapacity` sampled a single follow-up launch that can race the runner's permit release after the zombie stream finishes. The launch is now retried inside the `awaitUntil` poll; a rejected attempt throws before charging the `maxTotal` budget, so retrying is safe.

These are the three tests responsible for the intermittent CI failures observed on #54 (all unrelated to that change).

## Test plan
- [x] `swift test` — 1225 tests pass
- [x] Targeted suites (`GoogleGemini`, `AgentLoopPolicy`, `SubagentHardening`) pass repeatedly

Made with [Cursor](https://cursor.com)