### PR TITLE
fix(tui): repaint when a bottom-pinned live zone shrinks

### DIFF
--- a/Sources/KWWKCli/TUI.swift
+++ b/Sources/KWWKCli/TUI.swift
@@ -59,6 +59,14 @@ final class TUI: @unchecked Sendable {
     /// erased live zone left the cursor exactly where the next output should
     /// start. Reset whenever a render draws a fresh frame.
     private var frameCleared = false
+    /// Estimated blank rows between the live zone's bottom edge and the
+    /// bottom of the screen. Each render consumes them as committed + live
+    /// output grows (once at 0 the zone is pinned to the screen bottom and
+    /// further growth scrolls history up); a shrink while pinned means the
+    /// inline redraw would strand the frame high on the screen — see
+    /// `render()`. Initialized to 0 (assume pinned): the pessimistic guess
+    /// only costs a redundant repaint, which redraws the same layout.
+    private var rowsBelowLiveZone = 0
 
     private static let disableAutowrap = "\u{1B}[?7l"
     private static let enableAutowrap = "\u{1B}[?7h"
@@ -202,6 +210,9 @@ final class TUI: @unchecked Sendable {
             lastFrameHeight = 0
             lastCursorUpBy = 0
             lastRenderedLines = []
+            // Unknown geometry after the sub-flow's output — assume pinned
+            // (the conservative guess only risks a redundant repaint).
+            rowsBelowLiveZone = 0
         }
     }
 
@@ -225,6 +236,7 @@ final class TUI: @unchecked Sendable {
             lastFrameHeight = 0
             lastCursorUpBy = 0
             lastRenderedLines = []
+            rowsBelowLiveZone = 0
             frameCleared = true
             return s
         }
@@ -356,11 +368,20 @@ final class TUI: @unchecked Sendable {
         out += live
         out += "\u{1B}[?2026l"   // end synchronized output
 
+        // Rows the replayed header + history occupy once the terminal wraps
+        // them to the current width — the live zone's bottom edge lands that
+        // far down (or at the last row once the replay overflows the screen).
+        var historyPhysical = 0
+        for line in header + history {
+            historyPhysical += line.isEmpty ? 1 : ANSI.wrap(line, width: max(1, width)).count
+        }
+
         lock.withLock {
             lastRenderedLines = rendered
             lastFrameHeight = rendered.count
             lastCursorUpBy = upBy
             frameCleared = false
+            rowsBelowLiveZone = max(0, termHeight - historyPhysical - rendered.count)
             _fullRedraws += 1
         }
         terminal.write(out)
@@ -432,6 +453,9 @@ final class TUI: @unchecked Sendable {
             lastFrameHeight = rendered.count
             lastCursorUpBy = upBy
             frameCleared = false
+            // The snapped window bottom-fills with history; whatever the tail
+            // didn't cover stays blank below the live zone.
+            rowsBelowLiveZone = max(0, available - onScreen.count)
             _fullRedraws += 1
         }
         terminal.write(out)
@@ -521,6 +545,36 @@ final class TUI: @unchecked Sendable {
             return
         }
 
+        // Update the estimate of how many blank rows remain between the live
+        // zone's bottom and the screen bottom: the inline redraw below reuses
+        // the old zone's rows and pushes the bottom edge down by however much
+        // (committed + new live) output exceeds the old height — clamped at 0,
+        // where the terminal starts scrolling instead. Committed lines are
+        // written raw at full terminal width (autowrap on), so measure their
+        // physical rows with the same wrap the terminal will apply.
+        let prevSlack = lock.withLock { rowsBelowLiveZone }
+        var committedPhysical = 0
+        for line in committed {
+            committedPhysical += line.isEmpty ? 1 : ANSI.wrap(line, width: max(1, width)).count
+        }
+        let newSlack = max(0, prevSlack + oldHeight - committedPhysical - rendered.count)
+
+        // A live zone pinned to the screen bottom (a grown frame — e.g. the
+        // /model selector — scrolled history up until its bottom hit the last
+        // row) that now shrinks by more rows than the committed lines refill:
+        // the inline redraw below would strand the new (smaller) frame where
+        // the old zone's TOP was — after a tall modal closes that's (near)
+        // the very top of the screen, with nothing but blank rows underneath,
+        // and every subsequent keystroke would keep redrawing it up there.
+        // Fall back to the authoritative repaint instead, which re-lays the
+        // committed tail and parks the live zone back against the viewport
+        // bottom. The drained commits are already retained in
+        // `committedLines`, so the repaint replays them without loss.
+        if oldHeight > 0, prevSlack == 0, newSlack > 0 {
+            repaintForResize()
+            return
+        }
+
         let shrinking = rendered.count < oldHeight && clearOnShrinkEnabled
 
         let (frame, newCursorUpBy) = renderInline(
@@ -535,6 +589,7 @@ final class TUI: @unchecked Sendable {
             lastFrameHeight = rendered.count
             lastCursorUpBy = newCursorUpBy
             frameCleared = false
+            rowsBelowLiveZone = newSlack
             if shrinking { _fullRedraws += 1 }
         }
 

--- a/Tests/KWWKCliTests/TUIRenderTests.swift
+++ b/Tests/KWWKCliTests/TUIRenderTests.swift
@@ -166,6 +166,40 @@ struct TUIShrinkageTests {
         #expect(viewport[1].trimmingCharacters(in: .whitespaces) == "")
         tui.stop()
     }
+
+    @Test("shrinking from a full-height live zone repaints instead of stranding the frame at the top")
+    func fullHeightShrinkRepaints() async throws {
+        let terminal = VirtualTerminal(width: 40, height: 10)
+        let tui = TUI(terminal: terminal)
+        let comp = TestLinesComponent(["input", "footer"])
+        tui.addChild(comp)
+        tui.start()
+        tui.commit((0..<12).map { "h\($0)" })
+        tui.requestRender()
+        await terminal.waitForRender()
+
+        // A full-height modal takes over the live zone (top pinned to row 0).
+        comp.lines = (0..<10).map { "modal row \($0)" }
+        tui.requestRender()
+        await terminal.waitForRender()
+        // (VirtualTerminal doesn't scroll, so the overflowing modal rows pile
+        // up on the bottom row — the retained frame height is what matters.)
+        #expect(terminal.getViewport()[9].contains("modal row 9"))
+
+        // Closing the modal shrinks the zone back to the prompt frame. The
+        // inline redraw would leave it at the very top of the screen with
+        // blank rows below; the fix repaints so the committed tail comes back
+        // and the frame sits below it, against the viewport bottom.
+        comp.lines = ["input", "footer"]
+        tui.requestRender()
+        await terminal.waitForRender()
+
+        let viewport = terminal.getViewport()
+        #expect(!viewport[0].contains("input"))
+        #expect(viewport[0].hasPrefix("h"))
+        #expect(viewport[9].contains("footer"))
+        tui.stop()
+    }
 }
 
 @Suite("TUI suspend/resume geometry")


### PR DESCRIPTION
## Problem

After picking a model in the `/model` selector, the prompt box jumps to the very top of the screen with nothing but blank rows underneath — and every subsequent keystroke keeps redrawing it up there. Scrolling up (tmux copy mode) only helps until the next key press snaps the view back.

Repro (tmux, 100×30): launch `kwwk` → `/model` → pick a model → the prompt frame lands on rows 0–5 of the pane (`cursor_y=5`), the remaining 24 rows blank.

## Root cause

The inline renderer anchors the live zone at the cursor and grows downward. A tall modal grows the zone until the terminal scrolls, which pushes the zone's anchor to (near) the top of the screen. On close, `renderInline` rewinds to the anchor and draws the shrunken frame there — the top of the screen — because nothing ever re-anchors the frame against the viewport bottom.

## Fix

`TUI` now tracks an estimate of the blank rows between the live zone's bottom edge and the screen bottom (`rowsBelowLiveZone`): each render consumes them as committed + live output outgrows the previous frame, clamped at 0 — pinned — where further growth scrolls history instead. When a **pinned** zone shrinks by more rows than the committed lines refill, the render falls back to the existing authoritative repaint (`fullRepaint` on direct terminals, `multiplexerRepaint` inside tmux/screen/zellij), which re-lays the committed tail and parks the live zone back against the viewport bottom. The drained commits are already retained in `committedLines`, so the repaint replays them without loss.

The estimate is maintained by all repaint/clear paths, and initialized pessimistically to 0 (assume pinned): a wrong pessimistic guess only costs one redundant repaint that redraws the identical layout.

## Verification

- New regression test: "shrinking from a full-height live zone repaints instead of stranding the frame at the top"; full suite passes (1247 tests).
- tmux end-to-end: after model selection the transcript tail is restored and the prompt sits below it (`cursor_y=21` in a 30-row pane); in a 14-row pane (pinned case) select/cancel both keep the prompt at the pane bottom; a real streamed turn renders/commits normally afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inline render geometry and triggers full repaints on a specific shrink path; behavior is localized to TUI rendering with a dedicated test.
> 
> **Overview**
> Fixes the prompt jumping to the top of the screen (with blank rows below) after closing a tall UI like the `/model` selector.
> 
> **`TUI`** now tracks **`rowsBelowLiveZone`**, an estimate of blank rows under the live zone. Normal renders consume that slack as output grows; at **0** the zone is treated as **pinned** to the viewport bottom. When a pinned zone **shrinks** by more than committed lines refill, inline redraw is skipped in favor of **`repaintForResize()`** (`fullRepaint` or multiplexer snap), which replays the committed tail and parks the prompt at the bottom again. The estimate is reset on clear/resume and refreshed after full/multiplexer repaints.
> 
> Adds a regression test: shrinking from a full-height live zone must repaint instead of stranding the frame at row 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482c16419d750b304e212e5919f20e26b293bcc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->