### PR TITLE
Update model catalog from pi-mono; infer Cursor image input (omp port)

### DIFF
--- a/Sources/KWWKAI/Cursor/CursorModelCatalog.swift
+++ b/Sources/KWWKAI/Cursor/CursorModelCatalog.swift
@@ -176,7 +176,7 @@ public enum CursorModelCatalog {
                 provider: "cursor",
                 baseURL: "https://\(host)",
                 reasoning: m.hasThinking || thinkingVariant != nil || id.hasSuffix("-thinking"),
-                input: [.text],
+                input: inferInput(fromCursorId: id),
                 cost: ModelCost(),
                 contextWindow: 200_000,
                 maxTokens: 64_000,
@@ -205,6 +205,23 @@ public enum CursorModelCatalog {
         let msgLen = lenBytes.reduce(0) { ($0 << 8) | Int($1) }
         guard msgLen == data.count - 5 else { return data }
         return data.subdata(in: data.startIndex + 5 ..< data.endIndex)
+    }
+
+    /// Infers input modalities for Cursor models without a curated entry.
+    ///
+    /// `GetUsableModels` carries no per-model modality metadata, so
+    /// classification falls back to the model family: families that are
+    /// multimodal in their native catalogs (claude/gemini/gpt/codex) accept
+    /// images, everything else (composer-*, grok-code-*, kimi-*) stays
+    /// text-only. Curated entries above remain authoritative. Ports oh-my-pi's
+    /// `inferInputFromCursorId` (6e209d3ec).
+    static func inferInput(fromCursorId id: String) -> [InputModality] {
+        let lowered = id.lowercased()
+        let multimodalFamilies = ["claude", "gemini", "gpt-", "codex"]
+        if multimodalFamilies.contains(where: lowered.contains) {
+            return [.text, .image]
+        }
+        return [.text]
     }
 
     private static func pickDisplayName(_ m: CursorProto.UsableModel, fallbackId: String) -> String {

--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -31,7 +31,8 @@
     },
     "id" : "claude-4-sonnet",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 4",
@@ -137,7 +138,8 @@
     },
     "id" : "claude-4.6-opus-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.6 1M Max",
@@ -189,7 +191,8 @@
     },
     "id" : "claude-fable-5-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M (NO ZDR)",
@@ -208,7 +211,8 @@
     },
     "id" : "claude-fable-5-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Low (NO ZDR)",
@@ -227,7 +231,8 @@
     },
     "id" : "claude-fable-5-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Max (NO ZDR)",
@@ -246,7 +251,8 @@
     },
     "id" : "claude-fable-5-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Medium (NO ZDR)",
@@ -265,7 +271,8 @@
     },
     "id" : "claude-fable-5-thinking-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Thinking (NO ZDR)",
@@ -284,7 +291,8 @@
     },
     "id" : "claude-fable-5-thinking-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Low Thinking (NO ZDR)",
@@ -303,7 +311,8 @@
     },
     "id" : "claude-fable-5-thinking-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Max Thinking (NO ZDR)",
@@ -322,7 +331,8 @@
     },
     "id" : "claude-fable-5-thinking-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Medium Thinking (NO ZDR)",
@@ -341,7 +351,8 @@
     },
     "id" : "claude-fable-5-thinking-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Extra High Thinking (NO ZDR)",
@@ -360,7 +371,8 @@
     },
     "id" : "claude-fable-5-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Fable 5 1M Extra High (NO ZDR)",
@@ -379,7 +391,8 @@
     },
     "id" : "claude-opus-4-7-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M High",
@@ -398,7 +411,8 @@
     },
     "id" : "claude-opus-4-7-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M High Fast",
@@ -417,7 +431,8 @@
     },
     "id" : "claude-opus-4-7-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Low",
@@ -436,7 +451,8 @@
     },
     "id" : "claude-opus-4-7-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Low Fast",
@@ -455,7 +471,8 @@
     },
     "id" : "claude-opus-4-7-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Max",
@@ -474,7 +491,8 @@
     },
     "id" : "claude-opus-4-7-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Max Fast",
@@ -493,7 +511,8 @@
     },
     "id" : "claude-opus-4-7-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Medium",
@@ -512,7 +531,8 @@
     },
     "id" : "claude-opus-4-7-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Medium Fast",
@@ -531,7 +551,8 @@
     },
     "id" : "claude-opus-4-7-thinking-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M High Thinking",
@@ -550,7 +571,8 @@
     },
     "id" : "claude-opus-4-7-thinking-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M High Thinking Fast",
@@ -569,7 +591,8 @@
     },
     "id" : "claude-opus-4-7-thinking-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Low Thinking",
@@ -588,7 +611,8 @@
     },
     "id" : "claude-opus-4-7-thinking-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Low Thinking Fast",
@@ -607,7 +631,8 @@
     },
     "id" : "claude-opus-4-7-thinking-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Max Thinking",
@@ -626,7 +651,8 @@
     },
     "id" : "claude-opus-4-7-thinking-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Max Thinking Fast",
@@ -645,7 +671,8 @@
     },
     "id" : "claude-opus-4-7-thinking-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Medium Thinking",
@@ -664,7 +691,8 @@
     },
     "id" : "claude-opus-4-7-thinking-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Medium Thinking Fast",
@@ -683,7 +711,8 @@
     },
     "id" : "claude-opus-4-7-thinking-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Thinking",
@@ -702,7 +731,8 @@
     },
     "id" : "claude-opus-4-7-thinking-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Thinking Fast",
@@ -721,7 +751,8 @@
     },
     "id" : "claude-opus-4-7-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M",
@@ -740,7 +771,8 @@
     },
     "id" : "claude-opus-4-7-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.7 1M Fast",
@@ -759,7 +791,8 @@
     },
     "id" : "claude-opus-4-8-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M",
@@ -778,7 +811,8 @@
     },
     "id" : "claude-opus-4-8-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Fast",
@@ -797,7 +831,8 @@
     },
     "id" : "claude-opus-4-8-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Low",
@@ -816,7 +851,8 @@
     },
     "id" : "claude-opus-4-8-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Low Fast",
@@ -835,7 +871,8 @@
     },
     "id" : "claude-opus-4-8-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Max",
@@ -854,7 +891,8 @@
     },
     "id" : "claude-opus-4-8-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Max Fast",
@@ -873,7 +911,8 @@
     },
     "id" : "claude-opus-4-8-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Medium",
@@ -892,7 +931,8 @@
     },
     "id" : "claude-opus-4-8-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Medium Fast",
@@ -911,7 +951,8 @@
     },
     "id" : "claude-opus-4-8-thinking-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Thinking",
@@ -930,7 +971,8 @@
     },
     "id" : "claude-opus-4-8-thinking-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Thinking Fast",
@@ -949,7 +991,8 @@
     },
     "id" : "claude-opus-4-8-thinking-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Low Thinking",
@@ -968,7 +1011,8 @@
     },
     "id" : "claude-opus-4-8-thinking-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Low Thinking Fast",
@@ -987,7 +1031,8 @@
     },
     "id" : "claude-opus-4-8-thinking-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Max Thinking",
@@ -1006,7 +1051,8 @@
     },
     "id" : "claude-opus-4-8-thinking-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Max Thinking Fast",
@@ -1025,7 +1071,8 @@
     },
     "id" : "claude-opus-4-8-thinking-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Medium Thinking",
@@ -1044,7 +1091,8 @@
     },
     "id" : "claude-opus-4-8-thinking-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Medium Thinking Fast",
@@ -1063,7 +1111,8 @@
     },
     "id" : "claude-opus-4-8-thinking-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Extra High Thinking",
@@ -1082,7 +1131,8 @@
     },
     "id" : "claude-opus-4-8-thinking-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Extra High Thinking Fast",
@@ -1101,7 +1151,8 @@
     },
     "id" : "claude-opus-4-8-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Extra High",
@@ -1120,7 +1171,8 @@
     },
     "id" : "claude-opus-4-8-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Opus 4.8 1M Extra High Fast",
@@ -1139,7 +1191,8 @@
     },
     "id" : "claude-sonnet-5-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M",
@@ -1158,7 +1211,8 @@
     },
     "id" : "claude-sonnet-5-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Low",
@@ -1177,7 +1231,8 @@
     },
     "id" : "claude-sonnet-5-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Max",
@@ -1196,7 +1251,8 @@
     },
     "id" : "claude-sonnet-5-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Medium",
@@ -1215,7 +1271,8 @@
     },
     "id" : "claude-sonnet-5-thinking-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Thinking",
@@ -1234,7 +1291,8 @@
     },
     "id" : "claude-sonnet-5-thinking-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Low Thinking",
@@ -1253,7 +1311,8 @@
     },
     "id" : "claude-sonnet-5-thinking-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Max Thinking",
@@ -1272,7 +1331,8 @@
     },
     "id" : "claude-sonnet-5-thinking-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Medium Thinking",
@@ -1291,7 +1351,8 @@
     },
     "id" : "claude-sonnet-5-thinking-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Extra High Thinking",
@@ -1310,7 +1371,8 @@
     },
     "id" : "claude-sonnet-5-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Sonnet 5 1M Extra High",
@@ -1407,7 +1469,8 @@
     },
     "id" : "gemini-3.5-flash",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Gemini 3.5 Flash",
@@ -1464,7 +1527,8 @@
     },
     "id" : "gpt-5-mini",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5 Mini",
@@ -1483,7 +1547,8 @@
     },
     "id" : "gpt-5.1",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.1",
@@ -1522,7 +1587,8 @@
     },
     "id" : "gpt-5.1-codex-max-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max High Fast",
@@ -1541,7 +1607,8 @@
     },
     "id" : "gpt-5.1-codex-max-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max Low",
@@ -1560,7 +1627,8 @@
     },
     "id" : "gpt-5.1-codex-max-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max Low Fast",
@@ -1579,7 +1647,8 @@
     },
     "id" : "gpt-5.1-codex-max-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max",
@@ -1598,7 +1667,8 @@
     },
     "id" : "gpt-5.1-codex-max-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max Medium Fast",
@@ -1617,7 +1687,8 @@
     },
     "id" : "gpt-5.1-codex-max-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max Extra High",
@@ -1636,7 +1707,8 @@
     },
     "id" : "gpt-5.1-codex-max-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Max Extra High Fast",
@@ -1675,7 +1747,8 @@
     },
     "id" : "gpt-5.1-codex-mini-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Mini High",
@@ -1694,7 +1767,8 @@
     },
     "id" : "gpt-5.1-codex-mini-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "Codex 5.1 Mini Low",
@@ -1732,7 +1806,8 @@
     },
     "id" : "gpt-5.1-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.1 Low",
@@ -1924,7 +1999,8 @@
     },
     "id" : "gpt-5.2-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 Fast",
@@ -1963,7 +2039,8 @@
     },
     "id" : "gpt-5.2-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 High Fast",
@@ -1982,7 +2059,8 @@
     },
     "id" : "gpt-5.2-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 Low",
@@ -2001,7 +2079,8 @@
     },
     "id" : "gpt-5.2-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 Low Fast",
@@ -2020,7 +2099,8 @@
     },
     "id" : "gpt-5.2-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 Extra High",
@@ -2039,7 +2119,8 @@
     },
     "id" : "gpt-5.2-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.2 Extra High Fast",
@@ -2306,7 +2387,8 @@
     },
     "id" : "gpt-5.4-mini-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Mini High",
@@ -2325,7 +2407,8 @@
     },
     "id" : "gpt-5.4-mini-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Mini Low",
@@ -2344,7 +2427,8 @@
     },
     "id" : "gpt-5.4-mini-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Mini",
@@ -2363,7 +2447,8 @@
     },
     "id" : "gpt-5.4-mini-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Mini None",
@@ -2382,7 +2467,8 @@
     },
     "id" : "gpt-5.4-mini-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Mini Extra High",
@@ -2401,7 +2487,8 @@
     },
     "id" : "gpt-5.4-nano-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Nano High",
@@ -2420,7 +2507,8 @@
     },
     "id" : "gpt-5.4-nano-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Nano Low",
@@ -2439,7 +2527,8 @@
     },
     "id" : "gpt-5.4-nano-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Nano",
@@ -2458,7 +2547,8 @@
     },
     "id" : "gpt-5.4-nano-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Nano None",
@@ -2477,7 +2567,8 @@
     },
     "id" : "gpt-5.4-nano-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.4 Nano Extra High",
@@ -2534,7 +2625,8 @@
     },
     "id" : "gpt-5.5-extra-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 1M Extra High",
@@ -2553,7 +2645,8 @@
     },
     "id" : "gpt-5.5-extra-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 Extra High Fast",
@@ -2572,7 +2665,8 @@
     },
     "id" : "gpt-5.5-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 1M High",
@@ -2591,7 +2685,8 @@
     },
     "id" : "gpt-5.5-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 High Fast",
@@ -2610,7 +2705,8 @@
     },
     "id" : "gpt-5.5-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 1M Low",
@@ -2629,7 +2725,8 @@
     },
     "id" : "gpt-5.5-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 Low Fast",
@@ -2648,7 +2745,8 @@
     },
     "id" : "gpt-5.5-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 1M",
@@ -2667,7 +2765,8 @@
     },
     "id" : "gpt-5.5-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 Fast",
@@ -2686,7 +2785,8 @@
     },
     "id" : "gpt-5.5-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 1M None",
@@ -2705,7 +2805,8 @@
     },
     "id" : "gpt-5.5-none-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.5 None Fast",
@@ -2724,7 +2825,8 @@
     },
     "id" : "gpt-5.6-luna-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M High",
@@ -2743,7 +2845,8 @@
     },
     "id" : "gpt-5.6-luna-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna High Fast",
@@ -2762,7 +2865,8 @@
     },
     "id" : "gpt-5.6-luna-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M Low",
@@ -2781,7 +2885,8 @@
     },
     "id" : "gpt-5.6-luna-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna Low Fast",
@@ -2800,7 +2905,8 @@
     },
     "id" : "gpt-5.6-luna-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M Max",
@@ -2819,7 +2925,8 @@
     },
     "id" : "gpt-5.6-luna-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna Max Fast",
@@ -2838,7 +2945,8 @@
     },
     "id" : "gpt-5.6-luna-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M",
@@ -2857,7 +2965,8 @@
     },
     "id" : "gpt-5.6-luna-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna Fast",
@@ -2876,7 +2985,8 @@
     },
     "id" : "gpt-5.6-luna-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M None",
@@ -2895,7 +3005,8 @@
     },
     "id" : "gpt-5.6-luna-none-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna None Fast",
@@ -2914,7 +3025,8 @@
     },
     "id" : "gpt-5.6-luna-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna 1M Extra High",
@@ -2933,7 +3045,8 @@
     },
     "id" : "gpt-5.6-luna-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Luna Extra High Fast",
@@ -2952,7 +3065,8 @@
     },
     "id" : "gpt-5.6-sol-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M High",
@@ -2971,7 +3085,8 @@
     },
     "id" : "gpt-5.6-sol-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol High Fast",
@@ -2990,7 +3105,8 @@
     },
     "id" : "gpt-5.6-sol-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M Low",
@@ -3009,7 +3125,8 @@
     },
     "id" : "gpt-5.6-sol-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol Low Fast",
@@ -3028,7 +3145,8 @@
     },
     "id" : "gpt-5.6-sol-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M Max",
@@ -3047,7 +3165,8 @@
     },
     "id" : "gpt-5.6-sol-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol Max Fast",
@@ -3066,7 +3185,8 @@
     },
     "id" : "gpt-5.6-sol-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M",
@@ -3085,7 +3205,8 @@
     },
     "id" : "gpt-5.6-sol-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol Fast",
@@ -3104,7 +3225,8 @@
     },
     "id" : "gpt-5.6-sol-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M None",
@@ -3123,7 +3245,8 @@
     },
     "id" : "gpt-5.6-sol-none-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol None Fast",
@@ -3142,7 +3265,8 @@
     },
     "id" : "gpt-5.6-sol-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol 1M Extra High",
@@ -3161,7 +3285,8 @@
     },
     "id" : "gpt-5.6-sol-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Sol Extra High Fast",
@@ -3180,7 +3305,8 @@
     },
     "id" : "gpt-5.6-terra-high",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M High",
@@ -3199,7 +3325,8 @@
     },
     "id" : "gpt-5.6-terra-high-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra High Fast",
@@ -3218,7 +3345,8 @@
     },
     "id" : "gpt-5.6-terra-low",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M Low",
@@ -3237,7 +3365,8 @@
     },
     "id" : "gpt-5.6-terra-low-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra Low Fast",
@@ -3256,7 +3385,8 @@
     },
     "id" : "gpt-5.6-terra-max",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M Max",
@@ -3275,7 +3405,8 @@
     },
     "id" : "gpt-5.6-terra-max-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra Max Fast",
@@ -3294,7 +3425,8 @@
     },
     "id" : "gpt-5.6-terra-medium",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M",
@@ -3313,7 +3445,8 @@
     },
     "id" : "gpt-5.6-terra-medium-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra Fast",
@@ -3332,7 +3465,8 @@
     },
     "id" : "gpt-5.6-terra-none",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M None",
@@ -3351,7 +3485,8 @@
     },
     "id" : "gpt-5.6-terra-none-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra None Fast",
@@ -3370,7 +3505,8 @@
     },
     "id" : "gpt-5.6-terra-xhigh",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra 1M Extra High",
@@ -3389,7 +3525,8 @@
     },
     "id" : "gpt-5.6-terra-xhigh-fast",
     "input" : [
-      "text"
+      "text",
+      "image"
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra Extra High Fast",

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -7,7 +7,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.33000000000000002,
+        "input" : 0.33,
         "output" : 2.75
       },
       "id" : "amazon.nova-2-lite-v1:0",
@@ -25,10 +25,10 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 300000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23999999999999999
+        "input" : 0.06,
+        "output" : 0.24
       },
       "id" : "amazon.nova-lite-v1:0",
       "input" : [
@@ -45,10 +45,10 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.0087500000000000008,
+        "cacheRead" : 0.00875,
         "cacheWrite" : 0,
-        "input" : 0.035000000000000003,
-        "output" : 0.14000000000000001
+        "input" : 0.035,
+        "output" : 0.14
       },
       "id" : "amazon.nova-micro-v1:0",
       "input" : [
@@ -64,10 +64,10 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 300000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.80000000000000004,
-        "output" : 3.2000000000000002
+        "input" : 0.8,
+        "output" : 3.2
       },
       "id" : "amazon.nova-pro-v1:0",
       "input" : [
@@ -109,7 +109,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -240,7 +240,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -260,7 +260,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -283,7 +283,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -307,7 +307,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -327,7 +327,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1.6499999999999999,
+        "cacheRead" : 1.65,
         "cacheWrite" : 20.625,
         "input" : 16.5,
         "output" : 82.5
@@ -374,7 +374,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -394,9 +394,9 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.33000000000000002,
+        "cacheRead" : 0.33,
         "cacheWrite" : 4.125,
-        "input" : 3.2999999999999998,
+        "input" : 3.3,
         "output" : 16.5
       },
       "id" : "au.anthropic.claude-sonnet-4-6",
@@ -417,7 +417,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -443,8 +443,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.3500000000000001,
-        "output" : 5.4000000000000004
+        "input" : 1.35,
+        "output" : 5.4
       },
       "id" : "deepseek.r1-v1:0",
       "input" : [
@@ -462,8 +462,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.57999999999999996,
-        "output" : 1.6799999999999999
+        "input" : 0.58,
+        "output" : 1.68
       },
       "id" : "deepseek.v3-v1:0",
       "input" : [
@@ -482,7 +482,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.62,
-        "output" : 1.8500000000000001
+        "output" : 1.85
       },
       "id" : "deepseek.v3.2",
       "input" : [
@@ -498,7 +498,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1.1000000000000001,
+        "cacheRead" : 1.1,
         "cacheWrite" : 13.75,
         "input" : 11,
         "output" : 55
@@ -525,7 +525,7 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 1.375,
-        "input" : 1.1000000000000001,
+        "input" : 1.1,
         "output" : 5.5
       },
       "id" : "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -543,7 +543,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 6.875,
         "input" : 5.5,
         "output" : 27.5
@@ -563,7 +563,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 6.875,
         "input" : 5.5,
         "output" : 27.5
@@ -586,7 +586,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 6.875,
         "input" : 5.5,
         "output" : 27.5
@@ -610,7 +610,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 6.875,
         "input" : 5.5,
         "output" : 27.5
@@ -634,9 +634,9 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.33000000000000002,
+        "cacheRead" : 0.33,
         "cacheWrite" : 4.125,
-        "input" : 3.2999999999999998,
+        "input" : 3.3,
         "output" : 16.5
       },
       "id" : "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -654,9 +654,9 @@
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.33000000000000002,
+        "cacheRead" : 0.33,
         "cacheWrite" : 4.125,
-        "input" : 3.2999999999999998,
+        "input" : 3.3,
         "output" : 16.5
       },
       "id" : "eu.anthropic.claude-sonnet-4-6",
@@ -679,7 +679,7 @@
       "cost" : {
         "cacheRead" : 0.22,
         "cacheWrite" : 2.75,
-        "input" : 2.2000000000000002,
+        "input" : 2.2,
         "output" : 11
       },
       "id" : "eu.anthropic.claude-sonnet-5",
@@ -726,7 +726,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -837,7 +837,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -857,7 +857,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -880,7 +880,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -906,8 +906,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.040000000000000001,
-        "output" : 0.080000000000000002
+        "input" : 0.04,
+        "output" : 0.08
       },
       "id" : "google.gemma-3-4b-it",
       "input" : [
@@ -927,7 +927,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.12,
-        "output" : 0.20000000000000001
+        "output" : 0.2
       },
       "id" : "google.gemma-3-27b-it",
       "input" : [
@@ -944,7 +944,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -1012,7 +1012,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -1032,7 +1032,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -1055,7 +1055,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -1100,8 +1100,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
+        "input" : 0.72,
+        "output" : 0.72
       },
       "id" : "meta.llama3-1-70b-instruct-v1:0",
       "input" : [
@@ -1119,8 +1119,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
+        "input" : 0.72,
+        "output" : 0.72
       },
       "id" : "meta.llama3-3-70b-instruct-v1:0",
       "input" : [
@@ -1138,8 +1138,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.23999999999999999,
-        "output" : 0.96999999999999997
+        "input" : 0.24,
+        "output" : 0.97
       },
       "id" : "meta.llama4-maverick-17b-instruct-v1:0",
       "input" : [
@@ -1158,8 +1158,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17000000000000001,
-        "output" : 0.66000000000000003
+        "input" : 0.17,
+        "output" : 0.66
       },
       "id" : "meta.llama4-scout-17b-instruct-v1:0",
       "input" : [
@@ -1178,7 +1178,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax.minimax-m2",
@@ -1197,7 +1197,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax.minimax-m2.1",
@@ -1216,7 +1216,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax.minimax-m2.5",
@@ -1235,7 +1235,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistral.devstral-2-123b",
@@ -1274,8 +1274,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.1,
+        "output" : 0.1
       },
       "id" : "mistral.ministral-3-3b-instruct",
       "input" : [
@@ -1294,8 +1294,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistral.ministral-3-8b-instruct",
       "input" : [
@@ -1313,8 +1313,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.20000000000000001
+        "input" : 0.2,
+        "output" : 0.2
       },
       "id" : "mistral.ministral-3-14b-instruct",
       "input" : [
@@ -1372,8 +1372,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.040000000000000001,
-        "output" : 0.040000000000000001
+        "input" : 0.04,
+        "output" : 0.04
       },
       "id" : "mistral.voxtral-mini-3b-2507",
       "input" : [
@@ -1391,8 +1391,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.34999999999999998
+        "input" : 0.15,
+        "output" : 0.35
       },
       "id" : "mistral.voxtral-small-24b-2507",
       "input" : [
@@ -1410,7 +1410,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "moonshot.kimi-k2-thinking",
@@ -1429,7 +1429,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "moonshotai.kimi-k2.5",
@@ -1449,8 +1449,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23999999999999999
+        "input" : 0.06,
+        "output" : 0.24
       },
       "id" : "nvidia.nemotron-nano-3-30b",
       "input" : [
@@ -1468,8 +1468,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23000000000000001
+        "input" : 0.06,
+        "output" : 0.23
       },
       "id" : "nvidia.nemotron-nano-9b-v2",
       "input" : [
@@ -1487,8 +1487,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.59999999999999998
+        "input" : 0.2,
+        "output" : 0.6
       },
       "id" : "nvidia.nemotron-nano-12b-v2",
       "input" : [
@@ -1507,8 +1507,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.65000000000000002
+        "input" : 0.15,
+        "output" : 0.65
       },
       "id" : "nvidia.nemotron-super-3-120b",
       "input" : [
@@ -1524,7 +1524,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
         "input" : 2.75,
         "output" : 16.5
@@ -1547,7 +1547,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
         "input" : 5.5,
         "output" : 33
@@ -1572,8 +1572,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.29999999999999999
+        "input" : 0.07,
+        "output" : 0.3
       },
       "id" : "openai.gpt-oss-20b",
       "input" : [
@@ -1591,8 +1591,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.29999999999999999
+        "input" : 0.07,
+        "output" : 0.3
       },
       "id" : "openai.gpt-oss-20b-1:0",
       "input" : [
@@ -1610,8 +1610,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai.gpt-oss-120b",
       "input" : [
@@ -1629,8 +1629,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai.gpt-oss-120b-1:0",
       "input" : [
@@ -1648,8 +1648,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.20000000000000001
+        "input" : 0.07,
+        "output" : 0.2
       },
       "id" : "openai.gpt-oss-safeguard-20b",
       "input" : [
@@ -1667,8 +1667,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai.gpt-oss-safeguard-120b",
       "input" : [
@@ -1686,8 +1686,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "qwen.qwen3-32b-v1:0",
       "input" : [
@@ -1724,8 +1724,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "qwen.qwen3-coder-30b-a3b-v1:0",
       "input" : [
@@ -1781,8 +1781,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 1.3999999999999999
+        "input" : 0.14,
+        "output" : 1.4
       },
       "id" : "qwen.qwen3-next-80b-a3b",
       "input" : [
@@ -1800,7 +1800,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.5
       },
       "id" : "qwen.qwen3-vl-235b-a22b",
@@ -1843,7 +1843,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -1974,7 +1974,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -1994,7 +1994,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -2017,7 +2017,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -2043,8 +2043,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.3500000000000001,
-        "output" : 5.4000000000000004
+        "input" : 1.35,
+        "output" : 5.4
       },
       "id" : "us.deepseek.r1-v1:0",
       "input" : [
@@ -2062,8 +2062,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.23999999999999999,
-        "output" : 0.96999999999999997
+        "input" : 0.24,
+        "output" : 0.97
       },
       "id" : "us.meta.llama4-maverick-17b-instruct-v1:0",
       "input" : [
@@ -2082,8 +2082,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17000000000000001,
-        "output" : 0.66000000000000003
+        "input" : 0.17,
+        "output" : 0.66
       },
       "id" : "us.meta.llama4-scout-17b-instruct-v1:0",
       "input" : [
@@ -2121,7 +2121,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 6
       },
       "id" : "writer.palmyra-x5-v1:0",
@@ -2138,7 +2138,7 @@
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -2160,8 +2160,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai.glm-4.7",
       "input" : [
@@ -2179,8 +2179,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.40000000000000002
+        "input" : 0.07,
+        "output" : 0.4
       },
       "id" : "zai.glm-4.7-flash",
       "input" : [
@@ -2199,7 +2199,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 3.2000000000000002
+        "output" : 3.2
       },
       "id" : "zai.glm-5",
       "input" : [
@@ -2227,7 +2227,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.06,
         "output" : 0.25
       },
       "id" : "Ling-2.6-1T",
@@ -2281,7 +2281,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.06,
         "output" : 0.25
       },
       "id" : "Ring-2.6-1T",
@@ -2336,7 +2336,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -2356,7 +2356,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -2538,7 +2538,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -2558,7 +2558,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -2581,7 +2581,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -2607,7 +2607,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -2692,10 +2692,10 @@
       "baseUrl" : "",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "gpt-4.1-mini",
       "input" : [
@@ -2712,10 +2712,10 @@
       "baseUrl" : "",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "gpt-4.1-nano",
       "input" : [
@@ -2812,10 +2812,10 @@
       "baseUrl" : "",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "gpt-4o-mini",
       "input" : [
@@ -2901,7 +2901,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -2924,10 +2924,10 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.0050000000000000001,
+        "cacheRead" : 0.005,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.05,
+        "output" : 0.4
       },
       "id" : "gpt-5-nano",
       "input" : [
@@ -3062,7 +3062,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -3085,7 +3085,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3109,7 +3109,7 @@
       "baseUrl" : "",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3133,7 +3133,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3181,7 +3181,7 @@
       "baseUrl" : "",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3205,7 +3205,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3229,7 +3229,7 @@
       "baseUrl" : "",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -3277,7 +3277,7 @@
       "baseUrl" : "",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -3303,7 +3303,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "id" : "gpt-5.4-nano",
@@ -3399,7 +3399,7 @@
       "baseUrl" : "",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6
@@ -3554,10 +3554,10 @@
       "baseUrl" : "",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o3-mini",
       "input" : [
@@ -3593,10 +3593,10 @@
       "baseUrl" : "",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o4-mini",
       "input" : [
@@ -3641,7 +3641,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.98999999999999999,
+        "input" : 0.99,
         "output" : 1.49
       },
       "id" : "gemma-4-31b",
@@ -3665,7 +3665,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.34999999999999998,
+        "input" : 0.35,
         "output" : 0.75
       },
       "id" : "gpt-oss-120b",
@@ -3710,9 +3710,9 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 1,
-        "input" : 0.80000000000000004,
+        "input" : 0.8,
         "output" : 4
       },
       "id" : "claude-3-5-haiku",
@@ -3733,8 +3733,8 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0.29999999999999999,
+        "cacheRead" : 0.03,
+        "cacheWrite" : 0.3,
         "input" : 0.25,
         "output" : 1.25
       },
@@ -3779,8 +3779,8 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
-        "cacheWrite" : 0.29999999999999999,
+        "cacheRead" : 0.3,
+        "cacheWrite" : 0.3,
         "input" : 3,
         "output" : 15
       },
@@ -3802,9 +3802,9 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 1,
-        "input" : 0.80000000000000004,
+        "input" : 0.8,
         "output" : 4
       },
       "id" : "claude-3.5-haiku",
@@ -3825,7 +3825,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -3877,7 +3877,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -4054,7 +4054,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -4077,7 +4077,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -4101,7 +4101,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -4128,7 +4128,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -4211,10 +4211,10 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "gpt-4o-mini",
       "input" : [
@@ -4277,7 +4277,7 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -4301,7 +4301,7 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -4325,7 +4325,7 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -4437,10 +4437,10 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o3-mini",
       "input" : [
@@ -4476,10 +4476,10 @@
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.28000000000000003,
+        "cacheRead" : 0.28,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o4-mini",
       "input" : [
@@ -4505,9 +4505,9 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "workers-ai\/@cf\/moonshotai\/kimi-k2.5",
@@ -4536,7 +4536,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "workers-ai\/@cf\/moonshotai\/kimi-k2.6",
@@ -4593,8 +4593,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.40000000000000002
+        "input" : 0.06,
+        "output" : 0.4
       },
       "id" : "workers-ai\/@cf\/zai-org\/glm-4.7-flash",
       "input" : [
@@ -4620,8 +4620,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "@cf\/google\/gemma-4-26b-a4b-it",
       "input" : [
@@ -4646,7 +4646,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.017000000000000001,
+        "input" : 0.017,
         "output" : 0.112
       },
       "id" : "@cf\/ibm-granite\/granite-4.0-h-micro",
@@ -4671,8 +4671,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29299999999999998,
-        "output" : 2.2530000000000001
+        "input" : 0.293,
+        "output" : 2.253
       },
       "id" : "@cf\/meta\/llama-3.3-70b-instruct-fp8-fast",
       "input" : [
@@ -4696,8 +4696,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.27000000000000002,
-        "output" : 0.84999999999999998
+        "input" : 0.27,
+        "output" : 0.85
       },
       "id" : "@cf\/meta\/llama-4-scout-17b-16e-instruct",
       "input" : [
@@ -4722,8 +4722,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.35099999999999998,
-        "output" : 0.55500000000000005
+        "input" : 0.351,
+        "output" : 0.555
       },
       "id" : "@cf\/mistralai\/mistral-small-3.1-24b-instruct",
       "input" : [
@@ -4747,7 +4747,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "@cf\/moonshotai\/kimi-k2.6",
@@ -4773,7 +4773,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "@cf\/moonshotai\/kimi-k2.7-code",
@@ -4824,8 +4824,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.2,
+        "output" : 0.3
       },
       "id" : "@cf\/openai\/gpt-oss-20b",
       "input" : [
@@ -4849,7 +4849,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.34999999999999998,
+        "input" : 0.35,
         "output" : 0.75
       },
       "id" : "@cf\/openai\/gpt-oss-120b",
@@ -4874,8 +4874,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050900000000000001,
-        "output" : 0.33500000000000002
+        "input" : 0.0509,
+        "output" : 0.335
       },
       "id" : "@cf\/qwen\/qwen3-30b-a3b-fp8",
       "input" : [
@@ -4899,8 +4899,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.060499999999999998,
-        "output" : 0.40000000000000002
+        "input" : 0.0605,
+        "output" : 0.4
       },
       "id" : "@cf\/zai-org\/glm-4.7-flash",
       "input" : [
@@ -4922,10 +4922,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "@cf\/zai-org\/glm-5.2",
       "input" : [
@@ -4951,8 +4951,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek-v4-flash",
       "input" : [
@@ -4981,7 +4981,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.003625,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -5015,10 +5015,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "accounts\/fireworks\/models\/deepseek-v4-flash",
       "input" : [
@@ -5040,7 +5040,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14499999999999999,
+        "cacheRead" : 0.145,
         "cacheWrite" : 0,
         "input" : 1.74,
         "output" : 3.48
@@ -5065,10 +5065,10 @@
       },
       "contextWindow" : 202800,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "accounts\/fireworks\/models\/glm-5p1",
       "input" : [
@@ -5088,10 +5088,10 @@
       },
       "contextWindow" : 1048575,
       "cost" : {
-        "cacheRead" : 0.14000000000000001,
+        "cacheRead" : 0.14,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "accounts\/fireworks\/models\/glm-5p2",
       "input" : [
@@ -5120,10 +5120,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.035,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.29999999999999999
+        "input" : 0.07,
+        "output" : 0.3
       },
       "id" : "accounts\/fireworks\/models\/gpt-oss-20b",
       "input" : [
@@ -5145,10 +5145,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "accounts\/fireworks\/models\/gpt-oss-120b",
       "input" : [
@@ -5172,7 +5172,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "accounts\/fireworks\/models\/kimi-k2p6",
@@ -5198,7 +5198,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "accounts\/fireworks\/models\/kimi-k2p7-code",
@@ -5222,9 +5222,9 @@
       },
       "contextWindow" : 196608,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "accounts\/fireworks\/models\/minimax-m2p7",
@@ -5247,9 +5247,9 @@
       },
       "contextWindow" : 512000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "accounts\/fireworks\/models\/minimax-m3",
@@ -5272,10 +5272,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "accounts\/fireworks\/models\/qwen3p7-plus",
       "input" : [
@@ -5298,10 +5298,10 @@
       },
       "contextWindow" : 202800,
       "cost" : {
-        "cacheRead" : 0.52000000000000002,
+        "cacheRead" : 0.52,
         "cacheWrite" : 0,
-        "input" : 2.7999999999999998,
-        "output" : 8.8000000000000007
+        "input" : 2.8,
+        "output" : 8.8
       },
       "id" : "accounts\/fireworks\/routers\/glm-5p1-fast",
       "input" : [
@@ -5321,10 +5321,10 @@
       },
       "contextWindow" : 1048575,
       "cost" : {
-        "cacheRead" : 0.20999999999999999,
+        "cacheRead" : 0.21,
         "cacheWrite" : 0,
-        "input" : 2.1000000000000001,
-        "output" : 6.5999999999999996
+        "input" : 2.1,
+        "output" : 6.6
       },
       "id" : "accounts\/fireworks\/routers\/glm-5p2-fast",
       "input" : [
@@ -5353,7 +5353,7 @@
       },
       "contextWindow" : 262000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 8
@@ -5379,7 +5379,7 @@
       },
       "contextWindow" : 262000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 8
@@ -5407,7 +5407,7 @@
       "cost" : {
         "cacheRead" : 0.38,
         "cacheWrite" : 0,
-        "input" : 1.8999999999999999,
+        "input" : 1.9,
         "output" : 8
       },
       "id" : "accounts\/fireworks\/routers\/kimi-k2p7-code-fast",
@@ -5451,7 +5451,12 @@
       "maxTokens" : 128000,
       "name" : "Claude Fable 5",
       "provider" : "github-copilot",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "claude-haiku-4.5" : {
       "api" : "anthropic-messages",
@@ -5461,7 +5466,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -5618,7 +5623,7 @@
       },
       "contextWindow" : 216000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -5647,7 +5652,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -5676,7 +5681,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -5709,7 +5714,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -5775,7 +5780,7 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 3
@@ -5806,7 +5811,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -5837,7 +5842,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -5894,7 +5899,7 @@
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "contextWindow" : 264000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -5924,7 +5929,7 @@
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -5955,7 +5960,7 @@
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -5986,7 +5991,7 @@
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -6048,7 +6053,7 @@
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -6081,7 +6086,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "headers" : {
@@ -6148,7 +6153,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "headers" : {
@@ -6168,16 +6173,11 @@
       "reasoning" : true
     },
     "mai-code-1-flash-picker" : {
-      "api" : "openai-completions",
+      "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
-      },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -6204,10 +6204,10 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "gemini-2.0-flash",
       "input" : [
@@ -6226,8 +6226,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "gemini-2.0-flash-lite",
       "input" : [
@@ -6244,9 +6244,9 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "gemini-2.5-flash",
@@ -6266,8 +6266,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "gemini-2.5-flash-lite",
       "input" : [
@@ -6304,7 +6304,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 3
@@ -6327,7 +6327,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -6354,7 +6354,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -6377,7 +6377,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -6400,7 +6400,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -6427,7 +6427,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -6454,7 +6454,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -6477,7 +6477,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -6500,7 +6500,7 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -6579,9 +6579,9 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "gemini-2.5-flash",
@@ -6601,8 +6601,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "gemini-2.5-flash-lite",
       "input" : [
@@ -6639,7 +6639,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 3
@@ -6662,7 +6662,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -6685,7 +6685,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -6712,7 +6712,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -6739,7 +6739,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -6762,7 +6762,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -6785,7 +6785,7 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -6812,8 +6812,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.080000000000000002
+        "input" : 0.05,
+        "output" : 0.08
       },
       "id" : "llama-3.1-8b-instant",
       "input" : [
@@ -6831,8 +6831,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.58999999999999997,
-        "output" : 0.79000000000000004
+        "input" : 0.59,
+        "output" : 0.79
       },
       "id" : "llama-3.3-70b-versatile",
       "input" : [
@@ -6851,7 +6851,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.11,
-        "output" : 0.34000000000000002
+        "output" : 0.34
       },
       "id" : "meta-llama\/llama-4-scout-17b-16e-instruct",
       "input" : [
@@ -6868,10 +6868,10 @@
       "baseUrl" : "https:\/\/api.groq.com\/openai\/v1",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.037499999999999999,
+        "cacheRead" : 0.0375,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "openai\/gpt-oss-20b",
       "input" : [
@@ -6887,10 +6887,10 @@
       "baseUrl" : "https:\/\/api.groq.com\/openai\/v1",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
@@ -6908,8 +6908,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "openai\/gpt-oss-safeguard-20b",
       "input" : [
@@ -6927,8 +6927,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.28999999999999998,
-        "output" : 0.58999999999999997
+        "input" : 0.29,
+        "output" : 0.59
       },
       "id" : "qwen\/qwen3-32b",
       "input" : [
@@ -6957,7 +6957,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.69999999999999996,
+        "input" : 0.7,
         "output" : 2.5
       },
       "id" : "deepseek-ai\/DeepSeek-R1",
@@ -7001,8 +7001,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.28000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.28,
+        "output" : 0.4
       },
       "id" : "deepseek-ai\/DeepSeek-V3.2",
       "input" : [
@@ -7023,8 +7023,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek-ai\/DeepSeek-V4-Flash",
       "input" : [
@@ -7043,7 +7043,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.003625,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -7068,7 +7068,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 0.40000000000000002
+        "output" : 0.4
       },
       "id" : "google\/gemma-4-26B-A4B-it",
       "input" : [
@@ -7090,8 +7090,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.14,
+        "output" : 0.4
       },
       "id" : "google\/gemma-4-31B-it",
       "input" : [
@@ -7113,8 +7113,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.58999999999999997,
-        "output" : 0.79000000000000004
+        "input" : 0.59,
+        "output" : 0.79
       },
       "id" : "meta-llama\/Llama-3.3-70B-Instruct",
       "input" : [
@@ -7135,7 +7135,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M2",
@@ -7157,7 +7157,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M2.1",
@@ -7177,9 +7177,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M2.5",
@@ -7199,9 +7199,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M2.7",
@@ -7223,7 +7223,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M3",
@@ -7288,9 +7288,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "moonshotai\/Kimi-K2-Thinking",
@@ -7310,9 +7310,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "moonshotai\/Kimi-K2.5",
@@ -7335,7 +7335,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "moonshotai\/Kimi-K2.6",
@@ -7358,7 +7358,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "moonshotai\/Kimi-K2.7-Code",
@@ -7381,7 +7381,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
+        "input" : 0.1,
         "output" : 0.5
       },
       "id" : "openai\/gpt-oss-20b",
@@ -7404,7 +7404,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.25,
-        "output" : 0.68999999999999995
+        "output" : 0.69
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
@@ -7425,8 +7425,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.28999999999999998,
-        "output" : 0.58999999999999997
+        "input" : 0.29,
+        "output" : 0.59
       },
       "id" : "Qwen\/Qwen3-32B",
       "input" : [
@@ -7447,8 +7447,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.80000000000000004
+        "input" : 0.2,
+        "output" : 0.8
       },
       "id" : "Qwen\/Qwen3-235B-A22B",
       "input" : [
@@ -7469,7 +7469,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 3
       },
       "id" : "Qwen\/Qwen3-235B-A22B-Thinking-2507",
@@ -7491,8 +7491,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.26000000000000001
+        "input" : 0.07,
+        "output" : 0.26
       },
       "id" : "Qwen\/Qwen3-Coder-30B-A3B-Instruct",
       "input" : [
@@ -7535,7 +7535,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.5
       },
       "id" : "Qwen\/Qwen3-Coder-Next",
@@ -7579,7 +7579,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2
       },
       "id" : "Qwen\/Qwen3-Next-80B-A3B-Thinking",
@@ -7601,7 +7601,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17000000000000001,
+        "input" : 0.17,
         "output" : 0.25
       },
       "id" : "Qwen\/Qwen3.5-9B",
@@ -7624,8 +7624,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 2.3999999999999999
+        "input" : 0.3,
+        "output" : 2.4
       },
       "id" : "Qwen\/Qwen3.5-27B",
       "input" : [
@@ -7670,8 +7670,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 3.2000000000000002
+        "input" : 0.4,
+        "output" : 3.2
       },
       "id" : "Qwen\/Qwen3.5-122B-A10B",
       "input" : [
@@ -7693,8 +7693,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 3.6000000000000001
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "Qwen\/Qwen3.5-397B-A17B",
       "input" : [
@@ -7716,8 +7716,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.46999999999999997,
-        "output" : 3.1899999999999999
+        "input" : 0.47,
+        "output" : 3.19
       },
       "id" : "Qwen\/Qwen3.6-27B",
       "input" : [
@@ -7739,8 +7739,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.94999999999999996
+        "input" : 0.15,
+        "output" : 0.95
       },
       "id" : "Qwen\/Qwen3.6-35B-A3B",
       "input" : [
@@ -7762,8 +7762,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "stepfun-ai\/Step-3.5-Flash",
       "input" : [
@@ -7784,8 +7784,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 1.1499999999999999
+        "input" : 0.2,
+        "output" : 1.15
       },
       "id" : "stepfun-ai\/Step-3.7-Flash",
       "input" : [
@@ -7807,8 +7807,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "XiaomiMiMo\/MiMo-V2-Flash",
       "input" : [
@@ -7851,8 +7851,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai-org\/GLM-4.5",
       "input" : [
@@ -7874,7 +7874,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 0.84999999999999998
+        "output" : 0.85
       },
       "id" : "zai-org\/GLM-4.5-Air",
       "input" : [
@@ -7895,7 +7895,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 1.8
       },
       "id" : "zai-org\/GLM-4.5V",
@@ -7918,8 +7918,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.55000000000000004,
-        "output" : 2.2000000000000002
+        "input" : 0.55,
+        "output" : 2.2
       },
       "id" : "zai-org\/GLM-4.6",
       "input" : [
@@ -7940,8 +7940,8 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai-org\/GLM-4.7",
       "input" : [
@@ -7982,10 +7982,10 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 3.2000000000000002
+        "output" : 3.2
       },
       "id" : "zai-org\/GLM-5",
       "input" : [
@@ -8004,10 +8004,10 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 3.2000000000000002
+        "output" : 3.2
       },
       "id" : "zai-org\/GLM-5.1",
       "input" : [
@@ -8028,8 +8028,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "zai-org\/GLM-5.2",
       "input" : [
@@ -8117,9 +8117,9 @@
       "baseUrl" : "https:\/\/api.minimax.io\/anthropic",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMax-M2.7",
@@ -8136,10 +8136,10 @@
       "baseUrl" : "https:\/\/api.minimax.io\/anthropic",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "MiniMax-M2.7-highspeed",
       "input" : [
@@ -8155,9 +8155,9 @@
       "baseUrl" : "https:\/\/api.minimax.io\/anthropic",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMax-M3",
@@ -8177,9 +8177,9 @@
       "baseUrl" : "https:\/\/api.minimaxi.com\/anthropic",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMax-M2.7",
@@ -8196,10 +8196,10 @@
       "baseUrl" : "https:\/\/api.minimaxi.com\/anthropic",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "MiniMax-M2.7-highspeed",
       "input" : [
@@ -8215,9 +8215,9 @@
       "baseUrl" : "https:\/\/api.minimaxi.com\/anthropic",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMax-M3",
@@ -8237,10 +8237,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.3,
+        "output" : 0.9
       },
       "id" : "codestral-latest",
       "input" : [
@@ -8256,9 +8256,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "devstral-2512",
@@ -8275,9 +8275,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "devstral-latest",
@@ -8294,9 +8294,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "devstral-medium-2507",
@@ -8313,9 +8313,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "devstral-medium-latest",
@@ -8334,8 +8334,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "devstral-small-2505",
       "input" : [
@@ -8353,8 +8353,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "devstral-small-2507",
       "input" : [
@@ -8390,7 +8390,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 5
@@ -8409,7 +8409,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 1.5
@@ -8428,10 +8428,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.0040000000000000001,
+        "cacheRead" : 0.004,
         "cacheWrite" : 0,
-        "input" : 0.040000000000000001,
-        "output" : 0.040000000000000001
+        "input" : 0.04,
+        "output" : 0.04
       },
       "id" : "ministral-3b-latest",
       "input" : [
@@ -8449,8 +8449,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.1,
+        "output" : 0.1
       },
       "id" : "ministral-8b-latest",
       "input" : [
@@ -8466,7 +8466,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -8485,7 +8485,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 1.5
@@ -8505,7 +8505,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 1.5
@@ -8545,9 +8545,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistral-medium-2505",
@@ -8565,9 +8565,9 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistral-medium-2508",
@@ -8585,7 +8585,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 7.5
@@ -8605,7 +8605,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 7.5
@@ -8625,10 +8625,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistral-nemo",
       "input" : [
@@ -8646,8 +8646,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "mistral-small-2506",
       "input" : [
@@ -8664,10 +8664,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "mistral-small-2603",
       "input" : [
@@ -8684,10 +8684,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "mistral-small-latest",
       "input" : [
@@ -8704,7 +8704,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 8000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 0.25
@@ -8723,10 +8723,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "open-mistral-nemo",
       "input" : [
@@ -8742,10 +8742,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 32000,
       "cost" : {
-        "cacheRead" : 0.070000000000000007,
+        "cacheRead" : 0.07,
         "cacheWrite" : 0,
-        "input" : 0.69999999999999996,
-        "output" : 0.69999999999999996
+        "input" : 0.7,
+        "output" : 0.7
       },
       "id" : "open-mixtral-8x7b",
       "input" : [
@@ -8761,7 +8761,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 64000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -8780,10 +8780,10 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "pixtral-12b",
       "input" : [
@@ -8800,7 +8800,7 @@
       "baseUrl" : "https:\/\/api.mistral.ai",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -8830,9 +8830,9 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-0711-preview",
@@ -8857,9 +8857,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-0905-preview",
@@ -8884,9 +8884,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-thinking",
@@ -8911,9 +8911,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 1.1499999999999999,
+        "input" : 1.15,
         "output" : 8
       },
       "id" : "kimi-k2-thinking-turbo",
@@ -8938,9 +8938,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.59999999999999998,
+        "cacheRead" : 0.6,
         "cacheWrite" : 0,
-        "input" : 2.3999999999999999,
+        "input" : 2.4,
         "output" : 10
       },
       "id" : "kimi-k2-turbo-preview",
@@ -8965,9 +8965,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "kimi-k2.5",
@@ -8995,7 +8995,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.6",
@@ -9023,7 +9023,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.7-code",
@@ -9054,7 +9054,7 @@
       "cost" : {
         "cacheRead" : 0.38,
         "cacheWrite" : 0,
-        "input" : 1.8999999999999999,
+        "input" : 1.9,
         "output" : 8
       },
       "id" : "kimi-k2.7-code-highspeed",
@@ -9085,9 +9085,9 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-0711-preview",
@@ -9112,9 +9112,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-0905-preview",
@@ -9139,9 +9139,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "kimi-k2-thinking",
@@ -9166,9 +9166,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 1.1499999999999999,
+        "input" : 1.15,
         "output" : 8
       },
       "id" : "kimi-k2-thinking-turbo",
@@ -9193,9 +9193,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.59999999999999998,
+        "cacheRead" : 0.6,
         "cacheWrite" : 0,
-        "input" : 2.3999999999999999,
+        "input" : 2.4,
         "output" : 10
       },
       "id" : "kimi-k2-turbo-preview",
@@ -9220,9 +9220,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "kimi-k2.5",
@@ -9250,7 +9250,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.6",
@@ -9278,7 +9278,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.7-code",
@@ -9309,7 +9309,7 @@
       "cost" : {
         "cacheRead" : 0.38,
         "cacheWrite" : 0,
-        "input" : 1.8999999999999999,
+        "input" : 1.9,
         "output" : 8
       },
       "id" : "kimi-k2.7-code-highspeed",
@@ -9679,8 +9679,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.80000000000000004
+        "input" : 0.2,
+        "output" : 0.8
       },
       "headers" : {
         "NVCF-POLL-SECONDS" : "3600"
@@ -9707,7 +9707,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 2.5
@@ -10002,10 +10002,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "gpt-4.1-mini",
       "input" : [
@@ -10022,10 +10022,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "gpt-4.1-nano",
       "input" : [
@@ -10122,10 +10122,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "gpt-4o-mini",
       "input" : [
@@ -10211,7 +10211,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -10234,10 +10234,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.0050000000000000001,
+        "cacheRead" : 0.005,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.05,
+        "output" : 0.4
       },
       "id" : "gpt-5-nano",
       "input" : [
@@ -10372,7 +10372,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -10395,7 +10395,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10419,7 +10419,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10443,7 +10443,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10491,7 +10491,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10515,7 +10515,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10539,7 +10539,7 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -10561,6 +10561,9 @@
     "gpt-5.4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -10594,9 +10597,12 @@
     "gpt-5.4-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -10622,7 +10628,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "id" : "gpt-5.4-nano",
@@ -10642,6 +10648,9 @@
     "gpt-5.4-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0,
@@ -10675,6 +10684,9 @@
     "gpt-5.5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -10744,15 +10756,18 @@
     "gpt-5.6-luna" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6,
         "tiers" : [
           {
-            "cacheRead" : 0.20000000000000001,
+            "cacheRead" : 0.2,
             "cacheWrite" : 2.5,
             "input" : 2,
             "inputTokensAbove" : 272000,
@@ -10778,6 +10793,9 @@
     "gpt-5.6-sol" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -10812,6 +10830,9 @@
     "gpt-5.6-terra" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -10928,10 +10949,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o3-mini",
       "input" : [
@@ -10967,10 +10988,10 @@
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "o4-mini",
       "input" : [
@@ -11009,7 +11030,7 @@
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -11030,6 +11051,9 @@
     "gpt-5.4" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -11063,9 +11087,12 @@
     "gpt-5.4-mini" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -11087,6 +11114,9 @@
     "gpt-5.5" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -11120,15 +11150,18 @@
     "gpt-5.6-luna" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 372000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6,
         "tiers" : [
           {
-            "cacheRead" : 0.20000000000000001,
+            "cacheRead" : 0.2,
             "cacheWrite" : 2.5,
             "input" : 2,
             "inputTokensAbove" : 272000,
@@ -11154,6 +11187,9 @@
     "gpt-5.6-sol" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 372000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -11188,6 +11224,9 @@
     "gpt-5.6-terra" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsToolSearch" : true
+      },
       "contextWindow" : 372000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -11278,7 +11317,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -11420,7 +11459,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -11440,7 +11479,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -11463,7 +11502,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -11489,7 +11528,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -11520,10 +11559,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek-v4-flash",
       "input" : [
@@ -11585,10 +11624,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14499999999999999,
+        "cacheRead" : 0.145,
         "cacheWrite" : 0,
         "input" : 1.74,
-        "output" : 3.8399999999999999
+        "output" : 3.84
       },
       "id" : "deepseek-v4-pro",
       "input" : [
@@ -11611,7 +11650,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 3
@@ -11634,7 +11673,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -11661,7 +11700,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -11689,10 +11728,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 3.2000000000000002
+        "output" : 3.2
       },
       "id" : "glm-5",
       "input" : [
@@ -11713,10 +11752,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.1",
       "input" : [
@@ -11737,10 +11776,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.2",
       "input" : [
@@ -11758,7 +11797,7 @@
       "cost" : {
         "cacheRead" : 0.107,
         "cacheWrite" : 0,
-        "input" : 1.0700000000000001,
+        "input" : 1.07,
         "output" : 8.5
       },
       "id" : "gpt-5",
@@ -11781,7 +11820,7 @@
       "cost" : {
         "cacheRead" : 0.107,
         "cacheWrite" : 0,
-        "input" : 1.0700000000000001,
+        "input" : 1.07,
         "output" : 8.5
       },
       "id" : "gpt-5-codex",
@@ -11802,10 +11841,10 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.0050000000000000001,
+        "cacheRead" : 0.005,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.05,
+        "output" : 0.4
       },
       "id" : "gpt-5-nano",
       "input" : [
@@ -11827,7 +11866,7 @@
       "cost" : {
         "cacheRead" : 0.107,
         "cacheWrite" : 0,
-        "input" : 1.0700000000000001,
+        "input" : 1.07,
         "output" : 8.5
       },
       "id" : "gpt-5.1",
@@ -11850,7 +11889,7 @@
       "cost" : {
         "cacheRead" : 0.107,
         "cacheWrite" : 0,
-        "input" : 1.0700000000000001,
+        "input" : 1.07,
         "output" : 8.5
       },
       "id" : "gpt-5.1-codex",
@@ -11894,7 +11933,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -11917,7 +11956,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -11941,7 +11980,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -11965,7 +12004,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -12013,7 +12052,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -12039,7 +12078,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "id" : "gpt-5.4-nano",
@@ -12166,7 +12205,7 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 2
@@ -12222,9 +12261,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "kimi-k2.5",
@@ -12252,7 +12291,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.6",
@@ -12277,7 +12316,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.7-code",
@@ -12325,9 +12364,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax-m2.5",
@@ -12350,9 +12389,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax-m2.7",
@@ -12374,9 +12413,9 @@
       },
       "contextWindow" : 512000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax-m3",
@@ -12444,7 +12483,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0.25,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.2
       },
       "id" : "qwen3.5-plus",
@@ -12462,7 +12501,7 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0.625,
         "input" : 0.5,
         "output" : 3
@@ -12493,8 +12532,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek-v4-flash",
       "input" : [
@@ -12524,7 +12563,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.014500000000000001,
+        "cacheRead" : 0.0145,
         "cacheWrite" : 0,
         "input" : 1.74,
         "output" : 3.48
@@ -12555,10 +12594,10 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.1",
       "input" : [
@@ -12579,10 +12618,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.2",
       "input" : [
@@ -12616,7 +12655,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.6",
@@ -12646,7 +12685,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "kimi-k2.7-code",
@@ -12671,8 +12710,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -12694,7 +12733,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.014500000000000001,
+        "cacheRead" : 0.0145,
         "cacheWrite" : 0,
         "input" : 1.74,
         "output" : 3.48
@@ -12718,9 +12757,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax-m2.7",
@@ -12737,9 +12776,9 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax-m3",
@@ -12763,7 +12802,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0.625,
         "input" : 0.5,
         "output" : 3
@@ -12802,10 +12841,10 @@
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0.5,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "qwen3.7-plus",
       "input" : [
@@ -12852,7 +12891,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -12900,7 +12939,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -12924,8 +12963,8 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
-        "cacheWrite" : 0.083333000000000004,
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0.083333,
         "input" : 1.5,
         "output" : 9
       },
@@ -12948,7 +12987,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0.375,
         "input" : 2,
         "output" : 12
@@ -12972,10 +13011,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.66000000000000003,
-        "output" : 3.4100000000000001
+        "input" : 0.66,
+        "output" : 3.41
       },
       "id" : "~moonshotai\/kimi-latest",
       "input" : [
@@ -13020,7 +13059,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -13091,10 +13130,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.80000000000000004,
-        "output" : 1.6000000000000001
+        "input" : 0.8,
+        "output" : 1.6
       },
       "id" : "aion-labs\/aion-2.0",
       "input" : [
@@ -13137,10 +13176,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.17999999999999999,
+        "cacheRead" : 0.18,
         "cacheWrite" : 0,
-        "input" : 0.69999999999999996,
-        "output" : 1.3999999999999999
+        "input" : 0.7,
+        "output" : 1.4
       },
       "id" : "aion-labs\/aion-3.0-mini",
       "input" : [
@@ -13162,7 +13201,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "amazon\/nova-2-lite-v1",
@@ -13186,8 +13225,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23999999999999999
+        "input" : 0.06,
+        "output" : 0.24
       },
       "id" : "amazon\/nova-lite-v1",
       "input" : [
@@ -13210,8 +13249,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.035000000000000003,
-        "output" : 0.14000000000000001
+        "input" : 0.035,
+        "output" : 0.14
       },
       "id" : "amazon\/nova-micro-v1",
       "input" : [
@@ -13257,8 +13296,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.80000000000000004,
-        "output" : 3.2000000000000002
+        "input" : 0.8,
+        "output" : 3.2
       },
       "id" : "amazon\/nova-pro-v1",
       "input" : [
@@ -13279,8 +13318,8 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0.29999999999999999,
+        "cacheRead" : 0.03,
+        "cacheWrite" : 0.3,
         "input" : 0.25,
         "output" : 1.25
       },
@@ -13316,7 +13355,12 @@
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Fable 5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "anthropic\/claude-haiku-4.5" : {
       "api" : "openai-completions",
@@ -13327,7 +13371,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -13562,7 +13606,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -13586,7 +13630,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -13610,7 +13654,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -13637,7 +13681,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -13665,10 +13709,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
         "input" : 0.25,
-        "output" : 0.80000000000000004
+        "output" : 0.8
       },
       "id" : "arcee-ai\/trinity-large-thinking",
       "input" : [
@@ -13690,8 +13734,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.044999999999999998,
-        "output" : 0.14999999999999999
+        "input" : 0.045,
+        "output" : 0.15
       },
       "id" : "arcee-ai\/trinity-mini",
       "input" : [
@@ -13784,8 +13828,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "bytedance-seed\/seed-1.6-flash",
       "input" : [
@@ -13832,8 +13876,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "bytedance-seed\/seed-2.0-mini",
       "input" : [
@@ -13856,8 +13900,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "cohere\/command-r-08-2024",
       "input" : [
@@ -13921,12 +13965,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20019999999999999,
-        "output" : 0.80010000000000003
+        "input" : 0.2002,
+        "output" : 0.8001
       },
       "id" : "deepseek\/deepseek-chat",
       "input" : [
@@ -13946,10 +13990,10 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.13500000000000001,
+        "cacheRead" : 0.135,
         "cacheWrite" : 0,
-        "input" : 0.23999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.24,
+        "output" : 0.9
       },
       "id" : "deepseek\/deepseek-chat-v3-0324",
       "input" : [
@@ -13971,8 +14015,8 @@
       "cost" : {
         "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.20999999999999999,
-        "output" : 0.79000000000000004
+        "input" : 0.21,
+        "output" : 0.79
       },
       "id" : "deepseek\/deepseek-chat-v3.1",
       "input" : [
@@ -13990,11 +14034,11 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 163840,
+      "contextWindow" : 64000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.69999999999999996,
+        "input" : 0.7,
         "output" : 2.5
       },
       "id" : "deepseek\/deepseek-r1",
@@ -14015,10 +14059,10 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.34999999999999998,
+        "cacheRead" : 0.35,
         "cacheWrite" : 0,
         "input" : 0.5,
-        "output" : 2.1499999999999999
+        "output" : 2.15
       },
       "id" : "deepseek\/deepseek-r1-0528",
       "input" : [
@@ -14040,8 +14084,8 @@
       "cost" : {
         "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.27000000000000002,
-        "output" : 0.94999999999999996
+        "input" : 0.27,
+        "output" : 0.95
       },
       "id" : "deepseek\/deepseek-v3.1-terminus",
       "input" : [
@@ -14059,12 +14103,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.022880000000000001,
+        "cacheRead" : 0.02145,
         "cacheWrite" : 0,
-        "input" : 0.2288,
-        "output" : 0.34320000000000001
+        "input" : 0.2145,
+        "output" : 0.32175
       },
       "id" : "deepseek\/deepseek-v3.2",
       "input" : [
@@ -14086,8 +14130,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.27000000000000002,
-        "output" : 0.40999999999999998
+        "input" : 0.27,
+        "output" : 0.41
       },
       "id" : "deepseek\/deepseek-v3.2-exp",
       "input" : [
@@ -14108,10 +14152,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.017999999999999999,
+        "cacheRead" : 0.018,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.17999999999999999
+        "input" : 0.09,
+        "output" : 0.18
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -14140,7 +14184,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.003625,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -14171,9 +14215,9 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 0.29999999999999999,
+        "cacheRead" : 0.03,
+        "cacheWrite" : 0.083333,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "google\/gemini-2.5-flash",
@@ -14196,9 +14240,9 @@
       "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.01,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "cacheWrite" : 0.083333,
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "google\/gemini-2.5-flash-lite",
       "input" : [
@@ -14291,8 +14335,8 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0.083333000000000004,
+        "cacheRead" : 0.05,
+        "cacheWrite" : 0.083333,
         "input" : 0.5,
         "output" : 3
       },
@@ -14315,7 +14359,7 @@
       },
       "contextWindow" : 65536,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0.375,
         "input" : 2,
         "output" : 12
@@ -14339,8 +14383,8 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0.083333000000000004,
+        "cacheRead" : 0.025,
+        "cacheWrite" : 0.083333,
         "input" : 0.25,
         "output" : 1.5
       },
@@ -14363,8 +14407,8 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0.083333000000000004,
+        "cacheRead" : 0.025,
+        "cacheWrite" : 0.083333,
         "input" : 0.25,
         "output" : 1.5
       },
@@ -14387,7 +14431,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0.375,
         "input" : 2,
         "output" : 12
@@ -14409,9 +14453,9 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048756,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0.375,
         "input" : 2,
         "output" : 12
@@ -14435,8 +14479,8 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
-        "cacheWrite" : 0.083333000000000004,
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0.083333,
         "input" : 1.5,
         "output" : 9
       },
@@ -14461,8 +14505,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.14999999999999999
+        "input" : 0.05,
+        "output" : 0.15
       },
       "id" : "google\/gemma-3-12b-it",
       "input" : [
@@ -14485,7 +14529,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
+        "input" : 0.08,
         "output" : 0.16
       },
       "id" : "google\/gemma-3-27b-it",
@@ -14509,8 +14553,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.33000000000000002
+        "input" : 0.06,
+        "output" : 0.33
       },
       "id" : "google\/gemma-4-26b-a4b-it",
       "input" : [
@@ -14529,7 +14573,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14555,10 +14599,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.089999999999999997,
+        "cacheRead" : 0.09,
         "cacheWrite" : 0,
         "input" : 0.12,
-        "output" : 0.34999999999999998
+        "output" : 0.35
       },
       "id" : "google\/gemma-4-31b-it",
       "input" : [
@@ -14603,10 +14647,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.10000000000000001
+        "input" : 0.05,
+        "output" : 0.1
       },
       "id" : "ibm-granite\/granite-4.1-8b",
       "input" : [
@@ -14626,7 +14670,7 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 0.75
@@ -14652,9 +14696,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
+        "input" : 0.075,
         "output" : 0.625
       },
       "id" : "inclusionai\/ling-2.6-1t",
@@ -14678,7 +14722,7 @@
         "cacheRead" : 0.002,
         "cacheWrite" : 0,
         "input" : 0.01,
-        "output" : 0.029999999999999999
+        "output" : 0.03
       },
       "id" : "inclusionai\/ling-2.6-flash",
       "input" : [
@@ -14698,9 +14742,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
+        "input" : 0.075,
         "output" : 0.625
       },
       "id" : "inclusionai\/ring-2.6-1t",
@@ -14721,9 +14765,9 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "kwaipilot\/kat-coder-pro-v2",
@@ -14770,7 +14814,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.02,
-        "output" : 0.029999999999999999
+        "output" : 0.03
       },
       "id" : "meta-llama\/llama-3.1-8b-instruct",
       "input" : [
@@ -14792,8 +14836,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 0.40000000000000002
+        "input" : 0.4,
+        "output" : 0.4
       },
       "id" : "meta-llama\/llama-3.1-70b-instruct",
       "input" : [
@@ -14815,8 +14859,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.32000000000000001
+        "input" : 0.1,
+        "output" : 0.32
       },
       "id" : "meta-llama\/llama-3.3-70b-instruct",
       "input" : [
@@ -14834,7 +14878,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 65536,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -14861,8 +14905,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "meta-llama\/llama-4-maverick",
       "input" : [
@@ -14881,12 +14925,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 10000000,
+      "contextWindow" : 327680,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "meta-llama\/llama-4-scout",
       "input" : [
@@ -14909,8 +14953,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 2.2000000000000002
+        "input" : 0.4,
+        "output" : 2.2
       },
       "id" : "minimax\/minimax-m1",
       "input" : [
@@ -14953,9 +14997,9 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.1",
@@ -14974,12 +15018,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 204800,
+      "contextWindow" : 196608,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.15,
+        "output" : 0.9
       },
       "id" : "minimax\/minimax-m2.5",
       "input" : [
@@ -14997,12 +15041,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 204800,
+      "contextWindow" : 196608,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.23999999999999999,
-        "output" : 0.95999999999999996
+        "input" : 0.24,
+        "output" : 0.96
       },
       "id" : "minimax\/minimax-m2.7",
       "input" : [
@@ -15020,11 +15064,11 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m3",
@@ -15046,10 +15090,10 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.3,
+        "output" : 0.9
       },
       "id" : "mistralai\/codestral-2508",
       "input" : [
@@ -15069,9 +15113,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistralai\/devstral-2512",
@@ -15094,8 +15138,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.1,
+        "output" : 0.1
       },
       "id" : "mistralai\/ministral-3b-2512",
       "input" : [
@@ -15116,10 +15160,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistralai\/ministral-8b-2512",
       "input" : [
@@ -15142,8 +15186,8 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.20000000000000001
+        "input" : 0.2,
+        "output" : 0.2
       },
       "id" : "mistralai\/ministral-14b-2512",
       "input" : [
@@ -15164,7 +15208,7 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -15187,7 +15231,7 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -15210,7 +15254,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 1.5
@@ -15234,9 +15278,9 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistralai\/mistral-medium-3",
@@ -15282,9 +15326,9 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistralai\/mistral-medium-3.1",
@@ -15309,7 +15353,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.02,
-        "output" : 0.029999999999999999
+        "output" : 0.03
       },
       "id" : "mistralai\/mistral-nemo",
       "input" : [
@@ -15331,8 +15375,8 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.59999999999999998
+        "input" : 0.2,
+        "output" : 0.6
       },
       "id" : "mistralai\/mistral-saba",
       "input" : [
@@ -15354,8 +15398,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.20000000000000001
+        "input" : 0.075,
+        "output" : 0.2
       },
       "id" : "mistralai\/mistral-small-3.2-24b-instruct",
       "input" : [
@@ -15376,10 +15420,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "mistralai\/mistral-small-2603",
       "input" : [
@@ -15400,7 +15444,7 @@
       },
       "contextWindow" : 65536,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -15425,8 +15469,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "mistralai\/voxtral-small-24b-2507",
       "input" : [
@@ -15448,8 +15492,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.56999999999999995,
-        "output" : 2.2999999999999998
+        "input" : 0.57,
+        "output" : 2.3
       },
       "id" : "moonshotai\/kimi-k2",
       "input" : [
@@ -15471,7 +15515,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "moonshotai\/kimi-k2-0905",
@@ -15492,9 +15536,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 2.5
       },
       "id" : "moonshotai\/kimi-k2-thinking",
@@ -15513,12 +15557,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.070000000000000007,
+        "cacheRead" : 0.07,
         "cacheWrite" : 0,
-        "input" : 0.40999999999999998,
-        "output" : 2.0600000000000001
+        "input" : 0.41,
+        "output" : 2.06
       },
       "id" : "moonshotai\/kimi-k2.5",
       "input" : [
@@ -15540,10 +15584,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.66000000000000003,
-        "output" : 3.4100000000000001
+        "input" : 0.66,
+        "output" : 3.41
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -15566,8 +15610,8 @@
       "cost" : {
         "cacheRead" : 0.159,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 3.4900000000000002
+        "input" : 0.72,
+        "output" : 3.49
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -15588,10 +15632,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.0025000000000000001,
+        "cacheRead" : 0.0025,
         "cacheWrite" : 0,
-        "input" : 0.025000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.025,
+        "output" : 0.1
       },
       "id" : "nex-agi\/nex-n2-mini",
       "input" : [
@@ -15612,7 +15656,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1
@@ -15638,8 +15682,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 0.40000000000000002
+        "input" : 0.4,
+        "output" : 0.4
       },
       "id" : "nvidia\/llama-3.3-nemotron-super-49b-v1.5",
       "input" : [
@@ -15661,8 +15705,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.20000000000000001
+        "input" : 0.05,
+        "output" : 0.2
       },
       "id" : "nvidia\/nemotron-3-nano-30b-a3b",
       "input" : [
@@ -15727,12 +15771,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1000000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.45000000000000001
+        "input" : 0.08,
+        "output" : 0.45
       },
       "id" : "nvidia\/nemotron-3-super-120b-a12b",
       "input" : [
@@ -15750,7 +15794,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1000000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -15773,12 +15817,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1000000,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
         "input" : 0.5,
-        "output" : 2.2000000000000002
+        "output" : 2.2
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
@@ -16023,10 +16067,10 @@
       },
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "openai\/gpt-4.1-mini",
       "input" : [
@@ -16046,10 +16090,10 @@
       },
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "openai\/gpt-4.1-nano",
       "input" : [
@@ -16161,10 +16205,10 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-4o-mini",
       "input" : [
@@ -16184,10 +16228,10 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-4o-mini-2024-07-18",
       "input" : [
@@ -16253,7 +16297,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -16278,8 +16322,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.05,
+        "output" : 0.4
       },
       "id" : "openai\/gpt-5-nano",
       "input" : [
@@ -16414,7 +16458,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -16437,7 +16481,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -16463,7 +16507,7 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -16489,7 +16533,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -16541,7 +16585,7 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -16567,7 +16611,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -16619,7 +16663,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -16647,7 +16691,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "id" : "openai\/gpt-5.4-nano",
@@ -16752,7 +16796,7 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6
@@ -16779,7 +16823,7 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6
@@ -16938,8 +16982,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "openai\/gpt-audio-mini",
       "input" : [
@@ -16983,8 +17027,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.029000000000000001,
-        "output" : 0.14000000000000001
+        "input" : 0.029,
+        "output" : 0.14
       },
       "id" : "openai\/gpt-oss-20b",
       "input" : [
@@ -17027,8 +17071,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.035999999999999997,
-        "output" : 0.17999999999999999
+        "input" : 0.036,
+        "output" : 0.18
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
@@ -17069,10 +17113,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.037499999999999999,
+        "cacheRead" : 0.0375,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "openai\/gpt-oss-safeguard-20b",
       "input" : [
@@ -17160,10 +17204,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o3-mini",
       "input" : [
@@ -17182,10 +17226,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o3-mini-high",
       "input" : [
@@ -17227,10 +17271,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o4-mini",
       "input" : [
@@ -17273,10 +17317,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o4-mini-high",
       "input" : [
@@ -17368,10 +17412,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.2,
+        "output" : 0.4
       },
       "id" : "poolside\/laguna-m.1",
       "input" : [
@@ -17414,9 +17458,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.06,
         "output" : 0.12
       },
       "id" : "poolside\/laguna-xs-2.1",
@@ -17458,12 +17502,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 32768,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.040000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.04,
+        "output" : 0.1
       },
       "id" : "qwen\/qwen-2.5-7b-instruct",
       "input" : [
@@ -17481,12 +17525,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 32768,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.35999999999999999,
-        "output" : 0.40000000000000002
+        "input" : 0.36,
+        "output" : 0.4
       },
       "id" : "qwen\/qwen-2.5-72b-instruct",
       "input" : [
@@ -17506,10 +17550,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.051999999999999998,
-        "cacheWrite" : 0.32500000000000001,
-        "input" : 0.26000000000000001,
-        "output" : 0.78000000000000003
+        "cacheRead" : 0.052,
+        "cacheWrite" : 0.325,
+        "input" : 0.26,
+        "output" : 0.78
       },
       "id" : "qwen\/qwen-plus",
       "input" : [
@@ -17531,8 +17575,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26000000000000001,
-        "output" : 0.78000000000000003
+        "input" : 0.26,
+        "output" : 0.78
       },
       "id" : "qwen\/qwen-plus-2025-07-28",
       "input" : [
@@ -17553,9 +17597,9 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.32500000000000001,
-        "input" : 0.26000000000000001,
-        "output" : 0.78000000000000003
+        "cacheWrite" : 0.325,
+        "input" : 0.26,
+        "output" : 0.78
       },
       "id" : "qwen\/qwen-plus-2025-07-28:thinking",
       "input" : [
@@ -17577,8 +17621,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.11700000000000001,
-        "output" : 0.45500000000000002
+        "input" : 0.117,
+        "output" : 0.455
       },
       "id" : "qwen\/qwen3-8b",
       "input" : [
@@ -17596,12 +17640,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131702,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.23999999999999999
+        "input" : 0.1,
+        "output" : 0.24
       },
       "id" : "qwen\/qwen3-14b",
       "input" : [
@@ -17619,7 +17663,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -17642,11 +17686,11 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.048149999999999998,
+        "input" : 0.04815,
         "output" : 0.19305
       },
       "id" : "qwen\/qwen3-30b-a3b-instruct-2507",
@@ -17665,12 +17709,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 81920,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 1.5600000000000001
+        "output" : 1.56
       },
       "id" : "qwen\/qwen3-30b-a3b-thinking-2507",
       "input" : [
@@ -17688,12 +17732,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.28000000000000003
+        "input" : 0.08,
+        "output" : 0.28
       },
       "id" : "qwen\/qwen3-32b",
       "input" : [
@@ -17715,8 +17759,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.45500000000000002,
-        "output" : 1.8200000000000001
+        "input" : 0.455,
+        "output" : 1.82
       },
       "id" : "qwen\/qwen3-235b-a22b",
       "input" : [
@@ -17738,8 +17782,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.10000000000000001
+        "input" : 0.09,
+        "output" : 0.1
       },
       "id" : "qwen\/qwen3-235b-a22b-2507",
       "input" : [
@@ -17757,12 +17801,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14949999999999999,
-        "output" : 1.4950000000000001
+        "input" : 0.1495,
+        "output" : 1.495
       },
       "id" : "qwen\/qwen3-235b-a22b-thinking-2507",
       "input" : [
@@ -17780,7 +17824,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -17807,8 +17851,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.27000000000000002
+        "input" : 0.07,
+        "output" : 0.27
       },
       "id" : "qwen\/qwen3-coder-30b-a3b-instruct",
       "input" : [
@@ -17829,9 +17873,9 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.039,
-        "cacheWrite" : 0.24374999999999999,
-        "input" : 0.19500000000000001,
-        "output" : 0.97499999999999998
+        "cacheWrite" : 0.24375,
+        "input" : 0.195,
+        "output" : 0.975
       },
       "id" : "qwen\/qwen3-coder-flash",
       "input" : [
@@ -17851,10 +17895,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.070000000000000007,
+        "cacheRead" : 0.07,
         "cacheWrite" : 0,
         "input" : 0.11,
-        "output" : 0.80000000000000004
+        "output" : 0.8
       },
       "id" : "qwen\/qwen3-coder-next",
       "input" : [
@@ -17876,7 +17920,7 @@
       "cost" : {
         "cacheRead" : 0.13,
         "cacheWrite" : 0.8125,
-        "input" : 0.65000000000000002,
+        "input" : 0.65,
         "output" : 3.25
       },
       "id" : "qwen\/qwen3-coder-plus",
@@ -17895,7 +17939,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 262000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -17921,9 +17965,9 @@
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.156,
-        "cacheWrite" : 0.97499999999999998,
-        "input" : 0.78000000000000003,
-        "output" : 3.8999999999999999
+        "cacheWrite" : 0.975,
+        "input" : 0.78,
+        "output" : 3.9
       },
       "id" : "qwen\/qwen3-max",
       "input" : [
@@ -17945,8 +17989,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.78000000000000003,
-        "output" : 3.8999999999999999
+        "input" : 0.78,
+        "output" : 3.9
       },
       "id" : "qwen\/qwen3-max-thinking",
       "input" : [
@@ -17968,8 +18012,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 1.1000000000000001
+        "input" : 0.09,
+        "output" : 1.1
       },
       "id" : "qwen\/qwen3-next-80b-a3b-instruct",
       "input" : [
@@ -18010,12 +18054,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.097500000000000003,
-        "output" : 0.78000000000000003
+        "input" : 0.0975,
+        "output" : 0.78
       },
       "id" : "qwen\/qwen3-next-80b-a3b-thinking",
       "input" : [
@@ -18033,12 +18077,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.11700000000000001,
-        "output" : 0.45500000000000002
+        "input" : 0.117,
+        "output" : 0.455
       },
       "id" : "qwen\/qwen3-vl-8b-instruct",
       "input" : [
@@ -18057,11 +18101,11 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.11700000000000001,
+        "input" : 0.117,
         "output" : 1.365
       },
       "id" : "qwen\/qwen3-vl-8b-thinking",
@@ -18081,12 +18125,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 0.52000000000000002
+        "output" : 0.52
       },
       "id" : "qwen\/qwen3-vl-30b-a3b-instruct",
       "input" : [
@@ -18110,7 +18154,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 1.5600000000000001
+        "output" : 1.56
       },
       "id" : "qwen\/qwen3-vl-30b-a3b-thinking",
       "input" : [
@@ -18129,12 +18173,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.104,
-        "output" : 0.41599999999999998
+        "output" : 0.416
       },
       "id" : "qwen\/qwen3-vl-32b-instruct",
       "input" : [
@@ -18157,7 +18201,7 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 0.88
       },
       "id" : "qwen\/qwen3-vl-235b-a22b-instruct",
@@ -18181,8 +18225,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26000000000000001,
-        "output" : 2.6000000000000001
+        "input" : 0.26,
+        "output" : 2.6
       },
       "id" : "qwen\/qwen3-vl-235b-a22b-thinking",
       "input" : [
@@ -18205,8 +18249,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.14999999999999999
+        "input" : 0.1,
+        "output" : 0.15
       },
       "id" : "qwen\/qwen3.5-9b",
       "input" : [
@@ -18229,8 +18273,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.19500000000000001,
-        "output" : 1.5600000000000001
+        "input" : 0.195,
+        "output" : 1.56
       },
       "id" : "qwen\/qwen3.5-27b",
       "input" : [
@@ -18251,9 +18295,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
+        "input" : 0.14,
         "output" : 1
       },
       "id" : "qwen\/qwen3.5-35b-a3b",
@@ -18277,8 +18321,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26000000000000001,
-        "output" : 2.0800000000000001
+        "input" : 0.26,
+        "output" : 2.08
       },
       "id" : "qwen\/qwen3.5-122b-a10b",
       "input" : [
@@ -18297,12 +18341,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0.111,
         "cacheWrite" : 0,
-        "input" : 0.38500000000000001,
-        "output" : 2.4500000000000002
+        "input" : 0.385,
+        "output" : 2.45
       },
       "id" : "qwen\/qwen3.5-397b-a17b",
       "input" : [
@@ -18325,8 +18369,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.065000000000000002,
-        "output" : 0.26000000000000001
+        "input" : 0.065,
+        "output" : 0.26
       },
       "id" : "qwen\/qwen3.5-flash-02-23",
       "input" : [
@@ -18349,8 +18393,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26000000000000001,
-        "output" : 1.5600000000000001
+        "input" : 0.26,
+        "output" : 1.56
       },
       "id" : "qwen\/qwen3.5-plus-02-15",
       "input" : [
@@ -18373,7 +18417,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.8
       },
       "id" : "qwen\/qwen3.5-plus-20260420",
@@ -18393,12 +18437,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 262140,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.28499999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.285,
+        "output" : 2.4
       },
       "id" : "qwen\/qwen3.6-27b",
       "input" : [
@@ -18421,7 +18465,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
+        "input" : 0.14,
         "output" : 1
       },
       "id" : "qwen\/qwen3.6-35b-a3b",
@@ -18470,7 +18514,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 1.3,
         "input" : 1.04,
-        "output" : 6.2400000000000002
+        "output" : 6.24
       },
       "id" : "qwen\/qwen3.6-max-preview",
       "input" : [
@@ -18492,7 +18536,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0.40625,
-        "input" : 0.32500000000000001,
+        "input" : 0.325,
         "output" : 1.95
       },
       "id" : "qwen\/qwen3.6-plus",
@@ -18537,9 +18581,9 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.064000000000000001,
-        "cacheWrite" : 0.40000000000000002,
-        "input" : 0.32000000000000001,
+        "cacheRead" : 0.064,
+        "cacheWrite" : 0.4,
+        "input" : 0.32,
         "output" : 1.28
       },
       "id" : "qwen\/qwen3.7-plus",
@@ -18563,8 +18607,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.1,
+        "output" : 0.1
       },
       "id" : "rekaai\/reka-edge",
       "input" : [
@@ -18634,8 +18678,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.84999999999999998,
-        "output" : 0.84999999999999998
+        "input" : 0.85,
+        "output" : 0.85
       },
       "id" : "sao10k\/l3.1-euryale-70b",
       "input" : [
@@ -18657,8 +18701,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "stepfun\/step-3.5-flash",
       "input" : [
@@ -18678,10 +18722,10 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 1.1499999999999999
+        "input" : 0.2,
+        "output" : 1.15
       },
       "id" : "stepfun\/step-3.7-flash",
       "input" : [
@@ -18702,10 +18746,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.035,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.57999999999999996
+        "input" : 0.14,
+        "output" : 0.58
       },
       "id" : "tencent\/hy3",
       "input" : [
@@ -18725,10 +18769,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.021000000000000001,
+        "cacheRead" : 0.021,
         "cacheWrite" : 0,
         "input" : 0.063,
-        "output" : 0.20999999999999999
+        "output" : 0.21
       },
       "id" : "tencent\/hy3-preview",
       "input" : [
@@ -18773,8 +18817,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 0.40000000000000002
+        "input" : 0.4,
+        "output" : 0.4
       },
       "id" : "thedrummer\/unslopnemo-12b",
       "input" : [
@@ -18794,10 +18838,10 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "upstage\/solar-pro-3",
       "input" : [
@@ -18817,7 +18861,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -18865,7 +18909,7 @@
       },
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -18889,7 +18933,7 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 2
@@ -18911,12 +18955,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 32000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.028,
         "cacheWrite" : 0,
         "input" : 0.105,
-        "output" : 0.28000000000000003
+        "output" : 0.28
       },
       "id" : "xiaomi\/mimo-v2.5",
       "input" : [
@@ -18937,7 +18981,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.0036,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -18962,8 +19006,8 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "z-ai\/glm-4.5",
       "input" : [
@@ -18983,10 +19027,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.13,
-        "output" : 0.84999999999999998
+        "output" : 0.85
       },
       "id" : "z-ai\/glm-4.5-air",
       "input" : [
@@ -19008,7 +19052,7 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 1.8
       },
       "id" : "z-ai\/glm-4.5v",
@@ -19030,9 +19074,9 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0,
-        "input" : 0.42999999999999999,
+        "input" : 0.43,
         "output" : 1.74
       },
       "id" : "z-ai\/glm-4.6",
@@ -19055,8 +19099,8 @@
       "cost" : {
         "cacheRead" : 0.055,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.3,
+        "output" : 0.9
       },
       "id" : "z-ai\/glm-4.6v",
       "input" : [
@@ -19077,9 +19121,9 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 1.75
       },
       "id" : "z-ai\/glm-4.7",
@@ -19102,8 +19146,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.40000000000000002
+        "input" : 0.06,
+        "output" : 0.4
       },
       "id" : "z-ai\/glm-4.7-flash",
       "input" : [
@@ -19123,10 +19167,10 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.11899999999999999,
+        "cacheRead" : 0.119,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 1.8999999999999999
+        "input" : 0.6,
+        "output" : 1.9
       },
       "id" : "z-ai\/glm-5",
       "input" : [
@@ -19146,7 +19190,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 4
@@ -19167,11 +19211,11 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 202752,
+      "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1794,
         "cacheWrite" : 0,
-        "input" : 0.96599999999999997,
+        "input" : 0.966,
         "output" : 3.036
       },
       "id" : "z-ai\/glm-5.1",
@@ -19190,18 +19234,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.098799999999999999,
+        "cacheRead" : 0.156,
         "cacheWrite" : 0,
-        "input" : 0.53200000000000003,
-        "output" : 1.6719999999999999
+        "input" : 0.84,
+        "output" : 2.64
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 128000,
       "name" : "Z.ai: GLM 5.2",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -19218,7 +19262,7 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 4
@@ -19249,7 +19293,7 @@
       },
       "contextWindow" : 512000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.74,
         "output" : 3.48
@@ -19286,8 +19330,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "essentialai\/Rnj-1-Instruct",
       "input" : [
@@ -19314,8 +19358,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.39000000000000001,
-        "output" : 0.96999999999999997
+        "input" : 0.39,
+        "output" : 0.97
       },
       "id" : "google\/gemma-4-31B-it",
       "input" : [
@@ -19373,9 +19417,9 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M2.7",
@@ -19407,9 +19451,9 @@
       },
       "contextWindow" : 524288,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "MiniMaxAI\/MiniMax-M3",
@@ -19441,7 +19485,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 4.5
@@ -19477,7 +19521,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "moonshotai\/Kimi-K2.7-Code",
@@ -19508,10 +19552,10 @@
       },
       "contextWindow" : 512300,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 3.6000000000000001
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
@@ -19543,8 +19587,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.20000000000000001
+        "input" : 0.05,
+        "output" : 0.2
       },
       "id" : "openai\/gpt-oss-20b",
       "input" : [
@@ -19575,8 +19619,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
@@ -19607,8 +19651,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.29999999999999999
+        "input" : 0.3,
+        "output" : 0.3
       },
       "id" : "Qwen\/Qwen2.5-7B-Instruct-Turbo",
       "input" : [
@@ -19635,8 +19679,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.59999999999999998
+        "input" : 0.2,
+        "output" : 0.6
       },
       "id" : "Qwen\/Qwen3-235B-A22B-Instruct-2507-tput",
       "input" : [
@@ -19663,7 +19707,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17000000000000001,
+        "input" : 0.17,
         "output" : 0.25
       },
       "id" : "Qwen\/Qwen3.5-9B",
@@ -19697,8 +19741,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 3.6000000000000001
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "Qwen\/Qwen3.5-397B-A17B",
       "input" : [
@@ -19793,7 +19837,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 3.2000000000000002
+        "output" : 3.2
       },
       "id" : "zai-org\/GLM-5",
       "input" : [
@@ -19825,8 +19869,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "zai-org\/GLM-5.1",
       "input" : [
@@ -19856,10 +19900,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "zai-org\/GLM-5.2",
       "input" : [
@@ -19885,7 +19929,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.12,
-        "output" : 0.23999999999999999
+        "output" : 0.24
       },
       "id" : "alibaba\/qwen-3-14b",
       "input" : [
@@ -19923,7 +19967,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.16,
-        "output" : 0.64000000000000001
+        "output" : 0.64
       },
       "id" : "alibaba\/qwen-3-32b",
       "input" : [
@@ -19958,10 +20002,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 240000,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 1.625,
         "input" : 1.3,
-        "output" : 7.7999999999999998
+        "output" : 7.8
       },
       "id" : "alibaba\/qwen-3.6-max-preview",
       "input" : [
@@ -19979,7 +20023,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 4
       },
       "id" : "alibaba\/qwen3-235b-a22b-thinking",
@@ -19997,7 +20041,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 7.5
@@ -20018,8 +20062,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "alibaba\/qwen3-coder-30b-a3b",
       "input" : [
@@ -20054,7 +20098,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 5
@@ -20073,7 +20117,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 6
@@ -20092,7 +20136,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 6
@@ -20111,7 +20155,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 6
@@ -20132,7 +20176,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
+        "input" : 0.15,
         "output" : 1.2
       },
       "id" : "alibaba\/qwen3-next-80b-a3b-instruct",
@@ -20151,7 +20195,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
+        "input" : 0.15,
         "output" : 1.2
       },
       "id" : "alibaba\/qwen3-next-80b-a3b-thinking",
@@ -20170,8 +20214,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "alibaba\/qwen3-vl-235b-a22b-instruct",
       "input" : [
@@ -20190,8 +20234,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "alibaba\/qwen3-vl-instruct",
       "input" : [
@@ -20210,7 +20254,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 4
       },
       "id" : "alibaba\/qwen3-vl-thinking",
@@ -20230,8 +20274,8 @@
       "cost" : {
         "cacheRead" : 0.001,
         "cacheWrite" : 0.125,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "alibaba\/qwen3.5-flash",
       "input" : [
@@ -20248,10 +20292,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0.5,
-        "input" : 0.40000000000000002,
-        "output" : 2.3999999999999999
+        "input" : 0.4,
+        "output" : 2.4
       },
       "id" : "alibaba\/qwen3.5-plus",
       "input" : [
@@ -20270,8 +20314,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 3.6000000000000001
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "alibaba\/qwen3.6-27b",
       "input" : [
@@ -20288,7 +20332,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0.625,
         "input" : 0.5,
         "output" : 3
@@ -20327,10 +20371,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 0.5,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "alibaba\/qwen3.7-plus",
       "input" : [
@@ -20347,9 +20391,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "amazon\/nova-2-lite",
@@ -20369,8 +20413,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23999999999999999
+        "input" : 0.06,
+        "output" : 0.24
       },
       "id" : "amazon\/nova-lite",
       "input" : [
@@ -20389,8 +20433,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.035000000000000003,
-        "output" : 0.14000000000000001
+        "input" : 0.035,
+        "output" : 0.14
       },
       "id" : "amazon\/nova-micro",
       "input" : [
@@ -20408,8 +20452,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.80000000000000004,
-        "output" : 3.2000000000000002
+        "input" : 0.8,
+        "output" : 3.2
       },
       "id" : "amazon\/nova-pro",
       "input" : [
@@ -20426,8 +20470,8 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0.29999999999999999,
+        "cacheRead" : 0.03,
+        "cacheWrite" : 0.3,
         "input" : 0.25,
         "output" : 1.25
       },
@@ -20446,9 +20490,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.08,
         "cacheWrite" : 1,
-        "input" : 0.80000000000000004,
+        "input" : 0.8,
         "output" : 4
       },
       "id" : "anthropic\/claude-3.5-haiku",
@@ -20494,7 +20538,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 5
@@ -20656,7 +20700,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -20676,7 +20720,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -20699,7 +20743,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.29999999999999999,
+        "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
@@ -20725,7 +20769,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 10
@@ -20771,7 +20815,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.25,
-        "output" : 0.90000000000000002
+        "output" : 0.9
       },
       "id" : "arcee-ai\/trinity-large-thinking",
       "input" : [
@@ -20789,8 +20833,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.044999999999999998,
-        "output" : 0.14999999999999999
+        "input" : 0.045,
+        "output" : 0.15
       },
       "id" : "arcee-ai\/trinity-mini",
       "input" : [
@@ -20806,7 +20850,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -20826,7 +20870,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -20867,8 +20911,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.3500000000000001,
-        "output" : 5.4000000000000004
+        "input" : 1.35,
+        "output" : 5.4
       },
       "id" : "deepseek\/deepseek-r1",
       "input" : [
@@ -20884,10 +20928,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.13500000000000001,
+        "cacheRead" : 0.135,
         "cacheWrite" : 0,
-        "input" : 0.27000000000000002,
-        "output" : 1.1200000000000001
+        "input" : 0.27,
+        "output" : 1.12
       },
       "id" : "deepseek\/deepseek-v3",
       "input" : [
@@ -20905,7 +20949,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 1.7
       },
       "id" : "deepseek\/deepseek-v3.1",
@@ -20922,9 +20966,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.13500000000000001,
+        "cacheRead" : 0.135,
         "cacheWrite" : 0,
-        "input" : 0.27000000000000002,
+        "input" : 0.27,
         "output" : 1
       },
       "id" : "deepseek\/deepseek-v3.1-terminus",
@@ -20941,10 +20985,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.028,
         "cacheWrite" : 0,
-        "input" : 0.28000000000000003,
-        "output" : 0.41999999999999998
+        "input" : 0.28,
+        "output" : 0.42
       },
       "id" : "deepseek\/deepseek-v3.2",
       "input" : [
@@ -20963,7 +21007,7 @@
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.62,
-        "output" : 1.8500000000000001
+        "output" : 1.85
       },
       "id" : "deepseek\/deepseek-v3.2-thinking",
       "input" : [
@@ -20979,10 +21023,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -20998,7 +21042,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.0036,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -21017,9 +21061,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 2.5
       },
       "id" : "google\/gemini-2.5-flash",
@@ -21039,8 +21083,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "google\/gemini-2.5-flash-lite",
       "input" : [
@@ -21077,7 +21121,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
         "input" : 0.5,
         "output" : 3
@@ -21097,7 +21141,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -21117,7 +21161,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -21137,7 +21181,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 1.5
@@ -21157,7 +21201,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 12
@@ -21177,7 +21221,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.5,
         "output" : 9
@@ -21197,10 +21241,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.014999999999999999,
+        "cacheRead" : 0.015,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "google\/gemma-4-26b-a4b-it",
       "input" : [
@@ -21219,8 +21263,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.14,
+        "output" : 0.4
       },
       "id" : "google\/gemma-4-31b-it",
       "input" : [
@@ -21237,7 +21281,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 0.75
@@ -21295,9 +21339,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "kwaipilot\/kat-coder-pro-v1",
@@ -21314,9 +21358,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "kwaipilot\/kat-coder-pro-v2",
@@ -21392,8 +21436,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
+        "input" : 0.72,
+        "output" : 0.72
       },
       "id" : "meta\/llama-3.1-70b",
       "input" : [
@@ -21431,8 +21475,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
+        "input" : 0.72,
+        "output" : 0.72
       },
       "id" : "meta\/llama-3.2-90b",
       "input" : [
@@ -21451,8 +21495,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.71999999999999997,
-        "output" : 0.71999999999999997
+        "input" : 0.72,
+        "output" : 0.72
       },
       "id" : "meta\/llama-3.3-70b",
       "input" : [
@@ -21470,8 +21514,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.23999999999999999,
-        "output" : 0.96999999999999997
+        "input" : 0.24,
+        "output" : 0.97
       },
       "id" : "meta\/llama-4-maverick",
       "input" : [
@@ -21490,8 +21534,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.17000000000000001,
-        "output" : 0.66000000000000003
+        "input" : 0.17,
+        "output" : 0.66
       },
       "id" : "meta\/llama-4-scout",
       "input" : [
@@ -21508,7 +21552,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14999999999999999,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 4.25
@@ -21528,9 +21572,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 205000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2",
@@ -21547,9 +21591,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.1",
@@ -21566,10 +21610,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
-        "output" : 2.3999999999999999
+        "input" : 0.3,
+        "output" : 2.4
       },
       "id" : "minimax\/minimax-m2.1-lightning",
       "input" : [
@@ -21585,9 +21629,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.5",
@@ -21604,10 +21648,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0.375,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "minimax\/minimax-m2.5-highspeed",
       "input" : [
@@ -21623,9 +21667,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.7",
@@ -21642,10 +21686,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0.375,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "minimax\/minimax-m2.7-highspeed",
       "input" : [
@@ -21661,9 +21705,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.059999999999999998,
+        "cacheRead" : 0.06,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
+        "input" : 0.3,
         "output" : 1.2
       },
       "id" : "minimax\/minimax-m3",
@@ -21683,8 +21727,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.3,
+        "output" : 0.9
       },
       "id" : "mistral\/codestral",
       "input" : [
@@ -21702,7 +21746,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistral\/devstral-2",
@@ -21721,8 +21765,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "mistral\/devstral-small",
       "input" : [
@@ -21740,8 +21784,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "mistral\/devstral-small-2",
       "input" : [
@@ -21800,8 +21844,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.10000000000000001
+        "input" : 0.1,
+        "output" : 0.1
       },
       "id" : "mistral\/ministral-3b",
       "input" : [
@@ -21819,8 +21863,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistral\/ministral-8b",
       "input" : [
@@ -21838,8 +21882,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.20000000000000001
+        "input" : 0.2,
+        "output" : 0.2
       },
       "id" : "mistral\/ministral-14b",
       "input" : [
@@ -21878,7 +21922,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
+        "input" : 0.4,
         "output" : 2
       },
       "id" : "mistral\/mistral-medium",
@@ -21918,8 +21962,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistral\/mistral-nemo",
       "input" : [
@@ -21937,8 +21981,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "mistral\/mistral-small",
       "input" : [
@@ -21957,8 +22001,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.14999999999999999
+        "input" : 0.15,
+        "output" : 0.15
       },
       "id" : "mistral\/pixtral-12b",
       "input" : [
@@ -21997,8 +22041,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.56999999999999995,
-        "output" : 2.2999999999999998
+        "input" : 0.57,
+        "output" : 2.3
       },
       "id" : "moonshotai\/kimi-k2",
       "input" : [
@@ -22014,9 +22058,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 216144,
       "cost" : {
-        "cacheRead" : 0.14099999999999999,
+        "cacheRead" : 0.141,
         "cacheWrite" : 0,
-        "input" : 0.46999999999999997,
+        "input" : 0.47,
         "output" : 2
       },
       "id" : "moonshotai\/kimi-k2-thinking",
@@ -22033,9 +22077,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262114,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 3
       },
       "id" : "moonshotai\/kimi-k2.5",
@@ -22055,7 +22099,7 @@
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.6",
@@ -22075,7 +22119,7 @@
       "cost" : {
         "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
+        "input" : 0.95,
         "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.7-code",
@@ -22095,7 +22139,7 @@
       "cost" : {
         "cacheRead" : 0.38,
         "cacheWrite" : 0,
-        "input" : 1.8999999999999999,
+        "input" : 1.9,
         "output" : 8
       },
       "id" : "moonshotai\/kimi-k2.7-code-highspeed",
@@ -22115,8 +22159,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.23999999999999999
+        "input" : 0.05,
+        "output" : 0.24
       },
       "id" : "nvidia\/nemotron-3-nano-30b-a3b",
       "input" : [
@@ -22134,8 +22178,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.65000000000000002
+        "input" : 0.15,
+        "output" : 0.65
       },
       "id" : "nvidia\/nemotron-3-super-120b-a12b",
       "input" : [
@@ -22153,8 +22197,8 @@
       "cost" : {
         "cacheRead" : 0.12,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.3999999999999999
+        "input" : 0.6,
+        "output" : 2.4
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
@@ -22172,8 +22216,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.23000000000000001
+        "input" : 0.06,
+        "output" : 0.23
       },
       "id" : "nvidia\/nemotron-nano-9b-v2",
       "input" : [
@@ -22191,8 +22235,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 0.59999999999999998
+        "input" : 0.2,
+        "output" : 0.6
       },
       "id" : "nvidia\/nemotron-nano-12b-v2-vl",
       "input" : [
@@ -22268,10 +22312,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.40000000000000002,
-        "output" : 1.6000000000000001
+        "input" : 0.4,
+        "output" : 1.6
       },
       "id" : "openai\/gpt-4.1-mini",
       "input" : [
@@ -22288,10 +22332,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1047576,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.40000000000000002
+        "input" : 0.1,
+        "output" : 0.4
       },
       "id" : "openai\/gpt-4.1-nano",
       "input" : [
@@ -22328,10 +22372,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
-        "input" : 0.14999999999999999,
-        "output" : 0.59999999999999998
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-4o-mini",
       "input" : [
@@ -22408,7 +22452,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -22428,10 +22472,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.0050000000000000001,
+        "cacheRead" : 0.005,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.40000000000000002
+        "input" : 0.05,
+        "output" : 0.4
       },
       "id" : "openai\/gpt-5-nano",
       "input" : [
@@ -22508,7 +22552,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.025,
         "cacheWrite" : 0,
         "input" : 0.25,
         "output" : 2
@@ -22568,7 +22612,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -22591,7 +22635,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -22614,7 +22658,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -22660,7 +22704,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -22683,7 +22727,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.17499999999999999,
+        "cacheRead" : 0.175,
         "cacheWrite" : 0,
         "input" : 1.75,
         "output" : 14
@@ -22729,7 +22773,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
+        "cacheRead" : 0.075,
         "cacheWrite" : 0,
         "input" : 0.75,
         "output" : 4.5
@@ -22754,7 +22798,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.25
       },
       "id" : "openai\/gpt-5.4-nano",
@@ -22847,7 +22891,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.10000000000000001,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6
@@ -22918,8 +22962,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.20000000000000001
+        "input" : 0.05,
+        "output" : 0.2
       },
       "id" : "openai\/gpt-oss-20b",
       "input" : [
@@ -22937,7 +22981,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
+        "input" : 0.1,
         "output" : 0.5
       },
       "id" : "openai\/gpt-oss-120b",
@@ -22954,10 +22998,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.036999999999999998,
+        "cacheRead" : 0.037,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.075,
+        "output" : 0.3
       },
       "id" : "openai\/gpt-oss-safeguard-20b",
       "input" : [
@@ -23033,10 +23077,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.55000000000000004,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o3-mini",
       "input" : [
@@ -23072,10 +23116,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.27500000000000002,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
-        "input" : 1.1000000000000001,
-        "output" : 4.4000000000000004
+        "input" : 1.1,
+        "output" : 4.4
       },
       "id" : "openai\/o4-mini",
       "input" : [
@@ -23114,8 +23158,8 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.29999999999999999
+        "input" : 0.09,
+        "output" : 0.3
       },
       "id" : "stepfun\/step-3.5-flash",
       "input" : [
@@ -23131,10 +23175,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.04,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 1.1499999999999999
+        "input" : 0.2,
+        "output" : 1.15
       },
       "id" : "stepfun\/step-3.7-flash",
       "input" : [
@@ -23151,9 +23195,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 0.5
       },
       "id" : "xai\/grok-4.1-fast-non-reasoning",
@@ -23171,9 +23215,9 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 0.5
       },
       "id" : "xai\/grok-4.1-fast-reasoning",
@@ -23191,7 +23235,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23231,7 +23275,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23251,7 +23295,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23271,7 +23315,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23291,7 +23335,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23311,7 +23355,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23331,7 +23375,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 2000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23351,7 +23395,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 2
@@ -23373,8 +23417,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.10000000000000001,
-        "output" : 0.29999999999999999
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "xiaomi\/mimo-v2-flash",
       "input" : [
@@ -23390,7 +23434,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 3
@@ -23411,8 +23455,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "xiaomi\/mimo-v2.5",
       "input" : [
@@ -23429,7 +23473,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.0036,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -23450,8 +23494,8 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai\/glm-4.5",
       "input" : [
@@ -23467,10 +23511,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
-        "output" : 1.1000000000000001
+        "input" : 0.2,
+        "output" : 1.1
       },
       "id" : "zai\/glm-4.5-air",
       "input" : [
@@ -23488,7 +23532,7 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
+        "input" : 0.6,
         "output" : 1.8
       },
       "id" : "zai\/glm-4.5v",
@@ -23508,8 +23552,8 @@
       "cost" : {
         "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai\/glm-4.6",
       "input" : [
@@ -23525,10 +23569,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.29999999999999999,
-        "output" : 0.90000000000000002
+        "input" : 0.3,
+        "output" : 0.9
       },
       "id" : "zai\/glm-4.6v",
       "input" : [
@@ -23567,8 +23611,8 @@
       "cost" : {
         "cacheRead" : 0.12,
         "cacheWrite" : 0,
-        "input" : 0.59999999999999998,
-        "output" : 2.2000000000000002
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "zai\/glm-4.7",
       "input" : [
@@ -23586,8 +23630,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.40000000000000002
+        "input" : 0.07,
+        "output" : 0.4
       },
       "id" : "zai\/glm-4.7-flash",
       "input" : [
@@ -23605,8 +23649,8 @@
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.40000000000000002
+        "input" : 0.06,
+        "output" : 0.4
       },
       "id" : "zai\/glm-4.7-flashx",
       "input" : [
@@ -23622,10 +23666,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 202800,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.94999999999999996,
-        "output" : 3.1499999999999999
+        "input" : 0.95,
+        "output" : 3.15
       },
       "id" : "zai\/glm-5",
       "input" : [
@@ -23641,7 +23685,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 202800,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 4
@@ -23660,10 +23704,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 202000,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
         "input" : 1.3,
-        "output" : 4.2999999999999998
+        "output" : 4.3
       },
       "id" : "zai\/glm-5.1",
       "input" : [
@@ -23679,10 +23723,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1040000,
       "cost" : {
-        "cacheRead" : 0.26000000000000001,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 1.3999999999999999,
-        "output" : 4.4000000000000004
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "zai\/glm-5.2",
       "input" : [
@@ -23717,7 +23761,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.23999999999999999,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
         "input" : 1.2,
         "output" : 4
@@ -23792,7 +23836,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23842,7 +23886,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23867,7 +23911,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 2.5
@@ -23892,7 +23936,7 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.20000000000000001,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 1,
         "output" : 2
@@ -23919,7 +23963,7 @@
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
-        "input" : 0.20000000000000001,
+        "input" : 0.2,
         "output" : 1.5
       },
       "id" : "grok-code-fast-1",
@@ -23944,8 +23988,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "mimo-v2-flash",
       "input" : [
@@ -23967,8 +24011,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "mimo-v2-omni",
       "input" : [
@@ -23989,7 +24033,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.0036,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -24014,8 +24058,8 @@
       "cost" : {
         "cacheRead" : 0.0028,
         "cacheWrite" : 0,
-        "input" : 0.14000000000000001,
-        "output" : 0.28000000000000003
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "mimo-v2.5",
       "input" : [
@@ -24036,7 +24080,7 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.0036,
         "cacheWrite" : 0,
         "input" : 0.435,
         "output" : 0.87
@@ -24059,10 +24103,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.010800000000000001,
+        "cacheRead" : 0.0108,
         "cacheWrite" : 0,
-        "input" : 1.3049999999999999,
-        "output" : 2.6099999999999999
+        "input" : 1.305,
+        "output" : 2.61
       },
       "id" : "mimo-v2.5-pro-ultraspeed",
       "input" : [

--- a/Tests/KWWKAITests/CursorProtoTests.swift
+++ b/Tests/KWWKAITests/CursorProtoTests.swift
@@ -87,6 +87,29 @@ struct CursorProtoTests {
         #expect(models[0].provider == "cursor")
         #expect(models[0].reasoning == true)
         #expect(models[0].baseURL == "https://api2.cursor.sh")
+        #expect(models[0].input == [.text, .image])
+    }
+
+    @Test("normalize infers image input from the model family for uncurated ids")
+    func inferredInputModalities() {
+        func model(_ id: String) -> CursorProto.UsableModel {
+            CursorProto.UsableModel(
+                modelId: id, displayName: id, displayNameShort: "",
+                displayModelId: "", aliases: [], hasThinking: false
+            )
+        }
+        let models = CursorModelCatalog.normalize(
+            [model("claude-9-sonnet"), model("gemini-9-pro"), model("gpt-9"),
+             model("codex-9"), model("composer-9"), model("grok-code-fast-9")],
+            host: "api2.cursor.sh"
+        )
+        let byId = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+        #expect(byId["claude-9-sonnet"]?.input == [.text, .image])
+        #expect(byId["gemini-9-pro"]?.input == [.text, .image])
+        #expect(byId["gpt-9"]?.input == [.text, .image])
+        #expect(byId["codex-9"]?.input == [.text, .image])
+        #expect(byId["composer-9"]?.input == [.text])
+        #expect(byId["grok-code-fast-9"]?.input == [.text])
     }
 
     @Test("bundled cursor-models.json loads into the catalog")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two catalog updates, one per commit.

### 1. Regenerate `models.json` from pi-mono

Regenerated `Sources/KWWKAI/Resources/models.json` from pi-mono `models.generated.ts` at upstream commit `961fa6c1` (2026-07-14), via `swift run kwwk-generate-models`. 35 providers / 1057 models — no models added or removed since the last sync (#46, 2026-07-10); all changes are field-level:

- **github-copilot**: `mai-code-1-flash-picker` now routes through `openai-responses` instead of `openai-completions` (upstream #6544).
- **claude-fable-5** gains `xhigh`/`max` entries in `thinkingLevelMap` on the github-copilot and openrouter groups (upstream #6490).
- **openai / openai-codex**: GPT-5.4+ models carry `compat.supportsToolSearch` for upstream's new message-anchored tool loading. kwwk's `ModelCompat` decoder ignores this field for now; porting the feature itself is a separate follow-up.
- **openrouter**: 34 models' `contextWindow` now come from the top provider's context length (upstream #6481), plus minor price updates.

Most of the raw diff is float-formatting churn (`0.33000000000000002` → `0.33`): this run used Linux corelibs-foundation JSON serialization, whose shortest-representation output differs from the macOS run that produced the previous file. The double values are bit-identical.

### 2. Infer image input for uncurated Cursor models (ports oh-my-pi `6e209d3ec`)

Cursor's `GetUsableModels` carries no per-model modality metadata; kwwk's reference-less fallback in `CursorModelCatalog.normalize` hardcoded `input: [.text]`, so 137 multimodal models (claude/gpt/codex/gemini families outside the curated table — including all `claude-opus-4-*`, `claude-sonnet-5-*`, `gpt-5.5-*`, `gpt-5.6-*`) were classified vision-blind and attached images were silently dropped. This ports oh-my-pi's fix: infer modalities from the model family; curated entries stay authoritative; text-only families (`composer-*`, `grok-code-*`, `kimi-*`) stay `[text]`. The bundled `cursor-models.json` was updated with the same inference so the shipped catalog matches what the generator now produces.

### `cursor-models.json` not re-fetched from the RPC

`swift run kwwk-generate-cursor-models` needs a real Cursor account token (`CURSOR_ACCESS_TOKEN`, a `cursor` login in `~/.kwwk/oauth.json`, or an interactive browser login). None is available in this cloud environment, so the model *list* is still the one fetched in #46 (2026-07-10); only the input modalities were patched offline. To refresh the list, run the generator locally or add a `CURSOR_ACCESS_TOKEN` secret for cloud agents.

## Testing

- `swift build` — clean
- `swift test` — 1226 tests passed, including a new test covering family-based modality inference (`claude/gemini/gpt/codex` → text+image; `composer/grok-code` → text) and the existing catalog decode/absence assertions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6034-01cf-73c6-9fd2-bda108229e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6034-01cf-73c6-9fd2-bda108229e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

