### PR TITLE
Fix Cursor Grok 4.5 image input

### DIFF
--- a/Sources/KWWKAI/Cursor/CursorModelCatalog.swift
+++ b/Sources/KWWKAI/Cursor/CursorModelCatalog.swift
@@ -211,13 +211,13 @@ public enum CursorModelCatalog {
     ///
     /// `GetUsableModels` carries no per-model modality metadata, so
     /// classification falls back to the model family: families that are
-    /// multimodal in their native catalogs (claude/gemini/gpt/codex) accept
-    /// images, everything else (composer-*, grok-code-*, kimi-*) stays
-    /// text-only. Curated entries above remain authoritative. Ports oh-my-pi's
-    /// `inferInputFromCursorId` (6e209d3ec).
+    /// multimodal in their native catalogs (claude/gemini/gpt/codex/grok-4.5)
+    /// accept images, while text-only families such as composer-*, grok-code-*,
+    /// and kimi-* do not. Curated entries above remain authoritative. Ports
+    /// oh-my-pi's `inferInputFromCursorId` (6e209d3ec).
     static func inferInput(fromCursorId id: String) -> [InputModality] {
         let lowered = id.lowercased()
-        let multimodalFamilies = ["claude", "gemini", "gpt-", "codex"]
+        let multimodalFamilies = ["claude", "gemini", "gpt-", "codex", "grok-4.5"]
         if multimodalFamilies.contains(where: lowered.contains) {
             return [.text, .image]
         }

--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -1420,6 +1420,126 @@
   {
     "api" : "cursor-agent",
     "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-high-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-low-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Medium",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.5-medium-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.5 Medium Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
     "contextWindow" : 1048576,
     "cost" : {
       "cacheRead" : 0,
@@ -3530,120 +3650,6 @@
     ],
     "maxTokens" : 64000,
     "name" : "GPT-5.6 Terra Extra High Fast",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-fast-high",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5 Medium Fast",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-fast-medium",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5 Low Fast",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-fast-xhigh",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5 Fast",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-high",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5 Medium",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-medium",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5 Low",
-    "provider" : "cursor",
-    "reasoning" : false
-  },
-  {
-    "api" : "cursor-agent",
-    "baseUrl" : "https:\/\/api2.cursor.sh",
-    "contextWindow" : 200000,
-    "cost" : {
-      "cacheRead" : 0,
-      "cacheWrite" : 0,
-      "input" : 0,
-      "output" : 0
-    },
-    "id" : "grok-4.5-xhigh",
-    "input" : [
-      "text"
-    ],
-    "maxTokens" : 64000,
-    "name" : "Cursor Grok 4.5",
     "provider" : "cursor",
     "reasoning" : false
   },

--- a/Tests/KWWKAITests/CursorProtoTests.swift
+++ b/Tests/KWWKAITests/CursorProtoTests.swift
@@ -100,7 +100,8 @@ struct CursorProtoTests {
         }
         let models = CursorModelCatalog.normalize(
             [model("claude-9-sonnet"), model("gemini-9-pro"), model("gpt-9"),
-             model("codex-9"), model("composer-9"), model("grok-code-fast-9")],
+             model("codex-9"), model("cursor-grok-4.5-high"), model("composer-9"),
+             model("grok-code-fast-9")],
             host: "api2.cursor.sh"
         )
         let byId = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
@@ -108,6 +109,7 @@ struct CursorProtoTests {
         #expect(byId["gemini-9-pro"]?.input == [.text, .image])
         #expect(byId["gpt-9"]?.input == [.text, .image])
         #expect(byId["codex-9"]?.input == [.text, .image])
+        #expect(byId["cursor-grok-4.5-high"]?.input == [.text, .image])
         #expect(byId["composer-9"]?.input == [.text])
         #expect(byId["grok-code-fast-9"]?.input == [.text])
     }


### PR DESCRIPTION
## Summary

- regenerate the bundled Cursor model catalog from the live `GetUsableModels` endpoint
- replace six retired `grok-4.5-*` identifiers with the current `cursor-grok-4.5-*` variants
- teach the generator's shared normalization logic that Grok 4.5 accepts image input
- add regression coverage while keeping `grok-code-*` text-only

## Why

Cursor changed the wire identifiers for its Grok 4.5 variants. Its model-discovery response does not include input-modality metadata, so kwwk infers modalities from model families. The existing inference—ported from OMP—covered Claude, Gemini, GPT, and Codex, but not Grok 4.5, causing the newly discovered models to be generated as text-only.

Current OMP main uses the same family inference and has the same gap. This PR extends the local generator rather than hand-editing only the generated JSON.

## Impact

All six current `cursor-grok-4.5-*` models are generated with `["text", "image"]`. Existing text-only families such as Composer and Grok Code remain unchanged.

## Validation

- regenerated with `swift run kwwk-generate-cursor-models` (183 models)
- verified all six `cursor-grok-4.5-*` entries have text and image inputs
- `swift test --filter CursorProtoTests` (30 tests passed)
- `git diff --check`