### PR TITLE
Fix unmatched slash command dispatch

### DIFF
--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -906,7 +906,11 @@ func runCodingTUIInternal(
             }
             guard !text.isEmpty else { return }
 
-            let parsed = SlashInput.parse(text)
+            // Submission only dispatches exact registered names/aliases.
+            // Fuzzy matching is an explicit popup/completion affordance; if
+            // nothing was selected, slash-looking text (notably absolute
+            // paths) continues through the normal prompt path.
+            let parsed = SlashInput.parse(text, recognizing: slashRegistry)
             guard !frameStatus.isPreparingAttachments else { return }
             if case .prompt = parsed,
                frameStatus.isSessionSwitching || frameStatus.isRewinding {

--- a/Sources/KWWKCli/SlashCommand.swift
+++ b/Sources/KWWKCli/SlashCommand.swift
@@ -30,6 +30,18 @@ enum SlashInput: Equatable {
         let args = parts.count > 1 ? String(parts[1]) : ""
         return .command(name: name, args: args)
     }
+
+    /// Parse input for submission, treating slash-looking text as a command
+    /// only when its name (or alias) exists in the live registry. Fuzzy
+    /// matching belongs to the popup/completion path; an unmatched absolute
+    /// path such as `/Users/me/file` must remain an ordinary prompt.
+    @MainActor
+    static func parse(_ raw: String, recognizing registry: SlashCommandRegistry) -> SlashInput {
+        let parsed = parse(raw)
+        guard case .command(let name, _) = parsed else { return parsed }
+        guard registry.find(name) != nil else { return .prompt(text: raw) }
+        return parsed
+    }
 }
 
 enum ShakeMode: Sendable, Equatable {

--- a/Tests/KWWKCliTests/SlashCommandTests.swift
+++ b/Tests/KWWKCliTests/SlashCommandTests.swift
@@ -44,6 +44,38 @@ struct SlashInputParseTests {
         #expect(SlashInput.parse("a/b") == .prompt(text: "a/b"))
     }
 
+    @MainActor
+    @Test("submission recognizes only exact registered commands and aliases")
+    func registryAwareSubmission() {
+        let registry = SlashCommandRegistry()
+        registry.register(SlashCommand(
+            name: "new",
+            description: "start a new session",
+            aliases: ["clear"],
+            handler: { _, _ in }
+        ))
+
+        #expect(SlashInput.parse("/new", recognizing: registry) == .command(name: "new", args: ""))
+        #expect(SlashInput.parse("/clear", recognizing: registry) == .command(name: "clear", args: ""))
+        #expect(SlashInput.parse("/new title", recognizing: registry) == .command(name: "new", args: "title"))
+    }
+
+    @MainActor
+    @Test("unmatched slash text remains a prompt on submission")
+    func unmatchedSlashIsPrompt() {
+        let registry = SlashCommandRegistry()
+        registry.register(SlashCommand(
+            name: "model",
+            description: "switch model",
+            handler: { _, _ in }
+        ))
+
+        let absolutePath = "/Users/eyhn/Downloads/345796292\\"
+        #expect(SlashInput.parse(absolutePath, recognizing: registry) == .prompt(text: absolutePath))
+        #expect(SlashInput.parse("/mod", recognizing: registry) == .prompt(text: "/mod"))
+        #expect(SlashInput.parse("/unknown with args", recognizing: registry) == .prompt(text: "/unknown with args"))
+    }
+
     @Test("slash command completion returns ghost suffix and completed input")
     func completion() {
         let names = ["model", "compact", "queue"]


### PR DESCRIPTION
## Summary

- dispatch slash commands only when the submitted name or alias exactly exists in the live registry
- keep fuzzy matching scoped to the command menu and explicit completion flow
- pass unmatched slash-looking text, including absolute paths, through as a normal prompt

## Root cause

The submit path parsed every input beginning with `/` as a command before consulting the registry. Inputs such as `/Users/...` therefore reached the unknown-command error branch even when the command menu had no match.

## User impact

Absolute paths and unknown slash-prefixed text are no longer swallowed as invalid commands. Registered commands such as `/goal` and registered aliases continue to dispatch normally.

## Validation

- `swift test --filter SlashCommand`
- `swift test --filter SlashInputParseTests`
- `git diff --check`