### PR TITLE
fix(kwwk): make abort reach HTTP requests still awaiting response headers

### DIFF
--- a/Sources/KWWKAI/AnthropicProvider.swift
+++ b/Sources/KWWKAI/AnthropicProvider.swift
@@ -147,7 +147,8 @@ public final class AnthropicProvider: APIProvider, @unchecked Sendable {
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: body
+                url: url, method: "POST", headers: headers, body: body,
+                cancellation: options?.cancellation
             )
             if response.statusCode >= 400 {
                 // Drain the stream to surface the real error body — without

--- a/Sources/KWWKAI/BedrockProvider.swift
+++ b/Sources/KWWKAI/BedrockProvider.swift
@@ -156,7 +156,8 @@ public final class BedrockProvider: APIProvider, @unchecked Sendable {
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: body
+                url: url, method: "POST", headers: headers, body: body,
+                cancellation: options?.cancellation
             )
             if response.statusCode >= 400 {
                 // Surface the error body (a JSON `{message}` on 4xx/5xx) like the

--- a/Sources/KWWKAI/GoogleGeminiProvider.swift
+++ b/Sources/KWWKAI/GoogleGeminiProvider.swift
@@ -107,7 +107,8 @@ public final class GoogleGeminiProvider: APIProvider, @unchecked Sendable {
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: body
+                url: url, method: "POST", headers: headers, body: body,
+                cancellation: options?.cancellation
             )
             if response.statusCode >= 400 {
                 // Surface the JSON error body like the other providers.

--- a/Sources/KWWKAI/HTTPClient.swift
+++ b/Sources/KWWKAI/HTTPClient.swift
@@ -14,12 +14,15 @@ public protocol HTTPClient: Sendable {
     ///
     /// The stream is single-consumer and finishes (optionally throwing) when the
     /// request completes or errors. Cancelling the consuming task tears the
-    /// stream down, which aborts the underlying transport.
+    /// stream down, which aborts the underlying transport. `cancellation`
+    /// covers the window that consumer-task cancellation cannot reach: the
+    /// await for response headers, before any stream exists to tear down.
     func stream(
         url: URL,
         method: String,
         headers: [String: String],
-        body: Data?
+        body: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>)
 }
 
@@ -50,7 +53,8 @@ public final class URLSessionHTTPClient: HTTPClient, @unchecked Sendable {
         url: URL,
         method: String,
         headers: [String: String],
-        body: Data?
+        body: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -59,10 +63,19 @@ public final class URLSessionHTTPClient: HTTPClient, @unchecked Sendable {
 
         let task = session.dataTask(with: request)
         let id = task.taskIdentifier
+        // Bridge external cancellation for the request's whole lifetime.
+        // `awaitHeader` below is resumed only by delegate callbacks, so a
+        // cancelled consumer task cannot interrupt it — only cancelling the
+        // URLSession task (which fires `didCompleteWithError`) can.
+        let cancelRegistration = cancellation?.onCancel { [weak task] _ in task?.cancel() }
         // Register the body stream before `resume()` so early `didReceive`
         // callbacks find a continuation to feed. The stream aborts the request
-        // when the consumer stops iterating (or its task is cancelled).
-        let stream = delegate.makeBodyStream(for: id, onCancel: { [weak task] in task?.cancel() })
+        // when the consumer stops iterating (or its task is cancelled); either
+        // termination also retires the cancellation listener.
+        let stream = delegate.makeBodyStream(for: id, onCancel: { [weak task] in
+            task?.cancel()
+            cancelRegistration?.cancel()
+        })
         task.resume()
 
         do {
@@ -70,6 +83,7 @@ public final class URLSessionHTTPClient: HTTPClient, @unchecked Sendable {
             return (http, stream)
         } catch {
             task.cancel()
+            cancelRegistration?.cancel()
             throw error
         }
     }
@@ -286,10 +300,11 @@ public extension HTTPClient {
         url: URL,
         method: String,
         headers: [String: String],
-        body: Data?
+        body: Data?,
+        cancellation: CancellationHandle? = nil
     ) async throws -> (HTTPURLResponse, Data) {
         let (response, stream) = try await self.stream(
-            url: url, method: method, headers: headers, body: body
+            url: url, method: method, headers: headers, body: body, cancellation: cancellation
         )
         var buffer = Data()
         for try await chunk in stream { buffer.append(chunk) }

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -137,7 +137,8 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: body
+                url: url, method: "POST", headers: headers, body: body,
+                cancellation: options?.cancellation
             )
             if response.statusCode >= 400 {
                 let bodyText = await Self.errorBodyPreview(from: stream)

--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -175,7 +175,8 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
 
         do {
             let (response, stream) = try await client.stream(
-                url: url, method: "POST", headers: headers, body: try request.data()
+                url: url, method: "POST", headers: headers, body: try request.data(),
+                cancellation: options?.cancellation
             )
             if response.statusCode >= 400 {
                 // Collect whatever the server wrote (usually a small JSON

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -219,7 +219,10 @@ func runCodingTUIInternal(
     let frameStatus = FrameStatusState()
 
     let updateFrameStatus: @MainActor @Sendable () -> Void = {
-        frameStatus.reconcileMode(messageCount: agent.state.messages.count)
+        frameStatus.reconcileMode(
+            messageCount: agent.state.messages.count,
+            isStreaming: agent.state.isStreaming
+        )
         let capacityHint = formatCapacityHint(
             usage: AgentContextCompactor.currentUsage(
                 messages: agent.state.messages,
@@ -1393,10 +1396,19 @@ private final class FrameStatusState {
     var isRewinding = false
     var isSessionSwitching = false
 
-    func reconcileMode(messageCount: Int) {
+    func reconcileMode(messageCount: Int, isStreaming: Bool) {
         switch mode {
-        case .aborting, .retrying:
-            return
+        case .aborting:
+            // Hold only while the aborted owner (run or manual compaction) is
+            // still winding down. An Esc can race the natural end of a turn:
+            // it lands after .agentEnd already reconciled the mode, sees a
+            // still-true isStreaming, and re-enters .aborting with no further
+            // event coming to clear it. Falling through here once the owner is
+            // gone lets the next reconcile (spinner tick) self-heal instead of
+            // spinning on "aborting" forever.
+            if isStreaming || isManualCompacting { return }
+        case .retrying:
+            if isStreaming { return }
         default:
             break
         }

--- a/Tests/KWWKAITests/AWSSigV4Tests.swift
+++ b/Tests/KWWKAITests/AWSSigV4Tests.swift
@@ -139,7 +139,8 @@ struct BedrockProviderTests {
             self.statusCode = statusCode
         }
         func stream(
-            url: URL, method: String, headers: [String: String], body requestBody: Data?
+            url: URL, method: String, headers: [String: String], body requestBody: Data?,
+            cancellation: CancellationHandle?
         ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
             lastRequest = (url, method, headers, requestBody)
             let response = HTTPURLResponse(

--- a/Tests/KWWKAITests/AnthropicProviderTests.swift
+++ b/Tests/KWWKAITests/AnthropicProviderTests.swift
@@ -22,7 +22,8 @@ final class StubSSEClient: HTTPClient, @unchecked Sendable {
         url: URL,
         method: String,
         headers: [String: String],
-        body requestBody: Data?
+        body requestBody: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         lock.withLock { lastRequest = (url, method, headers, requestBody) }
 

--- a/Tests/KWWKAITests/BedrockHardeningTests.swift
+++ b/Tests/KWWKAITests/BedrockHardeningTests.swift
@@ -244,7 +244,8 @@ struct BedrockCacheAndAuthTests {
         var lastRequest: (url: URL, method: String, headers: [String: String], body: Data?)?
         init(body: Data) { self.body = body }
         func stream(
-            url: URL, method: String, headers: [String: String], body requestBody: Data?
+            url: URL, method: String, headers: [String: String], body requestBody: Data?,
+            cancellation: CancellationHandle?
         ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
             lastRequest = (url, method, headers, requestBody)
             let response = HTTPURLResponse(

--- a/Tests/KWWKAITests/LiveCodexStreamTest.swift
+++ b/Tests/KWWKAITests/LiveCodexStreamTest.swift
@@ -61,7 +61,8 @@ struct LiveCodexStreamTests {
             url: URL(string: "https://chatgpt.com/backend-api/codex/responses")!,
             method: "POST",
             headers: headers,
-            body: bodyData
+            body: bodyData,
+            cancellation: nil
         )
         print("status=\(response.statusCode)")
         var buffer = Data()

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -125,7 +125,8 @@ final class SequentialStubClient: HTTPClient, @unchecked Sendable {
     var recorded: [(url: URL, method: String, headers: [String: String], body: Data?)] = []
 
     func stream(
-        url: URL, method: String, headers: [String: String], body: Data?
+        url: URL, method: String, headers: [String: String], body: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         recorded.append((url, method, headers, body))
         let next = queue.removeFirst()

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -19,7 +19,8 @@ final class StubResponseClient: HTTPClient, @unchecked Sendable {
     }
 
     func stream(
-        url: URL, method: String, headers: [String: String], body: Data?
+        url: URL, method: String, headers: [String: String], body: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         lock.withLock { lastRequest = (url, method, headers, body) }
         let response = HTTPURLResponse(

--- a/Tests/KWWKAITests/TransportHardeningTests.swift
+++ b/Tests/KWWKAITests/TransportHardeningTests.swift
@@ -2,6 +2,7 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+import NIO
 import Testing
 @testable import KWWKAI
 
@@ -32,7 +33,8 @@ private final class ChunkStubClient: HTTPClient, @unchecked Sendable {
     }
 
     func stream(
-        url: URL, method: String, headers: [String: String], body: Data?
+        url: URL, method: String, headers: [String: String], body: Data?,
+        cancellation: CancellationHandle?
     ) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>) {
         let response = HTTPURLResponse(
             url: url, statusCode: statusCode, httpVersion: "HTTP/1.1",
@@ -279,5 +281,47 @@ struct BedrockSignatureTests {
         } else {
             Issue.record("expected a thinking block with a captured signature")
         }
+    }
+}
+
+@Suite("URLSessionHTTPClient cancellation")
+struct URLSessionHTTPClientCancellationTests {
+    // Regression: an abort while the request is still awaiting response
+    // headers must tear down the URLSession task immediately. Before the
+    // `cancellation` bridge, nothing reached the transport in that window and
+    // the caller sat in `awaitHeader` until URLSession's 60s request timeout —
+    // the TUI showed "aborting" the whole time.
+    @Test("cancel during the await-headers window fails the request promptly")
+    func cancelDuringHeaderWait() async throws {
+        // A TCP listener with no handlers: accepts the connection, reads
+        // nothing, never writes a response — headers never arrive.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = try await ServerBootstrap(group: group)
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
+        defer { group.shutdownGracefully { _ in } }
+        let port = server.localAddress!.port!
+
+        let client = URLSessionHTTPClient()
+        let cancellation = CancellationHandle()
+        Task.detached {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            cancellation.cancel(reason: "user abort")
+        }
+        let start = DispatchTime.now()
+        do {
+            _ = try await client.stream(
+                url: URL(string: "http://127.0.0.1:\(port)/hang")!,
+                method: "POST",
+                headers: [:],
+                body: Data(),
+                cancellation: cancellation
+            )
+            Issue.record("expected the cancelled request to throw")
+        } catch {
+            // Expected: URLSession surfaces the task cancellation as an error.
+        }
+        let elapsedSeconds = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+        #expect(elapsedSeconds < 10)
     }
 }


### PR DESCRIPTION
## Problem

Pressing Esc/Ctrl-C while a provider HTTP request was still awaiting response headers left the TUI stuck on `aborting` for up to 60s. The status line's `.aborting` mode is only cleared by `.agentEnd`, and the cancel→teardown bridge (`onCancel { driveTask.cancel() }`) was registered only **after** `client.stream()` returned — so an abort landing in the await-headers window cancelled nothing at the transport level, and the turn could not end until URLSession's request timeout fired. High-incidence when the network is flaky (stream retries; codex WebSocket transport disabled after repeated failures falls back to exactly this HTTP path).

A second, narrower bug: an Esc racing the natural end of a turn (after `.agentEnd` was delivered but before `isStreaming` flipped false) re-entered `.aborting` with no further event coming — stuck permanently, since `reconcileMode` never cleared it.

## Fix

- `HTTPClient.stream` gains a `cancellation: CancellationHandle?` parameter. `URLSessionHTTPClient` registers `onCancel { task.cancel() }` before `resume()`, covering the whole request lifetime — including the header await, which is resumed only by delegate callbacks and is unreachable by consumer-task cancellation. The listener is retired on stream termination or header failure. All five streaming providers (Anthropic, OpenAI Responses, OpenAI Completions, Gemini, Bedrock) pass `options?.cancellation` through; the existing provider-side drive-task bridge is kept.
- `reconcileMode` holds `.aborting` only while the aborted owner (run or manual compaction) is still live, and `.retrying` only while streaming — so the Esc-races-turn-end case self-heals on the next 90ms spinner tick.

## Testing

- New regression test: a SwiftNIO TCP listener that accepts but never responds + cancel at 200ms; the request must fail well under the 60s URLSession timeout (observed 0.22s).
- Full suite: 1233 tests / 185 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ETaxvmCZssYaYzTbCzrC3