### PR TITLE
Treat empty subagent model as omitted

### DIFF
--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -663,21 +663,22 @@ private func parseAgentToolInput(_ args: JSONValue) throws -> AgentToolInput {
           !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         throw CodingToolError.invalidArgument("agent: `prompt` is required")
     }
-    func optionalNonEmptyString(_ key: String) throws -> String? {
+    func optionalTrimmedString(_ key: String) throws -> String? {
         guard let value = obj[key] else { return nil }
         guard case .string(let raw) = value else {
             throw CodingToolError.invalidArgument("agent: `\(key)` must be a string when provided")
         }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw CodingToolError.invalidArgument("agent: `\(key)` must not be empty when provided")
-        }
-        return trimmed
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    guard let subagentType = try optionalNonEmptyString("subagent_type") else {
+    guard let subagentType = try optionalTrimmedString("subagent_type") else {
         throw CodingToolError.invalidArgument("agent: `subagent_type` is required")
     }
-    let modelOverride = try optionalNonEmptyString("model")
+    guard !subagentType.isEmpty else {
+        throw CodingToolError.invalidArgument("agent: `subagent_type` must not be empty when provided")
+    }
+    let modelOverride = try optionalTrimmedString("model").flatMap { model in
+        model.isEmpty ? nil : model
+    }
     let runInBackground: Bool?
     if let value = obj["run_in_background"] {
         guard case .bool(let parsed) = value else {

--- a/Tests/KWWKAgentTests/SubagentToolTests.swift
+++ b/Tests/KWWKAgentTests/SubagentToolTests.swift
@@ -507,6 +507,44 @@ struct SubagentToolTests {
         #expect(detailString(toolOverrideResult, "model") == "tool-model")
     }
 
+    @Test("empty tool-call model override is treated as omitted")
+    func emptyModelOverrideIsOmitted() async throws {
+        let faux = await registerFauxProvider(RegisterFauxProviderOptions(
+            models: [
+                FauxModelDefinition(id: "parent-model"),
+                FauxModelDefinition(id: "definition-model"),
+            ]
+        ))
+        defer { faux.unregister() }
+        let definitionModel = faux.getModel(id: "definition-model")!
+        faux.setResponses([
+            .message(subagentYieldMessage("empty model result")),
+            .message(subagentYieldMessage("whitespace model result")),
+        ])
+        let tool = createAgentTool(
+            cwd: FileManager.default.currentDirectoryPath,
+            subagents: [minimalSubagent(model: .override(definitionModel))],
+            parentModel: faux.getModel(id: "parent-model")!,
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
+        )
+
+        for (index, model) in ["", "  \n\t"].enumerated() {
+            let result = try await tool.execute(
+                "call-\(index)",
+                .object([
+                    "description": .string("empty model override"),
+                    "prompt": .string("use definition model"),
+                    "subagent_type": .string("mini"),
+                    "model": .string(model),
+                ]),
+                nil,
+                nil
+            )
+            #expect(detailString(result, "model") == "definition-model")
+        }
+    }
+
     @Test("tool-call model override cannot switch provider through the global catalog")
     func modelOverrideStaysOnParentProvider() async throws {
         guard let foreign = ModelsCatalog.models(for: "openai").first else {


### PR DESCRIPTION
## Summary

- normalize empty and whitespace-only `model` overrides to `nil`
- preserve strict validation for required `subagent_type` values
- add regression coverage for empty and whitespace-only model overrides

## Why

The agent tool schema marks `model` as optional, but model-generated tool calls can include `model: ""`. The parser previously rejected that value even though its intended semantics are equivalent to omitting the optional override.

With this change, those calls inherit the subagent definition model or parent model as expected, avoiding an unnecessary tool-call failure.

## Validation

- `swift test --filter SubagentToolTests` (21 tests passed)
- `git diff --check`