### PR TITLE
feat(cli): add Kimi For Coding and Z.AI Coding Plan to /login and /model

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A Swift-native coding agent with two faces:
 
 - **`kwwk`** — an interactive coding CLI (TUI) that drives your existing
-  Anthropic, ChatGPT (Codex), or GitHub Copilot subscription — or an API
-  key for Anthropic, OpenAI, Google (Gemini), OpenRouter, or any
-  OpenAI-compatible endpoint.
+  Anthropic, ChatGPT (Codex), GitHub Copilot, Cursor, or Kimi For Coding
+  subscription — or an API key for Anthropic, OpenAI, Google (Gemini),
+  OpenRouter, the Z.AI GLM Coding Plan, or any OpenAI-compatible endpoint.
 - **`KWWKAgent` / `KWWKAI`** — the agent runtime underneath, exposed as
   SwiftPM libraries so you can embed it in your own app, build custom
   tools, or swap the LLM provider.
@@ -45,8 +45,9 @@ Credentials come from the OAuth store at `~/.kwwk/oauth.json`; if no login
 exists, the CLI checks supported API-key environment variables. With
 neither configured, kwwk starts logged out — launch it and run `/login`
 to sign in to a provider (OAuth subscription like ChatGPT Codex, Copilot,
-or Claude Code; or an API key for Anthropic, OpenAI, Google (Gemini),
-OpenRouter, or any OpenAI-compatible endpoint).
+Claude Code, Cursor, or Kimi For Coding; or an API key for Anthropic,
+OpenAI, Google (Gemini), OpenRouter, the Z.AI GLM Coding Plan, or any
+OpenAI-compatible endpoint).
 
 Inside the TUI, `/help` lists slash commands (`/model`, `/thinking`,
 `/clear`, …). The agent ships with Bash, Read, Write, Edit, Grep, Find,

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -224,6 +224,7 @@ public actor OAuthManager {
             OpenAICodexOAuthProvider(),
             GitHubCopilotOAuthProvider(),
             CursorOAuthProvider(),
+            KimiCodingOAuthProvider(),
         ]
     }
 

--- a/Sources/KWWKAI/OAuthLogin.swift
+++ b/Sources/KWWKAI/OAuthLogin.swift
@@ -318,6 +318,107 @@ public enum OAuthLogin {
         throw OAuthError.transport("copilot device flow timed out")
     }
 
+    // MARK: - Kimi For Coding (device flow)
+    //
+    // Kimi's coding plan uses an OAuth device-authorization grant against
+    // `auth.kimi.com`: POST `/api/oauth/device_authorization` for a one-time
+    // user code, hand the verification URL to the browser, and poll
+    // `/api/oauth/token` until the user approves. Mirrors oh-my-pi's
+    // `loginKimi`. Every request carries the `X-Msh-*` device headers.
+
+    public static func loginKimiCoding(
+        clientID: String = KimiOAuth.clientID,
+        host: URL = KimiOAuth.host,
+        // Injectable for tests; the default persists one at
+        // `~/.kwwk/kimi-device-id`.
+        deviceId: String? = nil,
+        callbacks: Callbacks,
+        client: HTTPClient = URLSessionHTTPClient()
+    ) async throws -> OAuthCredentials {
+        var headers = KimiOAuth.commonHeaders(deviceId: deviceId)
+        headers["accept"] = "application/json"
+        headers["content-type"] = "application/x-www-form-urlencoded"
+
+        callbacks.onProgress("requesting Kimi device code…")
+        let (deviceResponse, deviceBody) = try await client.request(
+            url: host.appendingPathComponent("api/oauth/device_authorization"),
+            method: "POST",
+            headers: headers,
+            body: Data(OAuth.urlEncodedForm(["client_id": clientID]).utf8)
+        )
+        if deviceResponse.statusCode >= 400 {
+            throw OAuthError.refreshFailed("kimi device code \(deviceResponse.statusCode): \(String(data: deviceBody, encoding: .utf8) ?? "")")
+        }
+        guard let obj = try JSONSerialization.jsonObject(with: deviceBody) as? [String: Any],
+              let userCode = obj["user_code"] as? String,
+              let deviceCode = obj["device_code"] as? String,
+              let verifyURLString = (obj["verification_uri_complete"] as? String)
+                ?? (obj["verification_uri"] as? String),
+              let verifyURL = URL(string: verifyURLString) else {
+            throw OAuthError.invalidResponse("kimi device code response")
+        }
+        var intervalSec = (obj["interval"] as? Int).flatMap { $0 >= 0 ? $0 : nil } ?? 5
+        let expiresInSec = (obj["expires_in"] as? Int) ?? 15 * 60
+
+        callbacks.onAuthURL(verifyURL)
+        callbacks.onProgress("enter code in your browser: \(userCode)")
+
+        // Poll for the token until the user approves (or the code expires).
+        let pollURL = host.appendingPathComponent("api/oauth/token")
+        let deadline = Date().addingTimeInterval(TimeInterval(expiresInSec))
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: UInt64(intervalSec) * 1_000_000_000)
+            let (pollResponse, pollBody) = try await client.request(
+                url: pollURL,
+                method: "POST",
+                headers: headers,
+                body: Data(OAuth.urlEncodedForm([
+                    "client_id": clientID,
+                    "device_code": deviceCode,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                ]).utf8)
+            )
+            guard let polled = try? JSONSerialization.jsonObject(with: pollBody) as? [String: Any] else {
+                if pollResponse.statusCode >= 400 {
+                    throw OAuthError.refreshFailed("kimi device flow: HTTP \(pollResponse.statusCode)")
+                }
+                continue
+            }
+            if let err = polled["error"] as? String {
+                switch err {
+                case "authorization_pending":
+                    continue
+                case "slow_down":
+                    intervalSec += 5
+                    if let serverInterval = polled["interval"] as? Int, serverInterval > intervalSec {
+                        intervalSec = serverInterval
+                    }
+                    continue
+                case "expired_token":
+                    throw OAuthError.refreshFailed("kimi device authorization expired")
+                case "access_denied":
+                    throw OAuthError.refreshFailed("kimi device authorization denied")
+                default:
+                    let description = (polled["error_description"] as? String).map { ": \($0)" } ?? ""
+                    throw OAuthError.refreshFailed("kimi device flow: \(err)\(description)")
+                }
+            }
+            if pollResponse.statusCode < 400, let access = polled["access_token"] as? String {
+                guard let refresh = polled["refresh_token"] as? String, !refresh.isEmpty else {
+                    throw OAuthError.invalidResponse("kimi token response missing refresh token")
+                }
+                let expiresIn = (polled["expires_in"] as? Int) ?? 15 * 60
+                let now = Int64(Date().timeIntervalSince1970 * 1000)
+                return OAuthCredentials(
+                    access: access,
+                    refresh: refresh,
+                    expires: now + Int64(expiresIn) * 1000 - 5 * 60 * 1000
+                )
+            }
+        }
+        throw OAuthError.transport("kimi device flow timed out")
+    }
+
     // MARK: - JSON helpers
 
     private static func postJSON(

--- a/Sources/KWWKAI/OAuthLogin.swift
+++ b/Sources/KWWKAI/OAuthLogin.swift
@@ -364,8 +364,12 @@ public enum OAuthLogin {
         callbacks.onProgress("enter code in your browser: \(userCode)")
 
         // Poll for the token until the user approves (or the code expires).
+        // Transient HTTP failures with non-JSON bodies (gateway errors, …)
+        // are retried; only 3 consecutive ones abort the flow, so a blip
+        // can't kill an authorization the user is mid-way through.
         let pollURL = host.appendingPathComponent("api/oauth/token")
         let deadline = Date().addingTimeInterval(TimeInterval(expiresInSec))
+        var consecutiveErrors = 0
         while Date() < deadline {
             try await Task.sleep(nanoseconds: UInt64(intervalSec) * 1_000_000_000)
             let (pollResponse, pollBody) = try await client.request(
@@ -380,10 +384,14 @@ public enum OAuthLogin {
             )
             guard let polled = try? JSONSerialization.jsonObject(with: pollBody) as? [String: Any] else {
                 if pollResponse.statusCode >= 400 {
-                    throw OAuthError.refreshFailed("kimi device flow: HTTP \(pollResponse.statusCode)")
+                    consecutiveErrors += 1
+                    if consecutiveErrors >= 3 {
+                        throw OAuthError.refreshFailed("kimi device flow: HTTP \(pollResponse.statusCode)")
+                    }
                 }
                 continue
             }
+            consecutiveErrors = 0
             if let err = polled["error"] as? String {
                 switch err {
                 case "authorization_pending":

--- a/Sources/KWWKAI/OAuthProviders.swift
+++ b/Sources/KWWKAI/OAuthProviders.swift
@@ -235,6 +235,141 @@ public struct CursorOAuthProvider: OAuthProvider {
     }
 }
 
+// MARK: - Kimi For Coding (Moonshot coding plan)
+//
+// Kimi's coding-plan auth is an OAuth device-authorization grant against
+// `auth.kimi.com` (see `OAuthLogin.loginKimiCoding`). Refresh is a standard
+// `grant_type=refresh_token` form POST to the same token endpoint. Every
+// request carries the `X-Msh-*` device-identity headers the Kimi CLI sends.
+
+public struct KimiCodingOAuthProvider: OAuthProvider {
+    public let id = "kimi-coding"
+    public let name = "Kimi For Coding"
+    public let tokenURL: URL
+    public let clientID: String
+    /// Injectable for tests; the default persists one at
+    /// `~/.kwwk/kimi-device-id`.
+    public let deviceId: String?
+
+    public init(
+        tokenURL: URL = URL(string: "https://auth.kimi.com/api/oauth/token")!,
+        clientID: String = KimiOAuth.clientID,
+        deviceId: String? = nil
+    ) {
+        self.tokenURL = tokenURL
+        self.clientID = clientID
+        self.deviceId = deviceId
+    }
+
+    public func refresh(
+        _ credentials: OAuthCredentials, using client: HTTPClient
+    ) async throws -> OAuthCredentials {
+        let form = OAuth.urlEncodedForm([
+            "grant_type": "refresh_token",
+            "refresh_token": credentials.refresh,
+            "client_id": clientID,
+        ])
+        var headers = KimiOAuth.commonHeaders(deviceId: deviceId)
+        headers["content-type"] = "application/x-www-form-urlencoded"
+        headers["accept"] = "application/json"
+        let (response, body) = try await client.request(
+            url: tokenURL, method: "POST", headers: headers, body: Data(form.utf8)
+        )
+        if response.statusCode >= 400 {
+            let text = String(data: body, encoding: .utf8) ?? ""
+            throw OAuthError.refreshFailed("kimi-coding \(response.statusCode): \(text)")
+        }
+        let json = try OAuth.decodeTokenResponse(body)
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        return OAuthCredentials(
+            access: json.accessToken,
+            refresh: json.refreshToken ?? credentials.refresh,
+            expires: now + Int64(json.expiresIn * 1000) - 5 * 60 * 1000,
+            extras: credentials.extras
+        )
+    }
+}
+
+/// Constants + device-identity headers shared by the Kimi device-flow login
+/// and the refresh provider. Kimi's endpoints expect the CLI's `X-Msh-*`
+/// fingerprint headers alongside a `KimiCLI/<version>` User-Agent (the same
+/// agent string the bundled kimi-coding catalog models pin for chat requests).
+public enum KimiOAuth {
+    public static let clientID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+    public static let host = URL(string: "https://auth.kimi.com")!
+    /// Keep in sync with the `User-Agent` header on the bundled `kimi-coding`
+    /// catalog models.
+    static let cliVersion = "1.5"
+
+    /// Headers for Kimi OAuth endpoints. `deviceId` is injectable for tests;
+    /// the default persists a random id at `~/.kwwk/kimi-device-id` so the
+    /// device fingerprint is stable across logins.
+    public static func commonHeaders(deviceId: String? = nil) -> [String: String] {
+        [
+            "User-Agent": "KimiCLI/\(cliVersion)",
+            "X-Msh-Platform": "kimi_cli",
+            "X-Msh-Version": cliVersion,
+            "X-Msh-Device-Name": sanitized(ProcessInfo.processInfo.hostName),
+            "X-Msh-Device-Model": sanitized(deviceModel()),
+            "X-Msh-Os-Version": sanitized(ProcessInfo.processInfo.operatingSystemVersionString),
+            "X-Msh-Device-Id": sanitized(deviceId ?? persistentDeviceId()),
+        ]
+    }
+
+    /// Header values must be printable ASCII; anything else (or an empty
+    /// result) collapses to "unknown".
+    private static func sanitized(_ value: String) -> String {
+        let filtered = value.unicodeScalars
+            .filter { $0.value >= 0x20 && $0.value <= 0x7E }
+            .map(Character.init)
+        let result = String(filtered).trimmingCharacters(in: .whitespaces)
+        return result.isEmpty ? "unknown" : result
+    }
+
+    private static func deviceModel() -> String {
+        #if os(macOS)
+        let system = "macOS"
+        #elseif os(Linux)
+        let system = "Linux"
+        #else
+        let system = "unknown"
+        #endif
+        #if arch(arm64)
+        let arch = "arm64"
+        #elseif arch(x86_64)
+        let arch = "x86_64"
+        #else
+        let arch = "unknown"
+        #endif
+        return "\(system) \(arch)"
+    }
+
+    /// Read (or create, 0600) the stable device id beside the OAuth store.
+    /// Best-effort: an unwritable directory falls back to a fresh id per run.
+    static func persistentDeviceId(
+        at url: URL = OAuthStore.defaultURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("kimi-device-id")
+    ) -> String {
+        if let existing = try? String(contentsOf: url, encoding: .utf8) {
+            let trimmed = existing.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        let fresh = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        _ = FileManager.default.createFile(
+            atPath: url.path,
+            contents: Data("\(fresh)\n".utf8),
+            attributes: [.posixPermissions: 0o600]
+        )
+        return fresh
+    }
+}
+
 // MARK: - Helpers
 
 enum OAuth {

--- a/Sources/KWWKAI/OAuthProviders.swift
+++ b/Sources/KWWKAI/OAuthProviders.swift
@@ -344,8 +344,16 @@ public enum KimiOAuth {
         return "\(system) \(arch)"
     }
 
+    /// Process-stable fallback id, used only when the id file can't be
+    /// written: login and refresh both go through `commonHeaders`, and Kimi
+    /// may reject a refresh whose `X-Msh-Device-Id` differs from login's, so
+    /// the id must at least survive the process even when it can't survive
+    /// a restart.
+    private static let fallbackLock = NSLock()
+    nonisolated(unsafe) private static var fallbackDeviceId: String?
+
     /// Read (or create, 0600) the stable device id beside the OAuth store.
-    /// Best-effort: an unwritable directory falls back to a fresh id per run.
+    /// Best-effort: an unwritable directory falls back to one id per process.
     static func persistentDeviceId(
         at url: URL = OAuthStore.defaultURL()
             .deletingLastPathComponent()
@@ -361,11 +369,16 @@ public enum KimiOAuth {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700]
         )
-        _ = FileManager.default.createFile(
+        let wrote = FileManager.default.createFile(
             atPath: url.path,
             contents: Data("\(fresh)\n".utf8),
             attributes: [.posixPermissions: 0o600]
         )
+        if wrote { return fresh }
+        fallbackLock.lock()
+        defer { fallbackLock.unlock() }
+        if let cached = fallbackDeviceId { return cached }
+        fallbackDeviceId = fresh
         return fresh
     }
 }

--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -60,12 +60,17 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             // environment; provider variants that support Cloudflare pass
             // explicit values through their own URL builders.
             base = substituteCloudflarePlaceholders(in: base, value: { _ in nil })
-            // Tolerate catalog entries that bake `/v1` into baseURL
-            // (pi-mono's models.generated.ts does this for OpenAI).
-            // Without this, the session baseURL `https://api.openai.com`
-            // → `/v1/chat/completions`, but a `/model` swap pulls in
-            // `https://api.openai.com/v1` and we'd double-suffix.
-            let versioned = base.hasSuffix("/v1") ? base : "\(base)/v1"
+            // Tolerate catalog entries that bake a version segment into
+            // baseURL — pi-mono's models.generated.ts does this for OpenAI
+            // (`…/v1`) and Z.AI (`…/coding/paas/v4`). Without this, the
+            // session baseURL `https://api.openai.com` → `/v1/chat/completions`,
+            // but a `/model` swap pulls in `https://api.openai.com/v1` and
+            // we'd double-suffix; Z.AI's `/v4` would gain a bogus `/v1`.
+            let lastSegment = base.split(separator: "/").last ?? ""
+            let alreadyVersioned = lastSegment.count > 1
+                && lastSegment.first == "v"
+                && lastSegment.dropFirst().allSatisfy(\.isNumber)
+            let versioned = alreadyVersioned ? base : "\(base)/v1"
             return URL(string: "\(versioned)/chat/completions")
                 ?? fallback.appendingPathComponent("v1/chat/completions")
         }

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -264,6 +264,10 @@ func registerStored(
         return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "cursor":
         return await registerCursor(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+    case "kimi-coding":
+        return await registerKimiCoding(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+    case "zai", "zai-coding-cn":
+        return await registerZai(storeId: storeId, creds: creds, modelOverride: modelOverride)
     default:
         FileHandle.standardError.write(Data(
             "kwwk: stored credentials for '\(storeId)' aren't wired up; skipping.\n".utf8
@@ -807,6 +811,101 @@ private func registerCursor(
         model: model,
         modelLabel: "\(modelId) · Cursor",
         authResolver: oauthResolver(manager: manager, providerId: "cursor", scheme: .bearer)
+    )
+}
+
+// MARK: - Kimi For Coding (OAuth device flow)
+
+private func registerKimiCoding(
+    store: OAuthStore,
+    creds: OAuthCredentials,
+    modelOverride: String? = nil,
+    primeToken: Bool = true
+) async -> ResolvedAuth {
+    let manager = OAuthManager(store: store)
+    // Prime the token only for the active provider; the resolver refreshes
+    // lazily on the first request for the others.
+    if primeToken {
+        _ = try? await manager.apiKey(for: "kimi-coding")
+    }
+
+    // Kimi's coding endpoint speaks anthropic-messages but authenticates with
+    // a Bearer token instead of `x-api-key`. The resolver below supplies the
+    // OAuth token per request; the header builder covers any static-key path.
+    await APIRegistry.shared.register(AnthropicProvider(
+        authHeaderBuilder: { key in ["Authorization": cliBearerHeaderValue(key)] }
+    ), scope: "kimi-coding")
+
+    let modelId = modelOverride ?? "kimi-for-coding"
+    let catalog = ModelsCatalog.model(provider: "kimi-coding", id: modelId)
+    let model = Model(
+        id: modelId,
+        name: catalog?.name ?? modelId,
+        api: "anthropic-messages",
+        provider: "kimi-coding",
+        baseURL: catalog?.baseURL ?? "https://api.kimi.com/coding",
+        reasoning: catalog?.reasoning ?? true,
+        input: catalog?.input ?? [.text, .image],
+        cost: catalog?.cost ?? ModelCost(),
+        contextWindow: catalog?.contextWindow ?? 262_144,
+        maxTokens: catalog?.maxTokens ?? 32_768,
+        // Uncatalogued ids still need the KimiCLI agent string the coding
+        // endpoint expects.
+        headers: catalog?.headers ?? ["User-Agent": "KimiCLI/1.5"],
+        compat: catalog?.compat,
+        thinkingLevelMap: catalog?.thinkingLevelMap
+    )
+    return ResolvedAuth(
+        model: model,
+        modelLabel: "\(modelId) · Kimi For Coding",
+        authResolver: oauthResolver(manager: manager, providerId: "kimi-coding", scheme: .bearer)
+    )
+}
+
+// MARK: - Z.AI GLM Coding Plan (login form)
+
+private func registerZai(
+    storeId: String,
+    creds: OAuthCredentials,
+    modelOverride: String? = nil
+) async -> ResolvedAuth {
+    await APIRegistry.shared.register(
+        OpenAICompletionsProvider(defaultAPIKey: creds.access),
+        scope: storeId
+    )
+
+    let fallbackBase = storeId == "zai-coding-cn"
+        ? "https://open.bigmodel.cn/api/coding/paas/v4"
+        : "https://api.z.ai/api/coding/paas/v4"
+    let modelId = modelOverride ?? "glm-5.2"
+    let catalog = ModelsCatalog.model(provider: storeId, id: modelId)
+    // Uncatalogued ids still route with the Z.AI thinking format so reasoning
+    // deltas keep parsing.
+    let fallbackCompat: ModelCompat = {
+        var c = ModelCompat()
+        c.thinkingFormat = "zai"
+        c.zaiToolStream = true
+        return c
+    }()
+    let model = Model(
+        id: modelId,
+        name: catalog?.name ?? modelId,
+        api: "openai-completions",
+        provider: storeId,
+        baseURL: catalog?.baseURL ?? fallbackBase,
+        reasoning: catalog?.reasoning ?? true,
+        input: catalog?.input ?? [.text],
+        cost: catalog?.cost ?? ModelCost(),
+        contextWindow: catalog?.contextWindow ?? 204_800,
+        maxTokens: catalog?.maxTokens ?? 131_072,
+        headers: catalog?.headers,
+        compat: catalog?.compat ?? fallbackCompat,
+        thinkingLevelMap: catalog?.thinkingLevelMap
+    )
+    return ResolvedAuth(
+        model: model,
+        modelLabel: "\(modelId) · \(providerDisplayName(forStoreId: storeId))",
+        authResolver: nil
     )
 }
 

--- a/Sources/KWWKCli/AuthResolver.swift
+++ b/Sources/KWWKCli/AuthResolver.swift
@@ -838,6 +838,14 @@ private func registerKimiCoding(
 
     let modelId = modelOverride ?? "kimi-for-coding"
     let catalog = ModelsCatalog.model(provider: "kimi-coding", id: modelId)
+    // Uncatalogued ids still need the thinking wire shape every bundled
+    // kimi-coding model pins (adaptive thinking, unsigned thinking blocks).
+    let fallbackCompat: ModelCompat = {
+        var c = ModelCompat()
+        c.allowEmptySignature = true
+        c.forceAdaptiveThinking = true
+        return c
+    }()
     let model = Model(
         id: modelId,
         name: catalog?.name ?? modelId,
@@ -852,7 +860,7 @@ private func registerKimiCoding(
         // Uncatalogued ids still need the KimiCLI agent string the coding
         // endpoint expects.
         headers: catalog?.headers ?? ["User-Agent": "KimiCLI/1.5"],
-        compat: catalog?.compat,
+        compat: catalog?.compat ?? fallbackCompat,
         thinkingLevelMap: catalog?.thinkingLevelMap
     )
     return ResolvedAuth(

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -40,6 +40,11 @@ let loginProviders: [LoginEntry] = [
         flow: .oauth
     ),
     LoginEntry(
+        id: "kimi-coding",
+        display: "Kimi For Coding (Moonshot coding plan)",
+        flow: .oauth
+    ),
+    LoginEntry(
         id: "anthropic-api-key",
         display: "Anthropic API key (api.anthropic.com)",
         flow: .apiKey(
@@ -132,6 +137,38 @@ let loginProviders: [LoginEntry] = [
                 ),
             ],
             extrasKeys: ["defaultModel"]
+        )
+    ),
+    LoginEntry(
+        id: "zai",
+        display: "Z.AI GLM Coding Plan (api.z.ai)",
+        flow: .apiKey(
+            fields: [
+                APIKeyFormField(
+                    key: "apiKey",
+                    label: "API key",
+                    hint: "from z.ai/manage-apikey/apikey-list",
+                    placeholder: "sk-…",
+                    required: true
+                ),
+            ],
+            extrasKeys: []
+        )
+    ),
+    LoginEntry(
+        id: "zai-coding-cn",
+        display: "Z.AI GLM Coding Plan — China (open.bigmodel.cn)",
+        flow: .apiKey(
+            fields: [
+                APIKeyFormField(
+                    key: "apiKey",
+                    label: "API key",
+                    hint: "from bigmodel.cn API-keys console",
+                    placeholder: "…",
+                    required: true
+                ),
+            ],
+            extrasKeys: []
         )
     ),
     LoginEntry(
@@ -249,6 +286,8 @@ func runOAuthFlow(providerId: String) async throws {
             return try await OAuthLogin.loginGitHubCopilot(callbacks: callbacks)
         case "cursor":
             return try await OAuthLogin.loginCursor(callbacks: callbacks)
+        case "kimi-coding":
+            return try await OAuthLogin.loginKimiCoding(callbacks: callbacks)
         default:
             throw LoginError.unknownProvider(providerId)
         }

--- a/Sources/KWWKCli/ProviderDirectory.swift
+++ b/Sources/KWWKCli/ProviderDirectory.swift
@@ -99,6 +99,27 @@ let providerDirectory: [ProviderDescriptor] = [
         displayName: "Cursor",
         formTitle: nil
     ),
+    ProviderDescriptor(
+        storeId: "kimi-coding",
+        scope: "kimi-coding",
+        catalogKey: "kimi-coding",
+        displayName: "Kimi For Coding",
+        formTitle: nil
+    ),
+    ProviderDescriptor(
+        storeId: "zai",
+        scope: "zai",
+        catalogKey: "zai",
+        displayName: "Z.AI Coding Plan",
+        formTitle: "Z.AI API key"
+    ),
+    ProviderDescriptor(
+        storeId: "zai-coding-cn",
+        scope: "zai-coding-cn",
+        catalogKey: "zai-coding-cn",
+        displayName: "Z.AI Coding Plan (China)",
+        formTitle: "Z.AI API key (China)"
+    ),
 ]
 
 /// Descriptor for a store id, or nil for unknown / `env:` sentinel ids —

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -168,6 +168,50 @@ struct OAuthLoginShapeTests {
         }
     }
 
+    @Test("kimi device flow rides a transient non-JSON HTTP error")
+    func kimiDeviceFlowTransientError() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.kimi.com/device","interval":0,"expires_in":900}"#
+        ))
+        // A gateway blip with an HTML body must be retried, not surfaced.
+        client.queue.append((status: 502, body: "<html>bad gateway</html>"))
+        client.queue.append((
+            status: 200,
+            body: #"{"access_token":"kimi-access","refresh_token":"kimi-refresh","expires_in":3600}"#
+        ))
+        let creds = try await OAuthLogin.loginKimiCoding(
+            clientID: "test-client",
+            deviceId: "test-device",
+            callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+            client: client
+        )
+        #expect(creds.access == "kimi-access")
+        #expect(client.recorded.count == 3)
+    }
+
+    @Test("kimi device flow aborts after 3 consecutive hard HTTP errors")
+    func kimiDeviceFlowConsecutiveErrors() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.kimi.com/device","interval":0,"expires_in":900}"#
+        ))
+        for _ in 0..<3 {
+            client.queue.append((status: 502, body: "<html>bad gateway</html>"))
+        }
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginKimiCoding(
+                clientID: "test-client",
+                deviceId: "test-device",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+        #expect(client.recorded.count == 4)
+    }
+
     @Test("kimi device flow surfaces access_denied instead of polling forever")
     func kimiDeviceFlowDenied() async throws {
         let client = SequentialStubClient()

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -116,6 +116,107 @@ struct OAuthLoginShapeTests {
         #expect(pollBody.contains("device_code=DC"))
         #expect(pollBody.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"))
     }
+
+    @Test("kimi device flow rides authorization_pending and returns both tokens")
+    func kimiDeviceFlowShape() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC-1234","verification_uri":"https://auth.kimi.com/device","verification_uri_complete":"https://auth.kimi.com/device?code=UC-1234","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 400,
+            body: #"{"error":"authorization_pending"}"#
+        ))
+        client.queue.append((
+            status: 200,
+            body: #"{"access_token":"kimi-access","refresh_token":"kimi-refresh","expires_in":3600}"#
+        ))
+
+        let authURL = CapturedURL()
+        let creds = try await OAuthLogin.loginKimiCoding(
+            clientID: "test-client",
+            deviceId: "test-device",
+            callbacks: OAuthLogin.Callbacks(
+                onAuthURL: { authURL.set($0) },
+                onProgress: { _ in }
+            ),
+            client: client
+        )
+        #expect(creds.access == "kimi-access")
+        #expect(creds.refresh == "kimi-refresh")
+        // The complete verification URL (with the embedded code) is preferred.
+        #expect(authURL.get()?.absoluteString == "https://auth.kimi.com/device?code=UC-1234")
+
+        // First call: device authorization request with the fingerprint headers.
+        let device = client.recorded[0]
+        #expect(device.url.absoluteString == "https://auth.kimi.com/api/oauth/device_authorization")
+        let deviceBody = String(data: device.body ?? Data(), encoding: .utf8) ?? ""
+        #expect(deviceBody == "client_id=test-client")
+        #expect(device.headers["X-Msh-Platform"] == "kimi_cli")
+        #expect(device.headers["X-Msh-Device-Id"] == "test-device")
+        #expect(device.headers["User-Agent"]?.hasPrefix("KimiCLI/") == true)
+
+        // Polls carry device_code + the device-code grant; the pending
+        // response is retried rather than surfaced.
+        #expect(client.recorded.count == 3)
+        for poll in client.recorded[1...] {
+            #expect(poll.url.absoluteString == "https://auth.kimi.com/api/oauth/token")
+            let body = String(data: poll.body ?? Data(), encoding: .utf8) ?? ""
+            #expect(body.contains("device_code=DC"))
+            #expect(body.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"))
+        }
+    }
+
+    @Test("kimi device flow surfaces access_denied instead of polling forever")
+    func kimiDeviceFlowDenied() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.kimi.com/device","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 400,
+            body: #"{"error":"access_denied"}"#
+        ))
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginKimiCoding(
+                clientID: "test-client",
+                deviceId: "test-device",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+    }
+
+    @Test("kimi token response without a refresh token is rejected")
+    func kimiDeviceFlowMissingRefresh() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.kimi.com/device","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 200,
+            body: #"{"access_token":"kimi-access","expires_in":3600}"#
+        ))
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginKimiCoding(
+                clientID: "test-client",
+                deviceId: "test-device",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+    }
+}
+
+/// Thread-safe URL capture for @Sendable callback assertions.
+private final class CapturedURL: @unchecked Sendable {
+    private let lock = NSLock()
+    private var url: URL?
+    func set(_ u: URL) { lock.withLock { url = u } }
+    func get() -> URL? { lock.withLock { url } }
 }
 
 // MARK: - Stub helpers

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -250,6 +250,33 @@ struct KimiCodingOAuthTests {
     func kimiInDefaultProviders() {
         #expect(OAuthManager.defaultProviders().contains { $0.id == "kimi-coding" })
     }
+
+    @Test("device id stays process-stable when the id file can't be written")
+    func deviceIdFallbackIsStable() {
+        // /dev/null can't grow a subdirectory, so both the read and the
+        // write fail — the process-wide fallback id must be returned, and
+        // must be the same on every call (login and refresh share one
+        // device fingerprint).
+        let unwritable = URL(fileURLWithPath: "/dev/null/kwwk-test/kimi-device-id")
+        let first = KimiOAuth.persistentDeviceId(at: unwritable)
+        let second = KimiOAuth.persistentDeviceId(at: unwritable)
+        #expect(!first.isEmpty)
+        #expect(first == second)
+    }
+
+    @Test("device id round-trips through its file")
+    func deviceIdPersists() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-kimi-device-\(UUID().uuidString.prefix(8))")
+        let url = dir.appendingPathComponent("kimi-device-id")
+        let first = KimiOAuth.persistentDeviceId(at: url)
+        let second = KimiOAuth.persistentDeviceId(at: url)
+        #expect(first == second)
+        let onDisk = try String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(onDisk == first)
+        try? FileManager.default.removeItem(at: dir)
+    }
 }
 
 @Suite("OAuthManager integration")

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -204,6 +204,54 @@ struct GitHubCopilotOAuthTests {
     }
 }
 
+@Suite("OAuth refresh — Kimi For Coding")
+struct KimiCodingOAuthTests {
+    @Test("form POST with grant_type=refresh_token + X-Msh device headers")
+    func kimiRefresh() async throws {
+        let body = #"""
+        {"access_token":"kimi-new","refresh_token":"kimi-refresh-2","expires_in":3600}
+        """#
+        let client = StubResponseClient(body: Data(body.utf8))
+        let updated = try await KimiCodingOAuthProvider(deviceId: "test-device").refresh(
+            OAuthCredentials(access: "old", refresh: "kimi-refresh-1", expires: 0),
+            using: client
+        )
+        #expect(updated.access == "kimi-new")
+        #expect(updated.refresh == "kimi-refresh-2")
+        // Refreshed ~5 minutes before the hour-long expiry.
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        #expect(updated.expires > now + 50 * 60 * 1000)
+        #expect(updated.expires <= now + 60 * 60 * 1000)
+
+        let req = client.lastRequest!
+        #expect(req.method == "POST")
+        #expect(req.url.absoluteString == "https://auth.kimi.com/api/oauth/token")
+        let form = String(data: req.body ?? Data(), encoding: .utf8) ?? ""
+        #expect(form.contains("grant_type=refresh_token"))
+        #expect(form.contains("refresh_token=kimi-refresh-1"))
+        #expect(form.contains("client_id=\(KimiOAuth.clientID)"))
+        #expect(req.headers["X-Msh-Platform"] == "kimi_cli")
+        #expect(req.headers["X-Msh-Device-Id"] == "test-device")
+        #expect(req.headers["User-Agent"]?.hasPrefix("KimiCLI/") == true)
+    }
+
+    @Test("keeps the old refresh token when the server omits a new one")
+    func kimiRefreshKeepsOldToken() async throws {
+        let body = #"{"access_token":"kimi-new","expires_in":3600}"#
+        let client = StubResponseClient(body: Data(body.utf8))
+        let updated = try await KimiCodingOAuthProvider(deviceId: "test-device").refresh(
+            OAuthCredentials(access: "old", refresh: "keep-me", expires: 0),
+            using: client
+        )
+        #expect(updated.refresh == "keep-me")
+    }
+
+    @Test("kimi-coding is a default OAuthManager provider")
+    func kimiInDefaultProviders() {
+        #expect(OAuthManager.defaultProviders().contains { $0.id == "kimi-coding" })
+    }
+}
+
 @Suite("OAuthManager integration")
 struct OAuthManagerTests {
     /// Provider that counts refresh calls so we can verify caching.

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -162,6 +162,18 @@ struct MultiProviderAuthTests {
             #expect(auth?.token == "kimi-token")
             let scoped = await APIRegistry.shared.provider(scope: "kimi-coding", api: "anthropic-messages")
             #expect(scoped is AnthropicProvider)
+
+            // An uncatalogued override still routes through the coding
+            // endpoint with the Kimi thinking wire shape.
+            let custom = try await registerStored(
+                storeId: "kimi-coding", store: store,
+                modelOverride: "kimi-k9-experimental", context1m: false
+            )
+            #expect(custom?.model.id == "kimi-k9-experimental")
+            #expect(custom?.model.baseURL == "https://api.kimi.com/coding")
+            #expect(custom?.model.headers?["User-Agent"]?.hasPrefix("KimiCLI/") == true)
+            #expect(custom?.model.compat?.forceAdaptiveThinking == true)
+            #expect(custom?.model.compat?.allowEmptySignature == true)
             await APIRegistry.shared.unregisterScope("kimi-coding")
         }
     }

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -129,6 +129,116 @@ struct MultiProviderAuthTests {
         }
     }
 
+    // MARK: - Kimi For Coding + Z.AI Coding Plan (first-class providers)
+
+    @Test("registerStored wires a Kimi For Coding login onto the bearer anthropic wire")
+    func registerStoredKimiCoding() async throws {
+        try await withSharedAPIRegistry {
+            await APIRegistry.shared.unregisterScope("kimi-coding")
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kwwk-kimi-\(UUID().uuidString.prefix(8))")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+            // Never-expiring credentials so registration skips the token refresh.
+            try await store.set(OAuthCredentials(
+                access: "kimi-token", refresh: "kimi-refresh", expires: .max
+            ), for: "kimi-coding")
+
+            let resolved = try await registerStored(
+                storeId: "kimi-coding", store: store, modelOverride: nil, context1m: false
+            )
+            #expect(resolved?.model.id == "kimi-for-coding")
+            #expect(resolved?.model.provider == "kimi-coding")
+            #expect(resolved?.model.api == "anthropic-messages")
+            #expect(resolved?.model.baseURL == "https://api.kimi.com/coding")
+            // The KimiCLI agent string rides along from the catalog so the
+            // coding endpoint accepts the request.
+            #expect(resolved?.model.headers?["User-Agent"]?.hasPrefix("KimiCLI/") == true)
+            let catalogEntry = try #require(ModelsCatalog.model(provider: "kimi-coding", id: "kimi-for-coding"))
+            #expect(resolved?.model.contextWindow == catalogEntry.contextWindow)
+            #expect(resolved?.modelLabel == "kimi-for-coding · Kimi For Coding")
+            // The OAuth resolver supplies a bearer token per request.
+            let auth = try await resolved?.authResolver?(catalogEntry, nil)
+            #expect(auth?.token == "kimi-token")
+            let scoped = await APIRegistry.shared.provider(scope: "kimi-coding", api: "anthropic-messages")
+            #expect(scoped is AnthropicProvider)
+            await APIRegistry.shared.unregisterScope("kimi-coding")
+        }
+    }
+
+    @Test("registerStored wires Z.AI global + China logins with catalog metadata")
+    func registerStoredZai() async throws {
+        try await withSharedAPIRegistry {
+            for (storeId, base) in [
+                ("zai", "https://api.z.ai/api/coding/paas/v4"),
+                ("zai-coding-cn", "https://open.bigmodel.cn/api/coding/paas/v4"),
+            ] {
+                await APIRegistry.shared.unregisterScope(storeId)
+                let dir = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("kwwk-zai-\(UUID().uuidString.prefix(8))")
+                try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+                try await store.set(OAuthCredentials(
+                    access: "zai-key", refresh: "", expires: .max
+                ), for: storeId)
+
+                let resolved = try await registerStored(
+                    storeId: storeId, store: store, modelOverride: nil, context1m: false
+                )
+                #expect(resolved?.model.id == "glm-5.2")
+                #expect(resolved?.model.provider == storeId)
+                #expect(resolved?.model.api == "openai-completions")
+                #expect(resolved?.model.baseURL == base)
+                // Catalog compat — the Z.AI thinking format — rides along.
+                #expect(resolved?.model.compat?.thinkingFormat == "zai")
+                let scoped = await APIRegistry.shared.provider(scope: storeId, api: "openai-completions")
+                #expect(scoped is OpenAICompletionsProvider)
+
+                // An uncatalogued override still routes through the coding
+                // endpoint with the Z.AI thinking format.
+                let custom = try await registerStored(
+                    storeId: storeId, store: store,
+                    modelOverride: "glm-99-experimental", context1m: false
+                )
+                #expect(custom?.model.id == "glm-99-experimental")
+                #expect(custom?.model.baseURL == base)
+                #expect(custom?.model.compat?.thinkingFormat == "zai")
+                await APIRegistry.shared.unregisterScope(storeId)
+            }
+        }
+    }
+
+    @Test("the completions URL builder keeps versioned bases (Z.AI /paas/v4) intact")
+    func zaiURLNotDoubleVersioned() {
+        let provider = OpenAICompletionsProvider(defaultAPIKey: "k")
+        let fallback = URL(string: "https://api.openai.com")!
+        let zai = Model(
+            id: "glm-5.2", name: "GLM-5.2", api: "openai-completions",
+            provider: "zai", baseURL: "https://api.z.ai/api/coding/paas/v4"
+        )
+        #expect(
+            provider.urlBuilder(zai, nil, fallback).absoluteString
+                == "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        )
+        // Bare hosts still gain the default /v1; existing /v1 bases don't double it.
+        let bare = Model(
+            id: "m", name: "m", api: "openai-completions",
+            provider: "x", baseURL: "https://api.deepseek.com"
+        )
+        #expect(
+            provider.urlBuilder(bare, nil, fallback).absoluteString
+                == "https://api.deepseek.com/v1/chat/completions"
+        )
+        let v1 = Model(
+            id: "m", name: "m", api: "openai-completions",
+            provider: "x", baseURL: "https://openrouter.ai/api/v1"
+        )
+        #expect(
+            provider.urlBuilder(v1, nil, fallback).absoluteString
+                == "https://openrouter.ai/api/v1/chat/completions"
+        )
+    }
+
     // MARK: - Unified resolver dispatch
 
     @Test("SessionAuthResolvers dispatches by model.provider and supports mid-session add/remove")

--- a/Tests/KWWKCliTests/ProviderDirectoryTests.swift
+++ b/Tests/KWWKCliTests/ProviderDirectoryTests.swift
@@ -22,6 +22,9 @@ struct ProviderDirectoryTests {
         ("openrouter", "openrouter", "openrouter", "OpenRouter", "OpenRouter API key"),
         ("github-copilot", "github-copilot", "github-copilot", "GitHub Copilot", nil),
         ("cursor", "cursor", "cursor", "Cursor", nil),
+        ("kimi-coding", "kimi-coding", "kimi-coding", "Kimi For Coding", nil),
+        ("zai", "zai", "zai", "Z.AI Coding Plan", "Z.AI API key"),
+        ("zai-coding-cn", "zai-coding-cn", "zai-coding-cn", "Z.AI Coding Plan (China)", "Z.AI API key (China)"),
     ]
 
     @Test("directory order is the stored-provider priority order")


### PR DESCRIPTION
## Summary

Adds two providers to the TUI's `/login` picker and `/model` switcher, mirroring [oh-my-pi](https://github.com/can1357/oh-my-pi)'s wiring:

**Kimi For Coding (Moonshot coding plan, OAuth)**
- `OAuthLogin.loginKimiCoding`: device-authorization grant against `auth.kimi.com` — request a user code, open `verification_uri_complete` in the browser, poll the token endpoint (`authorization_pending` / `slow_down` / `expired_token` / `access_denied` handled per oh-my-pi's `oauth/kimi.ts`).
- `KimiCodingOAuthProvider`: standard `grant_type=refresh_token` refresh, registered in `OAuthManager.defaultProviders()`.
- `KimiOAuth.commonHeaders`: the `X-Msh-*` device-fingerprint headers Kimi's endpoints expect, with a stable device id persisted at `~/.kwwk/kimi-device-id` and a `KimiCLI/1.5` User-Agent matching the bundled catalog models.
- `registerKimiCoding`: bearer-authenticated `anthropic-messages` wire at `https://api.kimi.com/coding`, default model `kimi-for-coding` (same as oh-my-pi); all five bundled `kimi-coding` catalog models are switchable via `/model`.

**Z.AI GLM Coding Plan (API key)**
- Two login entries: global (`api.z.ai`) and China (`open.bigmodel.cn/api/coding/paas/v4`), paste-an-API-key form.
- `registerZai`: `openai-completions` wire, default model `glm-5.2` (same as oh-my-pi), catalog compat (`thinkingFormat: "zai"`, `zaiToolStream`) carried through, with a zai-format fallback for uncatalogued ids.

**Bug fix uncovered along the way**
- The `openai-completions` default URL builder appended `/v1` to any base not already ending in `/v1`, turning Z.AI's `…/coding/paas/v4` into `…/paas/v4/v1/chat/completions`. This also broke the pre-existing `ZAI_API_KEY` env path. Bases ending in any `/v<digits>` segment are now treated as versioned.

## Test plan

- New: Kimi device-flow shape / access-denied / missing-refresh-token tests, Kimi refresh tests, `registerStored` wiring tests for `kimi-coding` + both `zai` store ids, URL-builder versioned-base test.
- Updated: `ProviderDirectoryTests` pinned table with the three new descriptors.
- `swift test`: 1256 tests, 187 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth login/refresh and auth routing for new third-party endpoints; the URL-builder change affects all openai-completions models with versioned base URLs, including existing Z.AI env paths.
> 
> **Overview**
> Adds **Kimi For Coding** (Moonshot OAuth device flow) and **Z.AI GLM Coding Plan** (global + China API-key logins) to `/login`, `/model`, and stored-credential registration, with README updates.
> 
> **Kimi For Coding:** `OAuthLogin.loginKimiCoding` polls `auth.kimi.com` with `X-Msh-*` device headers and a stable `~/.kwwk/kimi-device-id`; `KimiCodingOAuthProvider` handles refresh and is registered in `OAuthManager.defaultProviders()`. The CLI routes chat through bearer-authenticated `anthropic-messages` at `https://api.kimi.com/coding` (default `kimi-for-coding`, KimiCLI `User-Agent` and thinking compat).
> 
> **Z.AI:** Two API-key login entries wire `registerZai` to scoped `openai-completions` with Z.AI thinking compat and default `glm-5.2`.
> 
> **URL builder fix:** `OpenAICompletionsProvider` treats any base URL whose last path segment is `/v<digits>` as already versioned, so Z.AI’s `…/paas/v4` (and similar) no longer get an extra `/v1` appended.
> 
> Tests cover Kimi device/refresh flows, `registerStored` wiring, provider directory entries, and the versioned-base URL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1013909ce017073b28bd55e5ebd0a078762be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->