### PR TITLE
Remove legacy compaction strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,6 @@ inspect it, or `/compact-model clear` to follow `/model` again. A custom
 the summary stream cap automatic; set a positive value only when an explicit
 hard output limit is required.
 
-Set `KWWK_COMPACTION_STRATEGY=legacy` as a temporary rollback switch for the
-previous full-history summary behavior.
-
 ### Steering a running agent
 
 Queue a message that will be injected at the next turn boundary —

--- a/Sources/KWWKAgent/AgentContextCompactor.swift
+++ b/Sources/KWWKAgent/AgentContextCompactor.swift
@@ -3,11 +3,6 @@ import KWWKAI
 
 public let agentCompactMinMessages = 4
 
-public enum AgentContextCompactionStrategy: String, Sendable, Equatable {
-    case legacyFullSummary = "legacy"
-    case retainedTailV1 = "retained-tail-v1"
-}
-
 public struct AgentContextUsage: Equatable, Sendable {
     public let tokens: Int
     public let window: Int
@@ -26,7 +21,6 @@ public struct AgentContextCompactionConfig: Sendable {
     public var minMessages: Int
     public var toolOutputCharacterLimit: Int
     public var summaryWordTarget: Int
-    public var strategy: AgentContextCompactionStrategy
     public var keepRecentTokens: Int
     public var messageTextByteLimit: Int
     public var thinkingByteLimit: Int
@@ -45,7 +39,6 @@ public struct AgentContextCompactionConfig: Sendable {
         minMessages: Int = agentCompactMinMessages,
         toolOutputCharacterLimit: Int = 4_000,
         summaryWordTarget: Int = 900,
-        strategy: AgentContextCompactionStrategy = .retainedTailV1,
         keepRecentTokens: Int = 20_000,
         messageTextByteLimit: Int = 12_000,
         thinkingByteLimit: Int = 8_000,
@@ -58,7 +51,6 @@ public struct AgentContextCompactionConfig: Sendable {
         self.minMessages = minMessages
         self.toolOutputCharacterLimit = toolOutputCharacterLimit
         self.summaryWordTarget = summaryWordTarget
-        self.strategy = strategy
         self.keepRecentTokens = keepRecentTokens
         self.messageTextByteLimit = messageTextByteLimit
         self.thinkingByteLimit = thinkingByteLimit

--- a/Sources/KWWKAgent/CompactionPlanner.swift
+++ b/Sources/KWWKAgent/CompactionPlanner.swift
@@ -159,30 +159,6 @@ enum CompactionPlanner {
         )
     }
 
-    static func legacyPlan(messages: [Message]) -> CompactionPlan? {
-        guard !messages.isEmpty else { return nil }
-        let previous = leadingRecap(in: messages)
-        let historyStart = previous.map { $0.index + 1 } ?? 0
-        guard historyStart < messages.count else { return nil }
-        let protectedUserStart = trailingUnansweredUserStart(
-            in: messages,
-            lowerBound: historyStart
-        ) ?? messages.count
-        guard protectedUserStart > historyStart else { return nil }
-        return CompactionPlan(
-            previousSummary: previous?.history,
-            previousTurnPrefixSummary: previous?.turnPrefix,
-            previousRecapForFacts: previous?.factsSource,
-            messagesToSummarize: Array(messages[historyStart..<protectedUserStart]),
-            turnPrefixToSummarize: [],
-            recentTail: Array(messages[protectedUserStart...]),
-            firstKeptMessageIndex: protectedUserStart,
-            estimatedRecentTokens: estimatedTokens(
-                in: Array(messages[protectedUserStart...])
-            )
-        )
-    }
-
     static func summaryText(from message: Message) -> String? {
         guard case .user(let user) = message,
               user.source == .compaction else {

--- a/Sources/KWWKAgent/ContextCompactionPipeline.swift
+++ b/Sources/KWWKAgent/ContextCompactionPipeline.swift
@@ -37,7 +37,6 @@ enum ContextCompactionPipeline {
             )
         }
 
-        let strategy = effectiveStrategy(request.config.strategy)
         let recapTokenBudget = maximumRecapTokenBudget(for: request)
         if let target = request.targetTokens,
            recapTokenBudget < CompactionRecapRenderer.minimumUsefulTokenBudget {
@@ -60,16 +59,15 @@ enum ContextCompactionPipeline {
             for: request,
             recapTokenBudget: recapTokenBudget
         )
-        let attemptLimit = request.targetTokens == nil || strategy == .legacyFullSummary
+        let attemptLimit = request.targetTokens == nil
             ? 1
             : max(1, request.config.maxSummaryAttempts)
         var previousCut: Int?
         var lastTokensAfter: Int?
 
         for attemptIndex in 0..<attemptLimit {
-            guard let plan = makePlan(
+            guard let plan = CompactionPlanner.plan(
                 messages: request.context.messages,
-                strategy: strategy,
                 keepRecentTokens: keepRecentTokens
             ) else {
                 throw ContextCompactionPipelineError.noCompressibleMessages
@@ -133,22 +131,6 @@ enum ContextCompactionPipeline {
             ),
             target: request.targetTokens ?? 0
         )
-    }
-
-    private static func makePlan(
-        messages: [Message],
-        strategy: AgentContextCompactionStrategy,
-        keepRecentTokens: Int
-    ) -> CompactionPlan? {
-        switch strategy {
-        case .legacyFullSummary:
-            return CompactionPlanner.legacyPlan(messages: messages)
-        case .retainedTailV1:
-            return CompactionPlanner.plan(
-                messages: messages,
-                keepRecentTokens: keepRecentTokens
-            )
-        }
     }
 
     private static func summarizeHistory(
@@ -428,16 +410,6 @@ enum ContextCompactionPipeline {
             max(50, summarySizingTokens * 3 / 4)
         )
         return config
-    }
-
-    private static func effectiveStrategy(
-        _ configured: AgentContextCompactionStrategy
-    ) -> AgentContextCompactionStrategy {
-        guard let override = ProcessInfo.processInfo.environment["KWWK_COMPACTION_STRATEGY"],
-              !override.isEmpty else {
-            return configured
-        }
-        return AgentContextCompactionStrategy(rawValue: override) ?? configured
     }
 
     private static func checkCancellation(_ cancellation: CancellationHandle?) throws {

--- a/Tests/KWWKAgentTests/CompactionPlannerTests.swift
+++ b/Tests/KWWKAgentTests/CompactionPlannerTests.swift
@@ -297,7 +297,6 @@ struct CompactionPlannerTests {
         ]
 
         #expect(CompactionPlanner.plan(messages: messages, keepRecentTokens: 20) == nil)
-        #expect(CompactionPlanner.legacyPlan(messages: messages) == nil)
     }
 
     private func conversation() -> [Message] {

--- a/Tests/KWWKAgentTests/CompactionRecapBudgetTests.swift
+++ b/Tests/KWWKAgentTests/CompactionRecapBudgetTests.swift
@@ -97,7 +97,6 @@ struct CompactionRecapBudgetTests {
             config: AgentContextCompactionConfig(
                 minMessages: 1,
                 summaryWordTarget: 900,
-                strategy: .legacyFullSummary,
                 keepRecentTokens: 300,
                 maxSummaryAttempts: 2
             ),
@@ -122,7 +121,7 @@ struct CompactionRecapBudgetTests {
         #expect(try #require(compacted.tokensAfter) <= 1_200)
         let recap = try #require(compacted.messages.first)
         #expect(ContextTokenEstimator.estimate(message: recap) <= 306)
-        #expect(await calls.value == 1)
+        #expect(await calls.value == 2)
     }
 
     @Test("a recovery target does not silently lower an explicit generation cap")
@@ -145,7 +144,6 @@ struct CompactionRecapBudgetTests {
             sessionId: "explicit-summary-cap",
             config: AgentContextCompactionConfig(
                 minMessages: 1,
-                strategy: .legacyFullSummary,
                 summaryMaxTokens: 4_096
             ),
             targetTokens: 1_200,

--- a/Tests/KWWKAgentTests/CompactionSerializationTests.swift
+++ b/Tests/KWWKAgentTests/CompactionSerializationTests.swift
@@ -494,7 +494,7 @@ struct CompactionSerializationTests {
             config: AgentContextCompactionConfig(
                 minMessages: 1,
                 summaryWordTarget: 250,
-                strategy: .legacyFullSummary
+                keepRecentTokens: 1
             ),
             streamFn: { model, context, _ in
                 await requests.append(contextText(context))
@@ -517,7 +517,7 @@ struct CompactionSerializationTests {
         #expect(snapshot.count > 1)
         #expect(snapshot.allSatisfy { !$0.contains("transcriptElision") })
         let transcript = snapshot.joined(separator: "\n")
-        for marker in markers {
+        for marker in markers.dropLast() {
             #expect(transcript.contains("\(marker)-USER"))
             #expect(transcript.contains("\(marker)-ASSISTANT"))
         }


### PR DESCRIPTION
## What changed

- remove the `KWWK_COMPACTION_STRATEGY=legacy` environment override
- remove the public compaction strategy enum and configuration surface
- delete the legacy full-history planner and its runtime branch
- keep retained-tail compaction as the only execution path
- update documentation and tests for the single architecture

## Why

The legacy rollback path was an obsolete architecture leftover. Keeping it increased the compaction API and control-flow surface and prevented the modern recovery path from consistently using its configured retry behavior.

Historical session-file decoding remains supported so existing persisted conversations continue to load; that compatibility code does not execute the removed strategy.

## Validation

- `swift test` — 1230 tests passed
- `swift test --filter Compaction` — 73 tests passed
- `git diff --check`
- repository scan confirms no remaining `KWWK_COMPACTION_STRATEGY`, `legacyFullSummary`, `AgentContextCompactionStrategy`, or `legacyPlan` references
