### PR TITLE
Port five upstream pi-mono provider/retry fixes

### DIFF
--- a/Sources/KWWKAI/AnthropicProvider.swift
+++ b/Sources/KWWKAI/AnthropicProvider.swift
@@ -617,9 +617,15 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
                         blocks.append(["type": "redacted_thinking", "data": th.thinkingSignature ?? ""])
                         break
                     }
-                    if th.thinking.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { break }
                     let sig = th.thinkingSignature
-                    if sig == nil || sig!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    let hasSignature = !(sig ?? "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    // A signed thinking block must be replayed even when its
+                    // visible text is empty (interleaved thinking can emit
+                    // signature-only blocks); dropping it invalidates the turn.
+                    if th.thinking.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       !hasSignature { break }
+                    if !hasSignature {
                         if allowEmptySignature {
                             blocks.append(["type": "thinking", "thinking": th.thinking, "signature": ""])
                         } else {

--- a/Sources/KWWKAI/BedrockProvider.swift
+++ b/Sources/KWWKAI/BedrockProvider.swift
@@ -312,9 +312,10 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
                 state.finishBlock(at: blockIndex) { event in out.push(event) }
             case "messageStop":
                 if case .string(let reason) = payload["stopReason"] ?? .null {
-                    state.stopReason = Self.mapStopReason(reason)
-                    if reason == "model_context_window_exceeded" {
-                        state.errorMessage = reason
+                    let mapped = Self.mapStopReason(reason)
+                    state.stopReason = mapped.stopReason
+                    if let errorMessage = mapped.errorMessage {
+                        state.errorMessage = errorMessage
                     }
                 }
             case "metadata":
@@ -690,13 +691,16 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
         }
     }
 
-    private static func mapStopReason(_ raw: String) -> StopReason {
+    /// Unhandled stop reasons (e.g. `guardrail_intervened`, `content_filtered`)
+    /// map to `.error` and carry the raw reason as the error message so the
+    /// failure is diagnosable instead of "an unknown error occurred".
+    private static func mapStopReason(_ raw: String) -> (stopReason: StopReason, errorMessage: String?) {
         switch raw {
-        case "end_turn", "stop_sequence": return .stop
-        case "max_tokens": return .length
-        case "model_context_window_exceeded": return .error
-        case "tool_use": return .toolUse
-        default: return .error
+        case "end_turn", "stop_sequence": return (.stop, nil)
+        case "max_tokens": return (.length, nil)
+        case "model_context_window_exceeded": return (.error, raw)
+        case "tool_use": return (.toolUse, nil)
+        default: return (.error, raw.isEmpty ? nil : raw)
         }
     }
 

--- a/Sources/KWWKAI/ModelCompat.swift
+++ b/Sources/KWWKAI/ModelCompat.swift
@@ -33,10 +33,13 @@ public struct ModelCompat: Codable, Sendable, Hashable {
 
     // MARK: shared (cache / session affinity)
     public var sendSessionAffinityHeaders: Bool?
+    /// Session-affinity header format: "openai" sends `session_id`,
+    /// `x-client-request-id`, and `x-session-affinity`; "openai-nosession"
+    /// sends `x-client-request-id` and `x-session-affinity`; "openrouter"
+    /// sends `x-session-id`. Does not affect the `prompt_cache_key` body
+    /// param, which is governed by cache retention. Default: auto-detected.
+    public var sessionAffinityFormat: String?
     public var supportsLongCacheRetention: Bool?
-
-    // MARK: openai-responses
-    public var sendSessionIdHeader: Bool?
 
     // MARK: anthropic-messages
     public var supportsEagerToolInputStreaming: Bool?

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -118,9 +118,19 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         if retention != .none,
            let sid = options?.sessionId, !sid.isEmpty,
            compat.sendSessionAffinityHeaders {
-            headers["session_id"] = sid
-            headers["x-client-request-id"] = sid
-            headers["x-session-affinity"] = sid
+            // pi #6496: OpenRouter uses a single `x-session-id` header;
+            // OpenAI-style providers take the session_id/affinity trio.
+            switch compat.sessionAffinityFormat {
+            case "openrouter":
+                headers["x-session-id"] = sid
+            case "openai-nosession":
+                headers["x-client-request-id"] = sid
+                headers["x-session-affinity"] = sid
+            default:
+                headers["session_id"] = sid
+                headers["x-client-request-id"] = sid
+                headers["x-session-affinity"] = sid
+            }
         }
         headersDecorator?(&headers, model, context, options)
         for (k, v) in options?.headers ?? [:] { headers[k] = v }
@@ -439,6 +449,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
         var supportsStrictMode: Bool
         var cacheControlFormat: String?
         var sendSessionAffinityHeaders: Bool
+        var sessionAffinityFormat: String
         var supportsLongCacheRetention: Bool
     }
 
@@ -492,6 +503,7 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             supportsStrictMode: c?.supportsStrictMode ?? (!isMoonshot && !isTogether && !isCfGateway && !isNvidia),
             cacheControlFormat: c?.cacheControlFormat ?? ((provider == "openrouter" && model.id.hasPrefix("anthropic/")) ? "anthropic" : nil),
             sendSessionAffinityHeaders: c?.sendSessionAffinityHeaders ?? false,
+            sessionAffinityFormat: c?.sessionAffinityFormat ?? (isOpenRouter ? "openrouter" : "openai"),
             supportsLongCacheRetention: c?.supportsLongCacheRetention ?? !(isTogether || isCloudflareWorkers || isCfGateway || isNvidia || isAntLing)
         )
     }

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -660,6 +660,9 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                     if state.hasToolCalls() {
                         state.stopReason = .toolUse
                     }
+                    if case .array(let outputItems) = response["output"] ?? .null {
+                        Self.backfillReasoningSignatures(outputItems, state: state)
+                    }
                 }
                 let final = state.finalize()
                 out.push(.done(reason: final.stopReason, message: final))
@@ -959,6 +962,30 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
               let data = try? JSONSerialization.data(withJSONObject: any, options: [.sortedKeys]),
               let s = String(data: data, encoding: .utf8) else { return nil }
         return s
+    }
+
+    /// Azure OpenAI can omit `reasoning.encrypted_content` from
+    /// `response.output_item.done` and provide it only in
+    /// `response.completed`'s `response.output`. Backfill the persisted
+    /// reasoning signature from the terminal response so `store: false`
+    /// multi-turn replay stays stateless. Output array positions correspond
+    /// to `output_index`. Ports pi #6608.
+    private static func backfillReasoningSignatures(
+        _ outputItems: [JSONValue], state: OpenAIResponsesState
+    ) {
+        for (outputIndex, entry) in outputItems.enumerated() {
+            guard case .object(let item) = entry,
+                  case .string("reasoning")? = item["type"],
+                  case .string = item["encrypted_content"] ?? .null,
+                  let index = state.reasoningIndex(for: outputIndex) else { continue }
+            // Preserve a signature that already carries encrypted content.
+            if let existing = state.thinkingSignature(at: index),
+               let parsed = parseReasoningItem(existing),
+               case .string = parsed["encrypted_content"] ?? .null { continue }
+            if let serialized = serializeReasoningItem(item) {
+                state.setThinkingSignature(at: index, signature: serialized)
+            }
+        }
     }
 
     /// Parse a stored reasoning-item signature back into its object form,
@@ -1435,6 +1462,13 @@ final class OpenAIResponsesState: @unchecked Sendable {
                 th.thinkingSignature = signature
                 blocks[index] = .thinking(th)
             }
+        }
+    }
+
+    func thinkingSignature(at index: Int) -> String? {
+        lock.withLock {
+            if case .thinking(let th) = blocks[index] { return th.thinkingSignature }
+            return nil
         }
     }
 

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -704,6 +704,9 @@ public enum AgentLoop {
             "econnreset", "enotconn", "epipe", "broken pipe", "reset by peer",
             "socket closed", "socket error", "closed before", "closed unexpectedly",
             "rate limit", "too many requests", "overloaded",
+            // gRPC-based providers (e.g. NVIDIA NIM) report quota pressure
+            // as a ResourceExhausted / RESOURCE_EXHAUSTED status.
+            "resourceexhausted", "resource_exhausted", "resource exhausted",
             "internal error", "server error", "service unavailable", "bad gateway",
             "temporarily", "stream stall", "fetch failed",
         ] where lower.contains(transient) {

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -457,6 +457,45 @@ struct AnthropicProviderTests {
         #expect(json["temperature"] == nil)
     }
 
+    @Test("signed thinking block is replayed even when its text is empty")
+    func emptyThinkingWithSignaturePreserved() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = AnthropicProvider(client: client, defaultAPIKey: "k")
+        let assistant = AssistantMessage(
+            content: [
+                .thinking(ThinkingContent(thinking: "", thinkingSignature: "signed-thinking")),
+                .thinking(ThinkingContent(thinking: "  ")),
+                .text(TextContent(text: "answer")),
+            ],
+            api: Self.sampleModel.api,
+            provider: Self.sampleModel.provider,
+            model: Self.sampleModel.id,
+            usage: Usage(),
+            stopReason: .stop,
+            timestamp: Timestamp.now()
+        )
+        _ = provider.stream(
+            model: Self.sampleModel,
+            context: Context(messages: [
+                .user(UserMessage(text: "hi")),
+                .assistant(assistant),
+                .user(UserMessage(text: "go on")),
+            ]),
+            options: nil
+        )
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        let json = Self.decodeBody(client)
+        let messages = json["messages"] as? [[String: Any]]
+        let content = messages?[1]["content"] as? [[String: Any]]
+        // The signed empty block survives; the unsigned empty block is dropped.
+        #expect(content?.count == 2)
+        #expect(content?[0]["type"] as? String == "thinking")
+        #expect(content?[0]["thinking"] as? String == "")
+        #expect(content?[0]["signature"] as? String == "signed-thinking")
+        #expect(content?[1]["type"] as? String == "text")
+    }
+
     @Test("thinking is omitted when reasoning level is nil, temperature passes through")
     func thinkingOmittedWithoutReasoning() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAITests/BedrockHardeningTests.swift
+++ b/Tests/KWWKAITests/BedrockHardeningTests.swift
@@ -600,14 +600,15 @@ struct BedrockCacheAndAuthTests {
         return final
     }
 
-    @Test("unknown stopReason maps to .error")
+    @Test("unknown stopReason maps to .error and surfaces the raw reason")
     func stopReasonUnknownIsError() async throws {
         let body = Self.frames([
             ("messageStart", "{\"role\":\"assistant\"}"),
-            ("messageStop", "{\"stopReason\":\"banana\"}"),
+            ("messageStop", "{\"stopReason\":\"guardrail_intervened\"}"),
         ])
         let final = await Self.drive(frames: body)
         #expect(final?.stopReason == .error)
+        #expect(final?.errorMessage == "guardrail_intervened")
     }
 
     @Test("model_context_window_exceeded remains a classifiable input error")

--- a/Tests/KWWKAITests/OpenAICompletionsTests.swift
+++ b/Tests/KWWKAITests/OpenAICompletionsTests.swift
@@ -292,6 +292,49 @@ struct OpenAICompletionsTests {
         #expect(noneHeaders["x-session-affinity"] == nil)
     }
 
+    @Test("OpenRouter session affinity uses the x-session-id header (pi #6496)")
+    func openRouterSessionAffinityHeader() async throws {
+        var model = Self.model
+        model.provider = "openrouter"
+        model.baseURL = "https://openrouter.ai/api"
+        var compat = ModelCompat()
+        compat.sendSessionAffinityHeaders = true
+        model.compat = compat
+
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAICompletionsProvider(client: client, defaultAPIKey: "k")
+        _ = provider.stream(
+            model: model,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(cacheRetention: .short, sessionId: "session-or")
+        )
+        await Self.waitForRequest(client)
+        let headers = client.lastRequest?.headers ?? [:]
+        #expect(headers["x-session-id"] == "session-or")
+        #expect(headers["session_id"] == nil)
+        #expect(headers["x-client-request-id"] == nil)
+        #expect(headers["x-session-affinity"] == nil)
+
+        // An explicit compat format overrides the URL-based detection.
+        var pinned = model
+        var pinnedCompat = ModelCompat()
+        pinnedCompat.sendSessionAffinityHeaders = true
+        pinnedCompat.sessionAffinityFormat = "openai-nosession"
+        pinned.compat = pinnedCompat
+        let pinnedClient = StubSSEClient(body: Self.textSSE)
+        let pinnedProvider = OpenAICompletionsProvider(client: pinnedClient, defaultAPIKey: "k")
+        _ = pinnedProvider.stream(
+            model: pinned,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(cacheRetention: .short, sessionId: "session-or")
+        )
+        await Self.waitForRequest(pinnedClient)
+        let pinnedHeaders = pinnedClient.lastRequest?.headers ?? [:]
+        #expect(pinnedHeaders["session_id"] == nil)
+        #expect(pinnedHeaders["x-client-request-id"] == "session-or")
+        #expect(pinnedHeaders["x-session-affinity"] == "session-or")
+    }
+
     @Test("compat chat-template kwargs and routing fields are encoded")
     func compatChatTemplateAndRouting() async throws {
         var model = Self.model

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -171,6 +171,82 @@ struct OpenAIResponsesTests {
         } else { Issue.record("expected text last") }
     }
 
+    /// Azure can omit `encrypted_content` from `response.output_item.done`
+    /// and only include it in `response.completed`'s output array.
+    static let reasoningBackfillSSE = """
+    data: {"type":"response.created","response":{"id":"resp_5","status":"in_progress"}}
+
+    data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"r_1"}}
+
+    data: {"type":"response.reasoning_text.delta","output_index":0,"delta":"think…"}
+
+    data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"r_1"}}
+
+    data: {"type":"response.output_item.added","output_index":1,"item":{"type":"message","role":"assistant","content":[]}}
+
+    data: {"type":"response.output_text.delta","output_index":1,"content_index":0,"delta":"answer"}
+
+    data: {"type":"response.output_item.done","output_index":1,"item":{"type":"message"}}
+
+    data: {"type":"response.completed","response":{"id":"resp_5","status":"completed","usage":{"input_tokens":20,"output_tokens":10},"output":[{"type":"reasoning","id":"r_1","encrypted_content":"enc-blob","summary":[]},{"type":"message"}]}}
+
+    """
+
+    @Test("backfills reasoning signature from response.completed output")
+    func reasoningSignatureBackfill() async throws {
+        let client = StubSSEClient(body: Self.reasoningBackfillSSE)
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "think"))]),
+            options: StreamOptions(reasoning: .high)
+        )
+        for await _ in s {}
+        let result = await s.result()
+        guard case .thinking(let th) = result.content.first else {
+            Issue.record("expected thinking first")
+            return
+        }
+        let signature = try #require(th.thinkingSignature)
+        let item = try JSONSerialization.jsonObject(
+            with: Data(signature.utf8)
+        ) as? [String: Any]
+        #expect(item?["type"] as? String == "reasoning")
+        #expect(item?["encrypted_content"] as? String == "enc-blob")
+        #expect(item?["id"] as? String == "r_1")
+    }
+
+    @Test("a signature that already has encrypted content is not overwritten")
+    func reasoningSignatureNotOverwritten() async throws {
+        // output_item.done carries encrypted content; response.completed
+        // carries a different blob that must not clobber the original.
+        let sse = """
+        data: {"type":"response.created","response":{"id":"resp_6","status":"in_progress"}}
+
+        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"r_1"}}
+
+        data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"r_1","encrypted_content":"original"}}
+
+        data: {"type":"response.completed","response":{"id":"resp_6","status":"completed","usage":{"input_tokens":1,"output_tokens":1},"output":[{"type":"reasoning","id":"r_1","encrypted_content":"stale"}]}}
+
+        """
+        let client = StubSSEClient(body: sse)
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
+        let s = provider.stream(
+            model: Self.model,
+            context: Context(messages: [.user(UserMessage(text: "think"))]),
+            options: StreamOptions(reasoning: .high)
+        )
+        for await _ in s {}
+        let result = await s.result()
+        guard case .thinking(let th) = result.content.first else {
+            Issue.record("expected thinking first")
+            return
+        }
+        #expect(th.thinkingSignature?.contains("original") == true)
+        #expect(th.thinkingSignature?.contains("stale") != true)
+    }
+
     @Test("resolved auth can select custom API key header")
     func resolvedAuthCustomAPIKeyHeader() async throws {
         let client = StubSSEClient(body: Self.textSSE)

--- a/Tests/KWWKAgentTests/AgentRetryTests.swift
+++ b/Tests/KWWKAgentTests/AgentRetryTests.swift
@@ -172,6 +172,10 @@ struct RetryClassificationTests {
         #expect(AgentLoop.isRetryableError("HTTP 429: rate limit exceeded"))
         #expect(AgentLoop.isRetryableError("HTTP 503: service unavailable"))
         #expect(AgentLoop.isRetryableError("HTTP 529: overloaded"))
+        // gRPC-based providers (e.g. NVIDIA NIM) report quota pressure as
+        // ResourceExhausted (pi #6449).
+        #expect(AgentLoop.isRetryableError("ResourceExhausted: quota exceeded"))
+        #expect(AgentLoop.isRetryableError("gRPC status RESOURCE_EXHAUSTED"))
     }
 
     @Test("validation and auth failures are not retryable")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the applicable, low-risk fixes that landed in pi-mono since the last sync. One commit per fix:

1. **Replay signed Anthropic thinking blocks with empty text** (upstream [#6457](https://github.com/badlogic/pi-mono/issues/6376)). `encodeMessage` dropped any thinking block whose visible text was empty — including blocks that carry a valid signature (interleaved thinking can emit signature-only blocks) — which invalidates the replayed turn. Now only blocks with neither text nor signature are dropped.

2. **Surface unhandled Bedrock stop reasons in `errorMessage`** (upstream #6598). Unknown stop reasons (`guardrail_intervened`, `content_filtered`, …) mapped to `.error` with no message. The raw reason is now carried as the error message, matching the existing `model_context_window_exceeded` behavior. kwwk's deliberate `.error` mapping for context-window-exceeded (which feeds overflow recovery) is unchanged.

3. **Backfill reasoning `encrypted_content` from `response.completed`** (upstream #6608). Azure OpenAI can omit `reasoning.encrypted_content` from `response.output_item.done` and provide it only in `response.completed`'s output array; kwwk never stored the signature in that case, degrading `store: false` multi-turn reasoning replay. The signature is now backfilled from the terminal response, and a signature that already carries encrypted content is never overwritten.

4. **Classify `ResourceExhausted` as retryable** (upstream #6449). gRPC-based providers (e.g. NVIDIA NIM) report quota pressure as `ResourceExhausted` / `RESOURCE_EXHAUSTED`; the turn-replay classifier now treats it like other rate-limit signals.

5. **OpenRouter session affinity via `x-session-id`** (upstream #6496). OpenRouter uses a single `x-session-id` header instead of OpenAI's `session_id`/`x-client-request-id`/`x-session-affinity` trio. Adds `ModelCompat.sessionAffinityFormat` (`"openai"`, `"openai-nosession"`, `"openrouter"`), auto-detected from provider/baseURL, honored in the Completions header emission. The dead `sendSessionIdHeader` field is removed (upstream removed it in the same change); kwwk's Responses provider pins cache affinity through the `prompt_cache_key` body param and never sent session headers, so it is unaffected.

### Reviewed and deliberately not ported

- **Anthropic: skip usage fields if empty** (upstream #6611) — the JS bug was dereferencing an undefined `event.usage`; kwwk's Swift pattern-matching already guards every field access, so there is nothing to fix.
- **Stale usage after compaction** (upstream #6464) — kwwk's `ContextTokenEstimator.latestValidProviderUsage` already rejects assistant usage older than the compaction recap via `recapTimestamp`.
- **Count custom messages in compaction budget** (upstream #6326) — kwwk's `Message` model has no custom role.
- **oh-my-pi: defer stream idle watchdog during Cursor exec tools** — kwwk has no generic stream idle watchdog on Cursor streams (only the WebSocket-client keepalive), so the mis-kill path doesn't exist.
- **Radius gateway, message-anchored tool loading, forced tool calls** — features, not fixes; left as separate follow-ups.

## Testing

- `swift build` — clean
- `swift test` — 1229 tests passed. New coverage: signed-empty-thinking replay, unknown Bedrock stop reason surfaced, `response.completed` signature backfill plus no-clobber guard, `ResourceExhausted` classification, and OpenRouter/`openai-nosession` affinity header formats.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6034-01cf-73c6-9fd2-bda108229e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6034-01cf-73c6-9fd2-bda108229e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

