### PR TITLE
feat(tui): add ask tool for mid-turn clarifying questions

### DIFF
--- a/Sources/KWWKCli/AskModal.swift
+++ b/Sources/KWWKCli/AskModal.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// Resume-exactly-once box around the `ask` tool's suspended continuation.
+/// Two paths race to finish a presentation — the modal's own completion and
+/// a run abort landing while the modal is still up — and a continuation must
+/// never resume twice. `@MainActor` so both paths serialize.
+@MainActor
+final class AskPresentation {
+    private var continuation: CheckedContinuation<AskOutcome, Never>?
+
+    init(_ continuation: CheckedContinuation<AskOutcome, Never>) {
+        self.continuation = continuation
+    }
+
+    var finished: Bool { continuation == nil }
+
+    func resume(_ outcome: AskOutcome) {
+        continuation?.resume(returning: outcome)
+        continuation = nil
+    }
+}
+
+/// Selector modal for one `ask` tool question (omp's ask UI ported to kwwk's
+/// modal system). Radio behavior for single-select (Enter answers), checkbox
+/// behavior for `multi` (Enter toggles, the Done row answers), a synthetic
+/// "Other (type your own)" row that switches the modal into inline free-text
+/// entry, and ←/→ wizard navigation for multi-question calls.
+///
+/// The modal never closes itself — it reports exactly one `AskOutcome` through
+/// `onComplete` and the TUI wiring closes the host and resumes the suspended
+/// tool call.
+@MainActor
+final class AskModal: Modal {
+    enum Entry: Equatable {
+        case option(Int)
+        case done
+        case other
+    }
+
+    private enum Mode {
+        case list
+        case otherInput
+    }
+
+    private let prompt: AskPrompt
+    private let onComplete: @MainActor (AskOutcome) -> Void
+    private var completed = false
+
+    private(set) var entries: [Entry]
+    private(set) var selectedIndex: Int
+    /// Checked labels for `multi` questions, in option order on submit.
+    private(set) var checked: Set<String>
+    private var mode: Mode = .list
+    private var buffer: String
+    /// Top display-line of the visible window (edge-scroll, matches
+    /// `ModalListCore` behavior).
+    private var scroll = 0
+
+    init(prompt: AskPrompt, onComplete: @MainActor @escaping (AskOutcome) -> Void) {
+        self.prompt = prompt
+        self.onComplete = onComplete
+
+        var entries: [Entry] = prompt.question.options.indices.map { .option($0) }
+        if prompt.question.multi { entries.append(.done) }
+        entries.append(.other)
+        self.entries = entries
+
+        let labels = prompt.question.options.map(\.label)
+        self.checked = Set(prompt.previousSelection).intersection(labels)
+        self.buffer = prompt.previousCustomInput ?? ""
+
+        if prompt.previousCustomInput != nil {
+            self.selectedIndex = entries.count - 1
+        } else if let first = prompt.previousSelection.first,
+                  let idx = labels.firstIndex(of: first) {
+            self.selectedIndex = idx
+        } else {
+            self.selectedIndex = prompt.question.recommended ?? 0
+        }
+    }
+
+    /// Checked labels in option order — the order the model sees.
+    var orderedSelection: [String] {
+        prompt.question.options.map(\.label).filter { checked.contains($0) }
+    }
+
+    private func finish(_ outcome: AskOutcome) {
+        guard !completed else { return }
+        completed = true
+        onComplete(outcome)
+    }
+
+    /// External teardown (run aborted while the modal was up): report
+    /// `cancelled` without touching the host — the caller closes it.
+    func cancelExternally() {
+        finish(.cancelled)
+    }
+
+    // MARK: - Modal
+
+    func up() {
+        guard mode == .list else { return }
+        selectedIndex = (selectedIndex - 1 + entries.count) % entries.count
+    }
+
+    func down() {
+        guard mode == .list else { return }
+        selectedIndex = (selectedIndex + 1) % entries.count
+    }
+
+    func confirm() {
+        switch mode {
+        case .list:
+            switch entries[selectedIndex] {
+            case .option(let i):
+                let label = prompt.question.options[i].label
+                if prompt.question.multi {
+                    if checked.contains(label) { checked.remove(label) } else { checked.insert(label) }
+                } else {
+                    finish(.answered(selected: [label], customInput: nil))
+                }
+            case .done:
+                finish(.answered(selected: orderedSelection, customInput: nil))
+            case .other:
+                mode = .otherInput
+            }
+        case .otherInput:
+            let text = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.isEmpty {
+                mode = .list
+            } else {
+                // multi keeps the checked options alongside the custom input
+                // (omp behavior); single-select custom input replaces any
+                // previous option answer.
+                let selected = prompt.question.multi ? orderedSelection : []
+                finish(.answered(selected: selected, customInput: text))
+            }
+        }
+    }
+
+    func cancel() {
+        switch mode {
+        case .otherInput:
+            mode = .list
+        case .list:
+            finish(.cancelled)
+        }
+    }
+
+    /// Current answer state for wizard navigation: multi carries the live
+    /// checkboxes, single-select carries whatever answer the question already
+    /// had (the cursor alone is not a selection).
+    private var navigationState: (selected: [String], customInput: String?) {
+        let selected = prompt.question.multi ? orderedSelection : prompt.previousSelection
+        return (selected, prompt.previousCustomInput)
+    }
+
+    func left() {
+        guard mode == .list, prompt.allowBack else { return }
+        let state = navigationState
+        finish(.back(selected: state.selected, customInput: state.customInput))
+    }
+
+    func right() {
+        guard mode == .list, prompt.allowForward else { return }
+        let state = navigationState
+        finish(.answered(selected: state.selected, customInput: state.customInput))
+    }
+
+    /// Typed text lands in the "Other" buffer while it is open; in list mode
+    /// nothing is consumed (falls through to the prompt editor, like every
+    /// list modal). Same filtering as `FormModal`: strip the bracketed-paste
+    /// envelope, backspace deletes, escape sequences and control chars drop.
+    func handleText(_ data: String) -> Bool {
+        guard mode == .otherInput else { return false }
+        var text = data
+        if text.hasPrefix("\u{1B}[200~") && text.hasSuffix("\u{1B}[201~") {
+            text.removeFirst("\u{1B}[200~".count)
+            text.removeLast("\u{1B}[201~".count)
+        }
+        if text == "\u{7F}" || text == "\u{08}" {
+            if !buffer.isEmpty { buffer.removeLast() }
+            return true
+        }
+        if text.hasPrefix("\u{1B}") {
+            return true
+        }
+        var appended = ""
+        for ch in text {
+            if ch == "\n" || ch == "\r" || ch == "\t" { continue }
+            if let ascii = ch.asciiValue, ascii < 0x20 { continue }
+            appended.append(ch)
+        }
+        if !appended.isEmpty {
+            buffer.append(appended)
+        }
+        return true
+    }
+
+    func render(maxRows: Int) -> [String] {
+        var title = "  ? \(prompt.question.question)"
+        if let progress = prompt.progressText {
+            title += " " + Style.dimmed("(\(progress))")
+        }
+
+        if mode == .otherInput {
+            var out: [String] = []
+            let roomy = maxRows >= 7
+            if roomy { out.append("") }
+            out.append(Style.header(title))
+            if roomy { out.append("") }
+            let display = buffer.isEmpty ? Style.dimmed("(type your answer)") : Style.prompt(buffer)
+            out.append(Style.prompt("  ❯ ") + display)
+            if roomy { out.append("") }
+            out.append(Style.dimmed("  Enter: submit   Esc: back to options"))
+            return out
+        }
+
+        // Display lines: one line per entry plus an optional description
+        // sub-line, tracking each entry's first line for the scroll window.
+        var lines: [String] = []
+        var selectedLine = 0
+        for (entryIndex, entry) in entries.enumerated() {
+            let isCursor = entryIndex == selectedIndex
+            if isCursor { selectedLine = lines.count }
+            let prefix = isCursor ? Style.prompt("  ❯ ") : "    "
+            switch entry {
+            case .option(let i):
+                let option = prompt.question.options[i]
+                let marker: String
+                if prompt.question.multi {
+                    let isChecked = checked.contains(option.label)
+                    marker = isChecked ? Theme.paint("◼", Theme.success) : Style.dimmed("◻")
+                } else {
+                    let isPrevious = prompt.previousSelection.first == option.label
+                    marker = isPrevious ? Theme.paint("●", Theme.success) : Style.dimmed("○")
+                }
+                var label = isCursor ? Style.prompt(option.label) : option.label
+                if i == prompt.question.recommended {
+                    label += Style.dimmed(Ask.recommendedSuffix)
+                }
+                lines.append("\(prefix)\(marker) \(label)")
+                if let description = option.description {
+                    lines.append(Theme.faintText("        ↳ \(description)"))
+                }
+            case .done:
+                let count = checked.count
+                let base = isCursor ? Style.prompt("Done") : "Done"
+                let suffix = count > 0 ? Style.dimmed(" (\(count) selected)") : ""
+                lines.append(prefix + "  " + base + suffix)
+            case .other:
+                let label = Ask.otherOptionLabel
+                lines.append(prefix + "  " + (isCursor ? Style.prompt(label) : Style.dimmed(label)))
+            }
+        }
+
+        var hints = ["↑/↓: move", prompt.question.multi ? "Enter: toggle" : "Enter: select"]
+        if prompt.allowBack || prompt.allowForward { hints.append("←/→: question") }
+        hints.append("Esc: cancel")
+        let footer = Style.dimmed("  " + hints.joined(separator: "   "))
+
+        let roomy = maxRows >= lines.count + 5
+        var out: [String] = []
+        if roomy { out.append("") }
+        out.append(Style.header(title))
+        if roomy { out.append("") }
+
+        let chrome = (roomy ? 5 : 2)
+        let bodyBudget = max(1, maxRows - chrome)
+        scroll = edgeScrollOffset(
+            selection: selectedLine, count: lines.count,
+            windowSize: bodyBudget, previous: scroll
+        )
+        out.append(contentsOf: lines[scroll ..< min(lines.count, scroll + bodyBudget)])
+
+        if roomy { out.append("") }
+        out.append(footer)
+        return out
+    }
+}

--- a/Sources/KWWKCli/AskModal.swift
+++ b/Sources/KWWKCli/AskModal.swift
@@ -43,6 +43,12 @@ final class AskModal: Modal {
     }
 
     private let prompt: AskPrompt
+    /// Live display width, queried per render (a resize reflow must re-fit).
+    /// Every emitted line is clamped to it: the frame wraps overlong modal
+    /// lines into extra physical rows and then keeps only the bottom of an
+    /// overflowing modal, so one logical line MUST be one terminal row for
+    /// the `maxRows` windowing contract to hold.
+    private let displayWidth: () -> Int
     private let onComplete: @MainActor (AskOutcome) -> Void
     private var completed = false
 
@@ -56,8 +62,13 @@ final class AskModal: Modal {
     /// `ModalListCore` behavior).
     private var scroll = 0
 
-    init(prompt: AskPrompt, onComplete: @MainActor @escaping (AskOutcome) -> Void) {
+    init(
+        prompt: AskPrompt,
+        displayWidth: @escaping () -> Int,
+        onComplete: @MainActor @escaping (AskOutcome) -> Void
+    ) {
         self.prompt = prompt
+        self.displayWidth = displayWidth
         self.onComplete = onComplete
 
         var entries: [Entry] = prompt.question.options.indices.map { .option($0) }
@@ -198,18 +209,36 @@ final class AskModal: Modal {
     }
 
     func render(maxRows: Int) -> [String] {
+        let width = max(24, displayWidth())
+        // The question is content — wrap it (charged against `maxRows` as
+        // chrome) rather than cutting it off. Everything below is one row
+        // per line by construction: option/description rows are truncated to
+        // the width, so the body window count is exact.
         var title = "  ? \(prompt.question.question)"
         if let progress = prompt.progressText {
             title += " " + Style.dimmed("(\(progress))")
         }
+        let titleLines = ANSI.wrap(Style.header(title), width: width)
 
         if mode == .otherInput {
             var out: [String] = []
-            let roomy = maxRows >= 7
+            let roomy = maxRows >= titleLines.count + 6
             if roomy { out.append("") }
-            out.append(Style.header(title))
+            out.append(contentsOf: titleLines)
             if roomy { out.append("") }
-            let display = buffer.isEmpty ? Style.dimmed("(type your answer)") : Style.prompt(buffer)
+            // Show the tail of an overlong buffer — that's where typing
+            // happens.
+            let inputBudget = width - 6
+            var visibleBuffer = buffer
+            if ANSI.visibleWidth(visibleBuffer) > inputBudget {
+                while ANSI.visibleWidth(visibleBuffer) > inputBudget - 1 {
+                    visibleBuffer.removeFirst()
+                }
+                visibleBuffer = "…" + visibleBuffer
+            }
+            let display = buffer.isEmpty
+                ? Style.dimmed("(type your answer)")
+                : Style.prompt(visibleBuffer)
             out.append(Style.prompt("  ❯ ") + display)
             if roomy { out.append("") }
             out.append(Style.dimmed("  Enter: submit   Esc: back to options"))
@@ -239,42 +268,51 @@ final class AskModal: Modal {
                 if i == prompt.question.recommended {
                     label += Style.dimmed(Ask.recommendedSuffix)
                 }
-                lines.append("\(prefix)\(marker) \(label)")
+                lines.append(ANSI.truncate("\(prefix)\(marker) \(label)", to: width))
                 if let description = option.description {
-                    lines.append(Theme.faintText("        ↳ \(description)"))
+                    lines.append(ANSI.truncate(Theme.faintText("        ↳ \(description)"), to: width))
                 }
             case .done:
                 let count = checked.count
                 let base = isCursor ? Style.prompt("Done") : "Done"
                 let suffix = count > 0 ? Style.dimmed(" (\(count) selected)") : ""
-                lines.append(prefix + "  " + base + suffix)
+                lines.append(ANSI.truncate(prefix + "  " + base + suffix, to: width))
             case .other:
                 let label = Ask.otherOptionLabel
-                lines.append(prefix + "  " + (isCursor ? Style.prompt(label) : Style.dimmed(label)))
+                lines.append(ANSI.truncate(
+                    prefix + "  " + (isCursor ? Style.prompt(label) : Style.dimmed(label)),
+                    to: width
+                ))
             }
         }
 
         var hints = ["↑/↓: move", prompt.question.multi ? "Enter: toggle" : "Enter: select"]
         if prompt.allowBack || prompt.allowForward { hints.append("←/→: question") }
         hints.append("Esc: cancel")
-        let footer = Style.dimmed("  " + hints.joined(separator: "   "))
 
-        let roomy = maxRows >= lines.count + 5
-        var out: [String] = []
-        if roomy { out.append("") }
-        out.append(Style.header(title))
-        if roomy { out.append("") }
-
-        let chrome = (roomy ? 5 : 2)
+        // Cosmetic blank spacers are dropped on short terminals; chrome is
+        // the wrapped title + footer (+ 3 spacers when roomy), everything
+        // else is the windowed body.
+        let roomy = maxRows >= lines.count + titleLines.count + 4
+        let chrome = titleLines.count + 1 + (roomy ? 3 : 0)
         let bodyBudget = max(1, maxRows - chrome)
         scroll = edgeScrollOffset(
             selection: selectedLine, count: lines.count,
             windowSize: bodyBudget, previous: scroll
         )
-        out.append(contentsOf: lines[scroll ..< min(lines.count, scroll + bodyBudget)])
+        let windowed = lines.count > bodyBudget
 
+        var out: [String] = []
         if roomy { out.append("") }
-        out.append(footer)
+        out.append(contentsOf: titleLines)
+        if roomy { out.append("") }
+        out.append(contentsOf: lines[scroll ..< min(lines.count, scroll + bodyBudget)])
+        if roomy { out.append("") }
+        let position = windowed ? "\(selectedIndex + 1)/\(entries.count)   " : ""
+        out.append(ANSI.truncate(
+            Style.dimmed("  " + position + hints.joined(separator: "   ")),
+            to: width
+        ))
         return out
     }
 }

--- a/Sources/KWWKCli/AskModal.swift
+++ b/Sources/KWWKCli/AskModal.swift
@@ -44,10 +44,12 @@ final class AskModal: Modal {
 
     private let prompt: AskPrompt
     /// Live display width, queried per render (a resize reflow must re-fit).
-    /// Every emitted line is clamped to it: the frame wraps overlong modal
-    /// lines into extra physical rows and then keeps only the bottom of an
-    /// overflowing modal, so one logical line MUST be one terminal row for
-    /// the `maxRows` windowing contract to hold.
+    /// Every emitted line is pre-wrapped to it: the frame wraps overlong
+    /// modal lines into extra physical rows and then keeps only the bottom
+    /// of an overflowing modal, so one emitted line MUST be one terminal row
+    /// for the `maxRows` windowing contract to hold. Content is never
+    /// truncated — long labels and descriptions wrap with a hanging indent
+    /// and the window scrolls over physical rows.
     private let displayWidth: () -> Int
     private let onComplete: @MainActor (AskOutcome) -> Void
     private var completed = false
@@ -208,12 +210,32 @@ final class AskModal: Modal {
         return true
     }
 
+    /// Wrap a styled line into physical rows: the first row carries `first`
+    /// (prefix + marker), continuations get a hanging indent of the same
+    /// visible width so wrapped content stays aligned under its own column.
+    private func wrapHanging(first: String, content: String, width: Int) -> [String] {
+        let indentWidth = ANSI.visibleWidth(first)
+        let pieces = ANSI.wrap(content, width: max(8, width - indentWidth))
+        let indent = String(repeating: " ", count: indentWidth)
+        return [first + (pieces.first ?? "")] + pieces.dropFirst().map { indent + $0 }
+    }
+
+    /// Edge-scroll for a windowed list of physical rows where the selection
+    /// spans a row RANGE (a wrapped entry): keep the whole entry visible,
+    /// preferring its first row when it is taller than the window.
+    private func rangeScrollOffset(
+        start: Int, end: Int, count: Int, windowSize: Int, previous: Int
+    ) -> Int {
+        var scroll = previous
+        if end >= scroll + windowSize { scroll = end - windowSize + 1 }
+        if start < scroll { scroll = start }
+        return max(0, min(scroll, max(0, count - windowSize)))
+    }
+
     func render(maxRows: Int) -> [String] {
         let width = max(24, displayWidth())
         // The question is content — wrap it (charged against `maxRows` as
-        // chrome) rather than cutting it off. Everything below is one row
-        // per line by construction: option/description rows are truncated to
-        // the width, so the body window count is exact.
+        // chrome) rather than cutting it off.
         var title = "  ? \(prompt.question.question)"
         if let progress = prompt.progressText {
             title += " " + Style.dimmed("(\(progress))")
@@ -221,37 +243,38 @@ final class AskModal: Modal {
         let titleLines = ANSI.wrap(Style.header(title), width: width)
 
         if mode == .otherInput {
+            let footer = Style.dimmed("  Enter: submit   Esc: back to options")
+            let footerLines = ANSI.wrap(footer, width: width)
+            let display = buffer.isEmpty
+                ? Style.dimmed("(type your answer)")
+                : Style.prompt(buffer)
+            var inputLines = wrapHanging(first: Style.prompt("  ❯ "), content: display, width: width)
+            let roomy = maxRows >= titleLines.count + inputLines.count + footerLines.count + 3
+            // A very long pasted answer overflows the viewport: keep the
+            // TAIL rows — that's where the cursor is.
+            let inputBudget = max(1, maxRows - titleLines.count - footerLines.count - (roomy ? 3 : 0))
+            if inputLines.count > inputBudget {
+                inputLines = Array(inputLines.suffix(inputBudget))
+            }
             var out: [String] = []
-            let roomy = maxRows >= titleLines.count + 6
             if roomy { out.append("") }
             out.append(contentsOf: titleLines)
             if roomy { out.append("") }
-            // Show the tail of an overlong buffer — that's where typing
-            // happens.
-            let inputBudget = width - 6
-            var visibleBuffer = buffer
-            if ANSI.visibleWidth(visibleBuffer) > inputBudget {
-                while ANSI.visibleWidth(visibleBuffer) > inputBudget - 1 {
-                    visibleBuffer.removeFirst()
-                }
-                visibleBuffer = "…" + visibleBuffer
-            }
-            let display = buffer.isEmpty
-                ? Style.dimmed("(type your answer)")
-                : Style.prompt(visibleBuffer)
-            out.append(Style.prompt("  ❯ ") + display)
+            out.append(contentsOf: inputLines)
             if roomy { out.append("") }
-            out.append(Style.dimmed("  Enter: submit   Esc: back to options"))
+            out.append(contentsOf: footerLines)
             return out
         }
 
-        // Display lines: one line per entry plus an optional description
-        // sub-line, tracking each entry's first line for the scroll window.
-        var lines: [String] = []
-        var selectedLine = 0
+        // Physical display rows, one row array per entry: each entry wraps
+        // into one or more rows with a hanging indent. Content is only ever
+        // cut when a SINGLE entry is taller than the whole scroll window —
+        // wrapping handles everything below that, and an over-tall entry
+        // could never be scrolled through anyway (↑/↓ move entry to entry).
+        var entryRows: [[String]] = []
         for (entryIndex, entry) in entries.enumerated() {
             let isCursor = entryIndex == selectedIndex
-            if isCursor { selectedLine = lines.count }
+            var rows: [String] = []
             let prefix = isCursor ? Style.prompt("  ❯ ") : "    "
             switch entry {
             case .option(let i):
@@ -268,22 +291,34 @@ final class AskModal: Modal {
                 if i == prompt.question.recommended {
                     label += Style.dimmed(Ask.recommendedSuffix)
                 }
-                lines.append(ANSI.truncate("\(prefix)\(marker) \(label)", to: width))
+                rows.append(contentsOf: wrapHanging(
+                    first: "\(prefix)\(marker) ", content: label, width: width
+                ))
                 if let description = option.description {
-                    lines.append(ANSI.truncate(Theme.faintText("        ↳ \(description)"), to: width))
+                    // Style row-by-row: wrap the plain text, then paint each
+                    // row faint including its indent.
+                    let descIndent = "        ↳ "
+                    let pieces = ANSI.wrap(description, width: max(8, width - ANSI.visibleWidth(descIndent)))
+                    rows.append(Theme.faintText(descIndent + (pieces.first ?? "")))
+                    let indent = String(repeating: " ", count: ANSI.visibleWidth(descIndent))
+                    rows.append(contentsOf: pieces.dropFirst().map { Theme.faintText(indent + $0) })
                 }
             case .done:
                 let count = checked.count
                 let base = isCursor ? Style.prompt("Done") : "Done"
                 let suffix = count > 0 ? Style.dimmed(" (\(count) selected)") : ""
-                lines.append(ANSI.truncate(prefix + "  " + base + suffix, to: width))
+                rows.append(contentsOf: wrapHanging(
+                    first: prefix + "  ", content: base + suffix, width: width
+                ))
             case .other:
                 let label = Ask.otherOptionLabel
-                lines.append(ANSI.truncate(
-                    prefix + "  " + (isCursor ? Style.prompt(label) : Style.dimmed(label)),
-                    to: width
+                rows.append(contentsOf: wrapHanging(
+                    first: prefix + "  ",
+                    content: isCursor ? Style.prompt(label) : Style.dimmed(label),
+                    width: width
                 ))
             }
+            entryRows.append(rows)
         }
 
         var hints = ["↑/↓: move", prompt.question.multi ? "Enter: toggle" : "Enter: select"]
@@ -292,15 +327,42 @@ final class AskModal: Modal {
 
         // Cosmetic blank spacers are dropped on short terminals; chrome is
         // the wrapped title + footer (+ 3 spacers when roomy), everything
-        // else is the windowed body.
-        let roomy = maxRows >= lines.count + titleLines.count + 4
-        let chrome = titleLines.count + 1 + (roomy ? 3 : 0)
+        // else is the windowed body. Whether the list is windowed is probed
+        // with a one-row footer estimate — the `n/m` indicator only needs to
+        // appear whenever rows are actually hidden.
+        let totalRows = entryRows.reduce(0) { $0 + $1.count }
+        let windowedProbe = totalRows + titleLines.count + 1 > maxRows
+        let position = windowedProbe ? "\(selectedIndex + 1)/\(entries.count)   " : ""
+        let footer = Style.dimmed("  " + position + hints.joined(separator: "   "))
+        let footerLines = ANSI.wrap(footer, width: width)
+
+        let roomy = maxRows >= totalRows + titleLines.count + footerLines.count + 3
+        let chrome = titleLines.count + footerLines.count + (roomy ? 3 : 0)
         let bodyBudget = max(1, maxRows - chrome)
-        scroll = edgeScrollOffset(
-            selection: selectedLine, count: lines.count,
-            windowSize: bodyBudget, previous: scroll
+
+        // Flatten, clamping any entry taller than the window to the window
+        // height with a dim `… +N lines` marker as its last visible row.
+        var lines: [String] = []
+        var selectedRange = 0...0
+        for (entryIndex, rows) in entryRows.enumerated() {
+            let rangeStart = lines.count
+            if rows.count > bodyBudget, bodyBudget >= 2 {
+                let hidden = rows.count - (bodyBudget - 1)
+                lines.append(contentsOf: rows.prefix(bodyBudget - 1))
+                lines.append(Style.dimmed("      … +\(hidden) more lines"))
+            } else if rows.count > bodyBudget {
+                // Degenerate one-row window: the entry's first row stands in
+                // for the whole entry.
+                lines.append(rows[0])
+            } else {
+                lines.append(contentsOf: rows)
+            }
+            if entryIndex == selectedIndex { selectedRange = rangeStart...(lines.count - 1) }
+        }
+        scroll = rangeScrollOffset(
+            start: selectedRange.lowerBound, end: selectedRange.upperBound,
+            count: lines.count, windowSize: bodyBudget, previous: scroll
         )
-        let windowed = lines.count > bodyBudget
 
         var out: [String] = []
         if roomy { out.append("") }
@@ -308,11 +370,7 @@ final class AskModal: Modal {
         if roomy { out.append("") }
         out.append(contentsOf: lines[scroll ..< min(lines.count, scroll + bodyBudget)])
         if roomy { out.append("") }
-        let position = windowed ? "\(selectedIndex + 1)/\(entries.count)   " : ""
-        out.append(ANSI.truncate(
-            Style.dimmed("  " + position + hints.joined(separator: "   ")),
-            to: width
-        ))
+        out.append(contentsOf: footerLines)
         return out
     }
 }

--- a/Sources/KWWKCli/AskModal.swift
+++ b/Sources/KWWKCli/AskModal.swift
@@ -162,10 +162,13 @@ final class AskModal: Modal {
 
     /// Current answer state for wizard navigation: multi carries the live
     /// checkboxes, single-select carries whatever answer the question already
-    /// had (the cursor alone is not a selection).
+    /// had (the cursor alone is not a selection). The custom input is the
+    /// LIVE "Other" buffer — it starts as the previous custom answer and an
+    /// in-progress draft must survive ←/→ exactly like checkbox state does.
     private var navigationState: (selected: [String], customInput: String?) {
         let selected = prompt.question.multi ? orderedSelection : prompt.previousSelection
-        return (selected, prompt.previousCustomInput)
+        let draft = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (selected, draft.isEmpty ? nil : draft)
     }
 
     func left() {

--- a/Sources/KWWKCli/AskTool.swift
+++ b/Sources/KWWKCli/AskTool.swift
@@ -123,17 +123,25 @@ enum Ask {
 
     // MARK: - Result shaping (mirrors omp's `ask` result text)
 
-    /// `id: value` line for the multi-question "User answers:" block.
+    /// `id: value` line for the multi-question "User answers:" block. A
+    /// multi answer can carry checked options AND a custom input — both are
+    /// reported.
     static func answerLine(_ a: AskAnswer) -> String {
-        if let custom = a.customInput {
+        let selection = a.selectedOptions.isEmpty
+            ? nil
+            : a.multi
+                ? "[\(a.selectedOptions.joined(separator: ", "))]"
+                : a.selectedOptions[0]
+        switch (selection, a.customInput) {
+        case (let selection?, let custom?):
+            return "\(a.id): \(selection) + \"\(custom)\""
+        case (let selection?, nil):
+            return "\(a.id): \(selection)"
+        case (nil, let custom?):
             return "\(a.id): \"\(custom)\""
+        case (nil, nil):
+            return "\(a.id): (no selection)"
         }
-        if !a.selectedOptions.isEmpty {
-            return a.multi
-                ? "\(a.id): [\(a.selectedOptions.joined(separator: ", "))]"
-                : "\(a.id): \(a.selectedOptions[0])"
-        }
-        return "\(a.id): (no selection)"
     }
 
     /// Model-facing result text for a single-question call.
@@ -162,16 +170,17 @@ enum Ask {
         "User answers:\n" + answers.map(answerLine).joined(separator: "\n")
     }
 
-    /// One transcript line per question: `question → answer`.
+    /// One transcript line per question: `question → answer`. Checked
+    /// options and a custom input can coexist on a multi answer.
     static func displayLine(_ a: AskAnswer) -> String {
-        let answer: String
-        if let custom = a.customInput {
-            answer = "\"\(custom.replacingOccurrences(of: "\n", with: " "))\""
-        } else if !a.selectedOptions.isEmpty {
-            answer = a.selectedOptions.joined(separator: ", ")
-        } else {
-            answer = "(no selection)"
+        var parts: [String] = []
+        if !a.selectedOptions.isEmpty {
+            parts.append(a.selectedOptions.joined(separator: ", "))
         }
+        if let custom = a.customInput {
+            parts.append("\"\(custom.replacingOccurrences(of: "\n", with: " "))\"")
+        }
+        let answer = parts.isEmpty ? "(no selection)" : parts.joined(separator: " + ")
         return "\(a.question) → \(answer)"
     }
 
@@ -254,6 +263,33 @@ private let askParameters: JSONValue = .object([
     "required": .array([.string("questions")]),
 ])
 
+/// FIFO gate serializing concurrent `ask` executions. The agent loop runs a
+/// tool batch in parallel by default, but there is one ModalHost — a second
+/// `ask` opening mid-question would replace the first modal and strand its
+/// suspended continuation forever. omp marks its ask `concurrency:
+/// "exclusive"` for the same reason; here the later call simply waits for
+/// the earlier one's questions to finish.
+private actor AskGate {
+    private var busy = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if busy {
+            await withCheckedContinuation { waiters.append($0) }
+        } else {
+            busy = true
+        }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            busy = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 /// Build the `ask` tool. `present` suspends until the user answers one
 /// question; `abortRun` is invoked when the user cancels (Esc) — mirroring
 /// omp, a cancelled ask aborts the whole run rather than handing the model a
@@ -262,7 +298,8 @@ func createAskTool(
     present: @escaping AskPresenter,
     abortRun: @escaping @Sendable () -> Void
 ) -> AgentTool {
-    AgentTool(
+    let gate = AskGate()
+    return AgentTool(
         name: "ask",
         label: "ask",
         description: askDescription,
@@ -271,52 +308,78 @@ func createAskTool(
             try cancellation?.throwIfCancelled()
             let questions = try Ask.parseQuestions(args)
 
-            var answers: [AskAnswer?] = Array(repeating: nil, count: questions.count)
-            let isWizard = questions.count > 1
-            var index = 0
-            while index < questions.count {
-                let question = questions[index]
-                let previous = answers[index]
-                let outcome = await present(AskPrompt(
-                    question: question,
-                    progressText: isWizard ? "\(index + 1)/\(questions.count)" : nil,
-                    allowBack: isWizard && index > 0,
-                    allowForward: isWizard,
-                    previousSelection: previous?.selectedOptions ?? [],
-                    previousCustomInput: previous?.customInput
-                ), cancellation)
-                let record: ([String], String?) -> Void = { selected, customInput in
-                    answers[index] = AskAnswer(
-                        id: question.id,
-                        question: question.question,
-                        options: question.options.map(\.label),
-                        multi: question.multi,
-                        selectedOptions: selected,
-                        customInput: customInput
-                    )
-                }
-                switch outcome {
-                case .cancelled:
-                    abortRun()
-                    throw CodingToolError.aborted
-                case .back(let selected, let customInput):
-                    record(selected, customInput)
-                    index = max(0, index - 1)
-                case .answered(let selected, let customInput):
-                    record(selected, customInput)
-                    index += 1
-                }
+            await gate.acquire()
+            do {
+                let result = try await runAskQuestions(
+                    questions: questions,
+                    present: present,
+                    abortRun: abortRun,
+                    cancellation: cancellation
+                )
+                await gate.release()
+                return result
+            } catch {
+                await gate.release()
+                throw error
             }
-            let resolved = answers.compactMap { $0 }
+        }
+    )
+}
 
-            let text = resolved.count == 1
-                ? Ask.singleResultText(resolved[0])
-                : Ask.multiResultText(resolved)
-            return AgentToolResult(
-                content: [.text(TextContent(text: text))],
-                details: Ask.details(resolved),
-                uiDisplay: resolved.map(Ask.displayLine)
+private func runAskQuestions(
+    questions: [AskQuestion],
+    present: AskPresenter,
+    abortRun: @Sendable () -> Void,
+    cancellation: CancellationHandle?
+) async throws -> AgentToolResult {
+    // A run abort may have landed while this call was queued behind another
+    // ask — don't present a dead run's questions.
+    try cancellation?.throwIfCancelled()
+
+    var answers: [AskAnswer?] = Array(repeating: nil, count: questions.count)
+    let isWizard = questions.count > 1
+    var index = 0
+    while index < questions.count {
+        let question = questions[index]
+        let previous = answers[index]
+        let outcome = await present(AskPrompt(
+            question: question,
+            progressText: isWizard ? "\(index + 1)/\(questions.count)" : nil,
+            allowBack: isWizard && index > 0,
+            allowForward: isWizard,
+            previousSelection: previous?.selectedOptions ?? [],
+            previousCustomInput: previous?.customInput
+        ), cancellation)
+        let record: ([String], String?) -> Void = { selected, customInput in
+            answers[index] = AskAnswer(
+                id: question.id,
+                question: question.question,
+                options: question.options.map(\.label),
+                multi: question.multi,
+                selectedOptions: selected,
+                customInput: customInput
             )
         }
+        switch outcome {
+        case .cancelled:
+            abortRun()
+            throw CodingToolError.aborted
+        case .back(let selected, let customInput):
+            record(selected, customInput)
+            index = max(0, index - 1)
+        case .answered(let selected, let customInput):
+            record(selected, customInput)
+            index += 1
+        }
+    }
+    let resolved = answers.compactMap { $0 }
+
+    let text = resolved.count == 1
+        ? Ask.singleResultText(resolved[0])
+        : Ask.multiResultText(resolved)
+    return AgentToolResult(
+        content: [.text(TextContent(text: text))],
+        details: Ask.details(resolved),
+        uiDisplay: resolved.map(Ask.displayLine)
     )
 }

--- a/Sources/KWWKCli/AskTool.swift
+++ b/Sources/KWWKCli/AskTool.swift
@@ -1,0 +1,322 @@
+import Foundation
+import KWWKAI
+import KWWKAgent
+
+/// The model-facing `ask` tool (omp's `ask` ported to kwwk): mid-turn
+/// clarifying questions answered through a TUI selector modal. UI-only —
+/// registered by the coding TUI next to `goal`, never by `makeCodingAgent`,
+/// so headless runs and subagents never see it.
+
+/// One selectable option of an ask question.
+struct AskOption: Sendable, Equatable {
+    let label: String
+    let description: String?
+}
+
+/// One question parsed from the model's `ask` call.
+struct AskQuestion: Sendable, Equatable {
+    let id: String
+    let question: String
+    let options: [AskOption]
+    let multi: Bool
+    let recommended: Int?
+}
+
+/// Everything the TUI needs to present one question of a call: the question
+/// itself plus wizard context (progress + ←/→ availability) and the previous
+/// answer to restore when the user navigated back to it.
+struct AskPrompt: Sendable {
+    let question: AskQuestion
+    /// `"2/3"` in a multi-question wizard; nil for a single question.
+    let progressText: String?
+    let allowBack: Bool
+    let allowForward: Bool
+    let previousSelection: [String]
+    let previousCustomInput: String?
+}
+
+/// The user's response to one presented question.
+enum AskOutcome: Sendable, Equatable {
+    /// Enter on an option / Done, → to advance keeping the current state, or
+    /// a submitted "Other" free-text answer. An empty `selected` with nil
+    /// `customInput` is a skip (wizard →) — the answer line reads
+    /// `(no selection)`.
+    case answered(selected: [String], customInput: String?)
+    /// ← pressed on a non-first wizard question. Carries the question's
+    /// current state so in-progress selections survive the round trip
+    /// (omp saves the answer before navigating).
+    case back(selected: [String], customInput: String?)
+    /// Esc — the whole `ask` call is torn down and the run aborted.
+    case cancelled
+}
+
+/// One answered question, kept for result shaping and the transcript.
+struct AskAnswer: Sendable, Equatable {
+    let id: String
+    let question: String
+    let options: [String]
+    let multi: Bool
+    let selectedOptions: [String]
+    let customInput: String?
+}
+
+/// Async bridge to the TUI: suspend the tool until the user answers the
+/// presented question. The cancellation handle lets the presenter tear the
+/// modal down when the run is aborted out from under it.
+typealias AskPresenter = @Sendable (AskPrompt, CancellationHandle?) async -> AskOutcome
+
+enum Ask {
+    /// Appended by the UI to every question; confirming it opens free-text
+    /// entry. The model is told not to offer its own "Other".
+    static let otherOptionLabel = "Other (type your own)"
+    static let recommendedSuffix = " (Recommended)"
+
+    // MARK: - Argument parsing
+
+    static func parseQuestions(_ args: JSONValue) throws -> [AskQuestion] {
+        guard case .object(let obj) = args,
+              case .array(let rawQuestions) = obj["questions"] ?? .null,
+              !rawQuestions.isEmpty else {
+            throw CodingToolError.invalidArgument("ask: `questions` must be a non-empty array")
+        }
+        return try rawQuestions.map { raw in
+            guard case .object(let q) = raw else {
+                throw CodingToolError.invalidArgument("ask: each question must be an object")
+            }
+            guard case .string(let id) = q["id"] ?? .null, !id.isEmpty else {
+                throw CodingToolError.invalidArgument("ask: question `id` is required")
+            }
+            guard case .string(let question) = q["question"] ?? .null, !question.isEmpty else {
+                throw CodingToolError.invalidArgument("ask: question `question` is required")
+            }
+            guard case .array(let rawOptions) = q["options"] ?? .null, !rawOptions.isEmpty else {
+                throw CodingToolError.invalidArgument("ask: question `options` must be a non-empty array")
+            }
+            let options = try rawOptions.map { rawOption -> AskOption in
+                guard case .object(let o) = rawOption,
+                      case .string(let label) = o["label"] ?? .null, !label.isEmpty else {
+                    throw CodingToolError.invalidArgument("ask: each option needs a non-empty `label`")
+                }
+                if case .string(let description) = o["description"] ?? .null,
+                   !description.trimmingCharacters(in: .whitespaces).isEmpty {
+                    return AskOption(label: label, description: description)
+                }
+                return AskOption(label: label, description: nil)
+            }
+            let multi: Bool = {
+                if case .bool(let b) = q["multi"] ?? .null { return b }
+                return false
+            }()
+            let recommended: Int? = {
+                switch q["recommended"] ?? .null {
+                case .int(let i): return (0..<options.count).contains(i) ? i : nil
+                case .double(let d): return (0..<options.count).contains(Int(d)) ? Int(d) : nil
+                default: return nil
+                }
+            }()
+            return AskQuestion(
+                id: id, question: question, options: options,
+                multi: multi, recommended: recommended
+            )
+        }
+    }
+
+    // MARK: - Result shaping (mirrors omp's `ask` result text)
+
+    /// `id: value` line for the multi-question "User answers:" block.
+    static func answerLine(_ a: AskAnswer) -> String {
+        if let custom = a.customInput {
+            return "\(a.id): \"\(custom)\""
+        }
+        if !a.selectedOptions.isEmpty {
+            return a.multi
+                ? "\(a.id): [\(a.selectedOptions.joined(separator: ", "))]"
+                : "\(a.id): \(a.selectedOptions[0])"
+        }
+        return "\(a.id): (no selection)"
+    }
+
+    /// Model-facing result text for a single-question call.
+    static func singleResultText(_ a: AskAnswer) -> String {
+        var parts: [String] = []
+        if !a.selectedOptions.isEmpty {
+            parts.append("User selected: \(a.selectedOptions.joined(separator: ", "))")
+        }
+        if let custom = a.customInput {
+            if custom.contains("\n") {
+                let indented = custom.split(separator: "\n", omittingEmptySubsequences: false)
+                    .map { "  \($0)" }.joined(separator: "\n")
+                parts.append("User provided custom input:\n\(indented)")
+            } else {
+                parts.append("User provided custom input: \(custom)")
+            }
+        }
+        if parts.isEmpty {
+            return "User made no selection"
+        }
+        return parts.joined(separator: "\n")
+    }
+
+    /// Model-facing result text for a multi-question call.
+    static func multiResultText(_ answers: [AskAnswer]) -> String {
+        "User answers:\n" + answers.map(answerLine).joined(separator: "\n")
+    }
+
+    /// One transcript line per question: `question → answer`.
+    static func displayLine(_ a: AskAnswer) -> String {
+        let answer: String
+        if let custom = a.customInput {
+            answer = "\"\(custom.replacingOccurrences(of: "\n", with: " "))\""
+        } else if !a.selectedOptions.isEmpty {
+            answer = a.selectedOptions.joined(separator: ", ")
+        } else {
+            answer = "(no selection)"
+        }
+        return "\(a.question) → \(answer)"
+    }
+
+    static func details(_ answers: [AskAnswer]) -> JSONValue {
+        .object(["results": .array(answers.map { a in
+            var fields: [String: JSONValue] = [
+                "id": .string(a.id),
+                "question": .string(a.question),
+                "options": .array(a.options.map { .string($0) }),
+                "multi": .bool(a.multi),
+                "selectedOptions": .array(a.selectedOptions.map { .string($0) }),
+            ]
+            if let custom = a.customInput { fields["customInput"] = .string(custom) }
+            return .object(fields)
+        })])
+    }
+}
+
+private let askDescription = """
+Ask the user when you need clarification or input during task execution.
+
+- Only ask when multiple approaches exist with materially different tradeoffs the user must weigh. Default to action: resolve ambiguity yourself using repo conventions, existing patterns, and reasonable defaults first.
+- If multiple choices are acceptable, pick the most conservative/standard option, proceed, and state the choice instead of asking.
+- Provide 2-5 concise, distinct options. Keep labels short; put explanatory tradeoffs in `description`.
+- Use `recommended: <index>` (0-based) to mark a default — " (Recommended)" is appended automatically.
+- Ask multiple related questions in ONE call via `questions` instead of one call at a time.
+- Set `multi: true` on a question to allow multiple selections.
+- Do NOT include an "Other" option — the UI automatically adds "Other (type your own)" to every question.
+"""
+
+private let askParameters: JSONValue = .object([
+    "type": .string("object"),
+    "properties": .object([
+        "questions": .object([
+            "type": .string("array"),
+            "minItems": .int(1),
+            "description": .string("questions to ask"),
+            "items": .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object([
+                        "type": .string("string"),
+                        "description": .string("short identifier echoed back in the result (e.g. auth_method)"),
+                    ]),
+                    "question": .object([
+                        "type": .string("string"),
+                        "description": .string("question text"),
+                    ]),
+                    "options": .object([
+                        "type": .string("array"),
+                        "description": .string("available options"),
+                        "items": .object([
+                            "type": .string("object"),
+                            "properties": .object([
+                                "label": .object([
+                                    "type": .string("string"),
+                                    "description": .string("display label"),
+                                ]),
+                                "description": .object([
+                                    "type": .string("string"),
+                                    "description": .string("optional explanatory text displayed below the label"),
+                                ]),
+                            ]),
+                            "required": .array([.string("label")]),
+                        ]),
+                    ]),
+                    "multi": .object([
+                        "type": .string("boolean"),
+                        "description": .string("allow multiple selections"),
+                    ]),
+                    "recommended": .object([
+                        "type": .string("integer"),
+                        "description": .string("0-based index of the recommended option"),
+                    ]),
+                ]),
+                "required": .array([.string("id"), .string("question"), .string("options")]),
+            ]),
+        ]),
+    ]),
+    "required": .array([.string("questions")]),
+])
+
+/// Build the `ask` tool. `present` suspends until the user answers one
+/// question; `abortRun` is invoked when the user cancels (Esc) — mirroring
+/// omp, a cancelled ask aborts the whole run rather than handing the model a
+/// "user declined" result to argue with.
+func createAskTool(
+    present: @escaping AskPresenter,
+    abortRun: @escaping @Sendable () -> Void
+) -> AgentTool {
+    AgentTool(
+        name: "ask",
+        label: "ask",
+        description: askDescription,
+        parameters: askParameters,
+        execute: { _, args, cancellation, _ in
+            try cancellation?.throwIfCancelled()
+            let questions = try Ask.parseQuestions(args)
+
+            var answers: [AskAnswer?] = Array(repeating: nil, count: questions.count)
+            let isWizard = questions.count > 1
+            var index = 0
+            while index < questions.count {
+                let question = questions[index]
+                let previous = answers[index]
+                let outcome = await present(AskPrompt(
+                    question: question,
+                    progressText: isWizard ? "\(index + 1)/\(questions.count)" : nil,
+                    allowBack: isWizard && index > 0,
+                    allowForward: isWizard,
+                    previousSelection: previous?.selectedOptions ?? [],
+                    previousCustomInput: previous?.customInput
+                ), cancellation)
+                let record: ([String], String?) -> Void = { selected, customInput in
+                    answers[index] = AskAnswer(
+                        id: question.id,
+                        question: question.question,
+                        options: question.options.map(\.label),
+                        multi: question.multi,
+                        selectedOptions: selected,
+                        customInput: customInput
+                    )
+                }
+                switch outcome {
+                case .cancelled:
+                    abortRun()
+                    throw CodingToolError.aborted
+                case .back(let selected, let customInput):
+                    record(selected, customInput)
+                    index = max(0, index - 1)
+                case .answered(let selected, let customInput):
+                    record(selected, customInput)
+                    index += 1
+                }
+            }
+            let resolved = answers.compactMap { $0 }
+
+            let text = resolved.count == 1
+                ? Ask.singleResultText(resolved[0])
+                : Ask.multiResultText(resolved)
+            return AgentToolResult(
+                content: [.text(TextContent(text: text))],
+                details: Ask.details(resolved),
+                uiDisplay: resolved.map(Ask.displayLine)
+            )
+        }
+    )
+}

--- a/Sources/KWWKCli/AskTool.swift
+++ b/Sources/KWWKCli/AskTool.swift
@@ -340,6 +340,9 @@ private func runAskQuestions(
     let isWizard = questions.count > 1
     var index = 0
     while index < questions.count {
+        // Cancellation can land between questions (or race the previous
+        // answer's resume) — never present another question for a dead run.
+        try cancellation?.throwIfCancelled()
         let question = questions[index]
         let previous = answers[index]
         let outcome = await present(AskPrompt(
@@ -372,6 +375,9 @@ private func runAskQuestions(
             index += 1
         }
     }
+    // A user confirm can race a cancellation that fired while the LAST
+    // question was up — an aborted run must not receive a normal result.
+    try cancellation?.throwIfCancelled()
     let resolved = answers.compactMap { $0 }
 
     let text = resolved.count == 1

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -638,7 +638,11 @@ func runCodingTUIInternal(
                 let presentation = AskPresentation(continuation)
                 let askModal = AskModal(
                     prompt: prompt,
-                    displayWidth: { runner.terminal.width }
+                    // The live zone renders children one column narrow
+                    // (TUI reserves the last column against pending-wrap);
+                    // wrapping at the full width would get every exactly-full
+                    // row re-wrapped by the frame into a spilled orphan cell.
+                    displayWidth: { max(0, runner.terminal.width - 1) }
                 ) { outcome in
                     modal.close()
                     presentation.resume(outcome)

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -645,7 +645,11 @@ func runCodingTUIInternal(
                     displayWidth: { max(0, runner.terminal.width - 1) }
                 ) { outcome in
                     modal.close()
-                    presentation.resume(outcome)
+                    // The cancel teardown below reaches this actor on a Task
+                    // hop, so a user confirm can race in after the run was
+                    // already cancelled. Resolve the race at this single
+                    // resume point: a cancelled run never gets an answer.
+                    presentation.resume(cancellation?.isCancelled == true ? .cancelled : outcome)
                 }
                 modal.open(askModal)
                 // A run abort landing while the modal is still up (Ctrl-C

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -636,7 +636,10 @@ func runCodingTUIInternal(
         await withCheckedContinuation { continuation in
             Task { @MainActor in
                 let presentation = AskPresentation(continuation)
-                let askModal = AskModal(prompt: prompt) { outcome in
+                let askModal = AskModal(
+                    prompt: prompt,
+                    displayWidth: { runner.terminal.width }
+                ) { outcome in
                     modal.close()
                     presentation.resume(outcome)
                 }

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -625,6 +625,71 @@ func runCodingTUIInternal(
     }
     agentBox.eventUnsubscribe = subscribeToAgentEvents(agent)
 
+    // --- ask tool (UI-only) ----------------------------------------------
+    // `ask` suspends its tool call mid-turn until the user answers in a
+    // selector modal, so it needs the ModalHost and is appended post-build
+    // like `goal` (the loop reads state.tools fresh each turn). Esc in the
+    // modal cancels the whole call and aborts the run, mirroring omp — the
+    // modal consumed the Esc that would otherwise have hit the streaming
+    // abort binding, so the abort is re-issued explicitly below.
+    let presentAsk: AskPresenter = { prompt, cancellation in
+        await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                let presentation = AskPresentation(continuation)
+                let askModal = AskModal(prompt: prompt) { outcome in
+                    modal.close()
+                    presentation.resume(outcome)
+                }
+                modal.open(askModal)
+                // A run abort landing while the modal is still up (Ctrl-C
+                // force-quit teardown, provider failure in a parallel branch)
+                // must not strand the suspended tool call behind a dead run.
+                cancellation?.onCancel { _ in
+                    Task { @MainActor in
+                        guard !presentation.finished else { return }
+                        modal.close()
+                        presentation.resume(.cancelled)
+                    }
+                }
+            }
+        }
+    }
+    let askAbortRun: @Sendable () -> Void = {
+        Task { @MainActor in
+            let wasStreaming = agent.state.isStreaming
+            guard abortInteractiveAgentWork(
+                agent: agent,
+                isManualCompacting: frameStatus.isManualCompacting
+            ) else { return }
+            frameStatus.mode = .aborting
+            if wasStreaming {
+                // Same bookkeeping as the Esc abort path: drop queued steers
+                // so they can't double-drain, and arm /retry from the message
+                // actually in flight.
+                agent.clearSteeringQueue()
+                if let t = retryArmTarget(
+                    summary: nil,
+                    aborted: true,
+                    trackedActive: retry.trackedActive,
+                    messages: agent.state.messages
+                ) {
+                    retry.lastText = t.text
+                    retry.lastImages = t.images
+                    retry.failed = true
+                }
+                retry.trackedActive = false
+            }
+            updateFrameStatus()
+            runner.tui.requestRender()
+        }
+    }
+    let askTool = createAskTool(present: presentAsk, abortRun: askAbortRun)
+    do {
+        var withAsk = agent.state.tools
+        withAsk.append(askTool)
+        agent.state.tools = withAsk
+    }
+
     let setSessionSwitching: @MainActor @Sendable (Bool) -> Void = { active in
         frameStatus.isSessionSwitching = active
         updateFrameStatus()
@@ -679,6 +744,7 @@ func runCodingTUIInternal(
         replacement.state.messages = messages
         var replacementTools = replacement.state.tools
         replacementTools.append(createGoalTool(store: goalStore))
+        replacementTools.append(askTool)
         replacement.state.tools = replacementTools
 
         agentBox.replace(with: replacementCodingAgent)

--- a/Sources/KWWKCli/TranscriptRenderer.swift
+++ b/Sources/KWWKCli/TranscriptRenderer.swift
@@ -359,7 +359,7 @@ final class TranscriptRenderer {
             if !isError, let summary = foldedSummary(name: slot.name, args: slot.args, result: result) {
                 toolSlots[idx].foldEntry = FoldEntry(name: slot.name, summary: summary)
             } else {
-                let header = Style.tool("● \(slot.name)(\(formatArgs(slot.args)))")
+                let header = toolHeader(name: slot.name, args: slot.args)
                 // Leading blank, no trailing — uniform "every scrollback block
                 // opens with a separator row, never closes with one" rule.
                 var finalLines = ["", header]
@@ -659,8 +659,7 @@ final class TranscriptRenderer {
             // scrollback convention so live view and scrollback look
             // identical as blocks roll out.
             out.append("")
-            let header = Style.tool("● \(slot.name)(\(formatArgs(slot.args)))")
-            out.append(header)
+            out.append(toolHeader(name: slot.name, args: slot.args))
             if let resolved = slot.resolution {
                 // Committed form is `["", header, body...]`; we've
                 // already emitted our own blank + header, so strip those
@@ -949,6 +948,26 @@ final class TranscriptRenderer {
         let m = Int(seconds) / 60
         let s = Int(seconds) % 60
         return "\(m)m \(s)s"
+    }
+
+    /// `● name(args…)` header line for a tool block. `ask` gets its first
+    /// question inline — the generic form would render the questions array as
+    /// an opaque `questions: [2 items]`.
+    private func toolHeader(name: String, args: JSONValue) -> String {
+        if name == "ask", let summary = askHeaderSummary(args) {
+            return Style.tool("● ask(\(summary))")
+        }
+        return Style.tool("● \(name)(\(formatArgs(args)))")
+    }
+
+    private func askHeaderSummary(_ args: JSONValue) -> String? {
+        guard case .object(let obj) = args,
+              case .array(let questions) = obj["questions"] ?? .null,
+              case .object(let first) = questions.first ?? .null,
+              case .string(let text) = first["question"] ?? .null else { return nil }
+        var summary = "\"\(truncate(text, to: 60))\""
+        if questions.count > 1 { summary += " +\(questions.count - 1) more" }
+        return summary
     }
 
     private func formatArgs(_ args: JSONValue) -> String {

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -427,6 +427,14 @@ struct AskModalTests {
             #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
             // The cursor row must be inside the window at every position.
             #expect(lines.contains(where: { $0.contains("❯") }), "cursor missing at step \(step)")
+            // The selected entry's label must be FULLY visible (wrapped, not
+            // truncated): its plain text reassembles from the window rows.
+            if case .option(let optIdx) = modal.entries[modal.selectedIndex] {
+                let plain = lines.map { ANSI.stripEscapes($0).replacingOccurrences(of: " ", with: "") }
+                    .joined()
+                let label = options[optIdx].label.replacingOccurrences(of: " ", with: "")
+                #expect(plain.contains(label), "label cut off at step \(step)")
+            }
             modal.down()
         }
         // Deep in the list the window has scrolled: the first option is gone,
@@ -438,7 +446,42 @@ struct AskModalTests {
         #expect(deep.contains(where: { $0.contains("/\(options.count + 2)") }))
     }
 
-    @Test("other-input shows the tail of an overlong buffer")
+    @Test("only an entry taller than the window is clamped, with a marker")
+    func overTallEntryClamps() {
+        let log = OutcomeLog()
+        let question = AskQuestion(
+            id: "q", question: "Q?",
+            options: [
+                AskOption(label: "Small", description: "short"),
+                AskOption(label: "Huge", description: String(repeating: "很长的描述内容", count: 80)),
+            ],
+            multi: false, recommended: nil
+        )
+        let width = 40
+        let maxRows = 12
+        let modal = makeModal(prompt(question), width: width, onComplete: log.callback)
+
+        modal.down() // onto Huge
+        let lines = modal.render(maxRows: maxRows)
+        #expect(lines.count <= maxRows)
+        #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+        #expect(lines.contains(where: { $0.contains("Huge") }))
+        #expect(lines.contains(where: { $0.contains("more lines") }))
+
+        // The rest of the list stays reachable past the clamped monster.
+        modal.down() // Other row
+        let after = modal.render(maxRows: maxRows)
+        #expect(after.contains(where: { $0.contains(Ask.otherOptionLabel) && $0.contains("❯") }))
+
+        // A normal multi-row entry below the window threshold is NOT clamped.
+        modal.up() // Huge
+        modal.up() // Small
+        let back = modal.render(maxRows: maxRows)
+        let plain = back.map { ANSI.stripEscapes($0) }.joined()
+        #expect(plain.contains("short"))
+    }
+
+    @Test("other-input wraps an overlong buffer and keeps the tail visible")
     func otherInputLongBuffer() {
         let log = OutcomeLog()
         let modal = makeModal(prompt(singleQuestion()), width: 40, onComplete: log.callback)
@@ -446,9 +489,11 @@ struct AskModalTests {
         modal.confirm()
         _ = modal.handleText(String(repeating: "a", count: 60) + "TAIL")
         let lines = modal.render(maxRows: 10)
+        #expect(lines.count <= 10)
         #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= 40 })
-        #expect(lines.contains(where: { $0.contains("TAIL") }))
-        #expect(lines.contains(where: { $0.contains("…") }))
+        // Wrapped, not truncated: the full buffer reassembles from the rows.
+        let plain = lines.map { ANSI.stripEscapes($0).replacingOccurrences(of: " ", with: "") }.joined()
+        #expect(plain.contains(String(repeating: "a", count: 60) + "TAIL"))
     }
 
     @Test("other-input render shows the buffer and its own hints")

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -93,6 +93,15 @@ private final class OutcomeLog {
     func callback(_ outcome: AskOutcome) { outcomes.append(outcome) }
 }
 
+@MainActor
+private func makeModal(
+    _ prompt: AskPrompt,
+    width: Int = 80,
+    onComplete: @MainActor @escaping (AskOutcome) -> Void
+) -> AskModal {
+    AskModal(prompt: prompt, displayWidth: { width }, onComplete: onComplete)
+}
+
 // MARK: - Argument parsing
 
 @Suite("Ask argument parsing")
@@ -272,7 +281,7 @@ struct AskModalTests {
     @Test("enter on an option answers a single-select question")
     func singleSelect() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion()), onComplete: log.callback)
         modal.down()
         modal.confirm()
         #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
@@ -281,7 +290,7 @@ struct AskModalTests {
     @Test("recommended option is the initial cursor position")
     func recommendedInitial() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion(recommended: 1)), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion(recommended: 1)), onComplete: log.callback)
         modal.confirm()
         #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
     }
@@ -289,7 +298,7 @@ struct AskModalTests {
     @Test("multi: enter toggles, Done submits in option order")
     func multiToggleAndDone() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion(multi: true)), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion(multi: true)), onComplete: log.callback)
         // Toggle B first, then A — submit order must follow option order.
         modal.down()
         modal.confirm()
@@ -307,7 +316,7 @@ struct AskModalTests {
     @Test("other: typed text submits as custom input; esc returns to the list")
     func otherInput() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion()), onComplete: log.callback)
         modal.up() // wraps to the Other row (last entry)
         modal.confirm()
         #expect(modal.handleText("hi there"))
@@ -319,7 +328,7 @@ struct AskModalTests {
     @Test("esc in other-input backs out; esc in the list cancels")
     func escBehavior() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion()), onComplete: log.callback)
         modal.up()
         modal.confirm() // into other-input
         modal.cancel() // back to the list
@@ -332,15 +341,15 @@ struct AskModalTests {
     @Test("left/right only navigate when the wizard allows them")
     func wizardNavGating() {
         let single = OutcomeLog()
-        let singleModal = AskModal(prompt: prompt(singleQuestion()), onComplete: single.callback)
+        let singleModal = makeModal(prompt(singleQuestion()), onComplete: single.callback)
         singleModal.left()
         singleModal.right()
         #expect(single.outcomes.isEmpty)
 
         let wizard = OutcomeLog()
-        let wizardModal = AskModal(
-            prompt: prompt(singleQuestion(), allowBack: true, allowForward: true,
-                           previousSelection: ["A"]),
+        let wizardModal = makeModal(
+            prompt(singleQuestion(), allowBack: true, allowForward: true,
+                   previousSelection: ["A"]),
             onComplete: wizard.callback
         )
         wizardModal.left()
@@ -354,8 +363,8 @@ struct AskModalTests {
     @Test("wizard back carries the live multi selections")
     func backCarriesMultiState() {
         let log = OutcomeLog()
-        let modal = AskModal(
-            prompt: prompt(singleQuestion(multi: true), allowBack: true, allowForward: true),
+        let modal = makeModal(
+            prompt(singleQuestion(multi: true), allowBack: true, allowForward: true),
             onComplete: log.callback
         )
         modal.confirm() // toggle A
@@ -366,9 +375,9 @@ struct AskModalTests {
     @Test("forward keeps the previous answer")
     func forwardKeepsPrevious() {
         let log = OutcomeLog()
-        let modal = AskModal(
-            prompt: prompt(singleQuestion(), allowBack: false, allowForward: true,
-                           previousSelection: ["B"]),
+        let modal = makeModal(
+            prompt(singleQuestion(), allowBack: false, allowForward: true,
+                   previousSelection: ["B"]),
             onComplete: log.callback
         )
         modal.right()
@@ -386,7 +395,7 @@ struct AskModalTests {
             ],
             multi: false, recommended: 0
         )
-        let modal = AskModal(prompt: prompt(question), onComplete: log.callback)
+        let modal = makeModal(prompt(question), onComplete: log.callback)
         let lines = modal.render(maxRows: 20)
         #expect(lines.contains(where: { $0.contains("Which auth?") }))
         #expect(lines.contains(where: { $0.contains("JWT") && $0.contains("(Recommended)") }))
@@ -395,10 +404,57 @@ struct AskModalTests {
         #expect(lines.contains(where: { $0.contains("Esc: cancel") }))
     }
 
+    @Test("long lists window within maxRows, clamp to width, and follow the cursor")
+    func longListWindows() {
+        let log = OutcomeLog()
+        let options = (1...30).map { i in
+            AskOption(
+                label: "选项 \(String(format: "%02d", i)): 一个非常非常长的标题用来测试列表较长时是否有滚动体验",
+                description: "这是第 \(i) 个超长选项说明：堆叠大量内容以测试 ask 工具接近极限时的表现。"
+            )
+        }
+        let question = AskQuestion(
+            id: "q", question: "超长压力测试：如果有超级多选项，列表应当在窗口内滚动而不是撑爆终端?",
+            options: options, multi: true, recommended: 7
+        )
+        let width = 60
+        let maxRows = 20
+        let modal = makeModal(prompt(question), width: width, onComplete: log.callback)
+
+        for step in 0..<40 {
+            let lines = modal.render(maxRows: maxRows)
+            #expect(lines.count <= maxRows)
+            #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+            // The cursor row must be inside the window at every position.
+            #expect(lines.contains(where: { $0.contains("❯") }), "cursor missing at step \(step)")
+            modal.down()
+        }
+        // Deep in the list the window has scrolled: the first option is gone,
+        // a windowed position indicator is shown.
+        for _ in 0..<25 { modal.down() } // wrap around and land mid-list again
+        modal.down()
+        let deep = modal.render(maxRows: maxRows)
+        #expect(!deep.contains(where: { $0.contains("选项 01") }))
+        #expect(deep.contains(where: { $0.contains("/\(options.count + 2)") }))
+    }
+
+    @Test("other-input shows the tail of an overlong buffer")
+    func otherInputLongBuffer() {
+        let log = OutcomeLog()
+        let modal = makeModal(prompt(singleQuestion()), width: 40, onComplete: log.callback)
+        modal.up()
+        modal.confirm()
+        _ = modal.handleText(String(repeating: "a", count: 60) + "TAIL")
+        let lines = modal.render(maxRows: 10)
+        #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= 40 })
+        #expect(lines.contains(where: { $0.contains("TAIL") }))
+        #expect(lines.contains(where: { $0.contains("…") }))
+    }
+
     @Test("other-input render shows the buffer and its own hints")
     func renderOtherInput() {
         let log = OutcomeLog()
-        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion()), onComplete: log.callback)
         modal.up()
         modal.confirm()
         _ = modal.handleText("custom")

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -161,6 +161,16 @@ struct AskParseTests {
 
 @Suite("Ask result shaping")
 struct AskResultTests {
+    @Test("multi answer with checked options AND custom input reports both")
+    func multiWithCustomKeepsSelections() {
+        let answer = AskAnswer(
+            id: "q", question: "Which?", options: [], multi: true,
+            selectedOptions: ["A", "B"], customInput: "also this"
+        )
+        #expect(Ask.answerLine(answer) == "q: [A, B] + \"also this\"")
+        #expect(Ask.displayLine(answer) == "Which? → A, B + \"also this\"")
+    }
+
     @Test("answer lines mirror omp: custom / multi / single / none")
     func answerLines() {
         #expect(Ask.answerLine(AskAnswer(
@@ -255,6 +265,40 @@ struct AskExecuteTests {
         // the second question's in-progress state survives the round trip.
         #expect(prompts[2].previousSelection == ["A"])
         #expect(prompts[3].previousSelection == ["X"])
+    }
+
+    @Test("parallel ask calls serialize instead of hanging on the one modal host")
+    func parallelCallsSerialize() async throws {
+        // Presenter that fails the test if two presentations ever overlap,
+        // mirroring the single-ModalHost constraint.
+        final class OverlapGuard: @unchecked Sendable {
+            private let lock = NSLock()
+            private var active = 0
+            private(set) var overlapped = false
+            private(set) var served = 0
+            func present(_ prompt: AskPrompt, _ cancellation: CancellationHandle?) async -> AskOutcome {
+                lock.withLock {
+                    active += 1
+                    if active > 1 { overlapped = true }
+                }
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                lock.withLock {
+                    active -= 1
+                    served += 1
+                }
+                return .answered(selected: ["A"], customInput: nil)
+            }
+        }
+        let guardBox = OverlapGuard()
+        let tool = createAskTool(present: guardBox.present, abortRun: {})
+
+        async let first = tool.execute("t1", askArgs([questionJSON(id: "one")]), nil, nil)
+        async let second = tool.execute("t2", askArgs([questionJSON(id: "two")]), nil, nil)
+        let results = try await [first, second]
+
+        #expect(!guardBox.overlapped)
+        #expect(guardBox.served == 2)
+        #expect(results.count == 2)
     }
 
     @Test("multi answer and skipped question render omp-style lines")
@@ -382,6 +426,21 @@ struct AskModalTests {
         )
         modal.right()
         #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
+    }
+
+    @Test("wizard nav carries an in-progress Other draft")
+    func navCarriesOtherDraft() {
+        let log = OutcomeLog()
+        let modal = makeModal(
+            prompt(singleQuestion(), allowBack: true, allowForward: true),
+            onComplete: log.callback
+        )
+        modal.up() // Other row
+        modal.confirm() // into free-text entry
+        _ = modal.handleText("draft answer")
+        modal.cancel() // back to the list, buffer retained
+        modal.right()
+        #expect(log.outcomes == [.answered(selected: [], customInput: "draft answer")])
     }
 
     @Test("render shows question, markers, recommended tag, and hints")

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -1,0 +1,439 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+@testable import KWWKAgent
+@testable import KWWKCli
+
+// MARK: - Helpers
+
+/// Scripted presenter: pops pre-arranged outcomes in order and records every
+/// prompt the tool presented.
+private final class ScriptedPresenter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcomes: [AskOutcome]
+    private(set) var prompts: [AskPrompt] = []
+
+    init(_ outcomes: [AskOutcome]) {
+        self.outcomes = outcomes
+    }
+
+    func present(_ prompt: AskPrompt, _ cancellation: CancellationHandle?) async -> AskOutcome {
+        lock.withLock {
+            prompts.append(prompt)
+            return outcomes.removeFirst()
+        }
+    }
+
+    var recorded: [AskPrompt] { lock.withLock { prompts } }
+}
+
+private final class AbortFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _aborted = false
+    var aborted: Bool { lock.withLock { _aborted } }
+    func set() { lock.withLock { _aborted = true } }
+}
+
+private func askArgs(_ questions: [JSONValue]) -> JSONValue {
+    .object(["questions": .array(questions)])
+}
+
+private func questionJSON(
+    id: String = "q",
+    question: String = "Which one?",
+    options: [String] = ["A", "B"],
+    multi: Bool? = nil,
+    recommended: Int? = nil
+) -> JSONValue {
+    var fields: [String: JSONValue] = [
+        "id": .string(id),
+        "question": .string(question),
+        "options": .array(options.map { .object(["label": .string($0)]) }),
+    ]
+    if let multi { fields["multi"] = .bool(multi) }
+    if let recommended { fields["recommended"] = .int(recommended) }
+    return .object(fields)
+}
+
+private func resultText(_ result: AgentToolResult) -> String {
+    result.content.compactMap { block -> String? in
+        if case .text(let t) = block { return t.text } else { return nil }
+    }.joined(separator: "\n")
+}
+
+private func singleQuestion(
+    options: [AskOption] = [AskOption(label: "A", description: nil), AskOption(label: "B", description: nil)],
+    multi: Bool = false,
+    recommended: Int? = nil
+) -> AskQuestion {
+    AskQuestion(id: "q", question: "Which one?", options: options, multi: multi, recommended: recommended)
+}
+
+private func prompt(
+    _ question: AskQuestion,
+    allowBack: Bool = false,
+    allowForward: Bool = false,
+    previousSelection: [String] = [],
+    previousCustomInput: String? = nil
+) -> AskPrompt {
+    AskPrompt(
+        question: question,
+        progressText: nil,
+        allowBack: allowBack,
+        allowForward: allowForward,
+        previousSelection: previousSelection,
+        previousCustomInput: previousCustomInput
+    )
+}
+
+/// Records modal outcomes; asserts single-fire by construction (appends).
+@MainActor
+private final class OutcomeLog {
+    var outcomes: [AskOutcome] = []
+    func callback(_ outcome: AskOutcome) { outcomes.append(outcome) }
+}
+
+// MARK: - Argument parsing
+
+@Suite("Ask argument parsing")
+struct AskParseTests {
+    @Test("parses a full question")
+    func parsesFullQuestion() throws {
+        let args = askArgs([.object([
+            "id": .string("auth"),
+            "question": .string("Which auth?"),
+            "options": .array([
+                .object(["label": .string("JWT"), "description": .string("Bearer tokens")]),
+                .object(["label": .string("Sessions")]),
+            ]),
+            "multi": .bool(true),
+            "recommended": .int(1),
+        ])])
+        let questions = try Ask.parseQuestions(args)
+        #expect(questions == [AskQuestion(
+            id: "auth",
+            question: "Which auth?",
+            options: [
+                AskOption(label: "JWT", description: "Bearer tokens"),
+                AskOption(label: "Sessions", description: nil),
+            ],
+            multi: true,
+            recommended: 1
+        )])
+    }
+
+    @Test("rejects missing questions, empty questions, and empty options")
+    func rejectsMalformed() {
+        #expect(throws: CodingToolError.self) { try Ask.parseQuestions(.object([:])) }
+        #expect(throws: CodingToolError.self) { try Ask.parseQuestions(askArgs([])) }
+        #expect(throws: CodingToolError.self) {
+            try Ask.parseQuestions(askArgs([.object([
+                "id": .string("q"), "question": .string("?"), "options": .array([]),
+            ])]))
+        }
+        #expect(throws: CodingToolError.self) {
+            try Ask.parseQuestions(askArgs([.object([
+                "question": .string("?"),
+                "options": .array([.object(["label": .string("A")])]),
+            ])]))
+        }
+    }
+
+    @Test("out-of-range recommended index is dropped")
+    func recommendedOutOfRange() throws {
+        let questions = try Ask.parseQuestions(askArgs([
+            questionJSON(options: ["A", "B"], recommended: 5),
+        ]))
+        #expect(questions[0].recommended == nil)
+    }
+}
+
+// MARK: - Result shaping
+
+@Suite("Ask result shaping")
+struct AskResultTests {
+    @Test("answer lines mirror omp: custom / multi / single / none")
+    func answerLines() {
+        #expect(Ask.answerLine(AskAnswer(
+            id: "q", question: "?", options: [], multi: false,
+            selectedOptions: [], customInput: "my own"
+        )) == "q: \"my own\"")
+        #expect(Ask.answerLine(AskAnswer(
+            id: "q", question: "?", options: [], multi: true,
+            selectedOptions: ["A", "B"], customInput: nil
+        )) == "q: [A, B]")
+        #expect(Ask.answerLine(AskAnswer(
+            id: "q", question: "?", options: [], multi: false,
+            selectedOptions: ["A"], customInput: nil
+        )) == "q: A")
+        #expect(Ask.answerLine(AskAnswer(
+            id: "q", question: "?", options: [], multi: false,
+            selectedOptions: [], customInput: nil
+        )) == "q: (no selection)")
+    }
+
+    @Test("single-question text: selection, multiline custom input, both")
+    func singleText() {
+        #expect(Ask.singleResultText(AskAnswer(
+            id: "q", question: "?", options: [], multi: false,
+            selectedOptions: ["JWT"], customInput: nil
+        )) == "User selected: JWT")
+        #expect(Ask.singleResultText(AskAnswer(
+            id: "q", question: "?", options: [], multi: false,
+            selectedOptions: [], customInput: "line1\nline2"
+        )) == "User provided custom input:\n  line1\n  line2")
+        #expect(Ask.singleResultText(AskAnswer(
+            id: "q", question: "?", options: [], multi: true,
+            selectedOptions: ["A"], customInput: "extra"
+        )) == "User selected: A\nUser provided custom input: extra")
+    }
+}
+
+// MARK: - Tool execution
+
+@Suite("Ask tool execution")
+struct AskExecuteTests {
+    @Test("single question answers with selection text and display line")
+    func singleAnswered() async throws {
+        let presenter = ScriptedPresenter([.answered(selected: ["B"], customInput: nil)])
+        let abort = AbortFlag()
+        let tool = createAskTool(present: presenter.present, abortRun: { abort.set() })
+
+        let result = try await tool.execute("t1", askArgs([questionJSON()]), nil, nil)
+        #expect(resultText(result) == "User selected: B")
+        #expect(result.uiDisplay == ["Which one? → B"])
+        #expect(!abort.aborted)
+
+        let prompts = presenter.recorded
+        #expect(prompts.count == 1)
+        #expect(prompts[0].progressText == nil)
+        #expect(!prompts[0].allowBack && !prompts[0].allowForward)
+    }
+
+    @Test("cancel aborts the run and throws")
+    func cancelAborts() async throws {
+        let presenter = ScriptedPresenter([.cancelled])
+        let abort = AbortFlag()
+        let tool = createAskTool(present: presenter.present, abortRun: { abort.set() })
+
+        await #expect(throws: CodingToolError.aborted) {
+            _ = try await tool.execute("t1", askArgs([questionJSON()]), nil, nil)
+        }
+        #expect(abort.aborted)
+    }
+
+    @Test("wizard: back revisits with the previous answer, result lists all ids")
+    func wizardBackNavigation() async throws {
+        let q1 = questionJSON(id: "first", question: "First?", options: ["A", "B"])
+        let q2 = questionJSON(id: "second", question: "Second?", options: ["X", "Y"])
+        let presenter = ScriptedPresenter([
+            .answered(selected: ["A"], customInput: nil),
+            .back(selected: ["X"], customInput: nil),
+            .answered(selected: ["B"], customInput: nil),
+            .answered(selected: ["Y"], customInput: nil),
+        ])
+        let tool = createAskTool(present: presenter.present, abortRun: {})
+
+        let result = try await tool.execute("t1", askArgs([q1, q2]), nil, nil)
+        #expect(resultText(result) == "User answers:\nfirst: B\nsecond: Y")
+
+        let prompts = presenter.recorded
+        #expect(prompts.count == 4)
+        #expect(prompts.map(\.progressText) == ["1/2", "2/2", "1/2", "2/2"])
+        #expect(prompts.map(\.allowBack) == [false, true, false, true])
+        #expect(prompts.map(\.allowForward) == [true, true, true, true])
+        // Revisited first question carries its previous answer back in, and
+        // the second question's in-progress state survives the round trip.
+        #expect(prompts[2].previousSelection == ["A"])
+        #expect(prompts[3].previousSelection == ["X"])
+    }
+
+    @Test("multi answer and skipped question render omp-style lines")
+    func multiAndSkipped() async throws {
+        let q1 = questionJSON(id: "langs", question: "Which?", options: ["Swift", "Rust"], multi: true)
+        let q2 = questionJSON(id: "extra", question: "More?", options: ["Yes"])
+        let presenter = ScriptedPresenter([
+            .answered(selected: ["Swift", "Rust"], customInput: nil),
+            .answered(selected: [], customInput: nil),
+        ])
+        let tool = createAskTool(present: presenter.present, abortRun: {})
+
+        let result = try await tool.execute("t1", askArgs([q1, q2]), nil, nil)
+        #expect(resultText(result) == "User answers:\nlangs: [Swift, Rust]\nextra: (no selection)")
+        #expect(result.uiDisplay == ["Which? → Swift, Rust", "More? → (no selection)"])
+    }
+}
+
+// MARK: - Modal behavior
+
+@MainActor
+@Suite("Ask modal")
+struct AskModalTests {
+    @Test("enter on an option answers a single-select question")
+    func singleSelect() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        modal.down()
+        modal.confirm()
+        #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
+    }
+
+    @Test("recommended option is the initial cursor position")
+    func recommendedInitial() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion(recommended: 1)), onComplete: log.callback)
+        modal.confirm()
+        #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
+    }
+
+    @Test("multi: enter toggles, Done submits in option order")
+    func multiToggleAndDone() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion(multi: true)), onComplete: log.callback)
+        // Toggle B first, then A — submit order must follow option order.
+        modal.down()
+        modal.confirm()
+        modal.up()
+        modal.confirm()
+        #expect(log.outcomes.isEmpty)
+        #expect(modal.orderedSelection == ["A", "B"])
+        // Entries: A, B, Done, Other — move from A to Done.
+        modal.down()
+        modal.down()
+        modal.confirm()
+        #expect(log.outcomes == [.answered(selected: ["A", "B"], customInput: nil)])
+    }
+
+    @Test("other: typed text submits as custom input; esc returns to the list")
+    func otherInput() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        modal.up() // wraps to the Other row (last entry)
+        modal.confirm()
+        #expect(modal.handleText("hi there"))
+        #expect(modal.handleText("\u{7F}")) // backspace: "hi ther"
+        modal.confirm()
+        #expect(log.outcomes == [.answered(selected: [], customInput: "hi ther")])
+    }
+
+    @Test("esc in other-input backs out; esc in the list cancels")
+    func escBehavior() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        modal.up()
+        modal.confirm() // into other-input
+        modal.cancel() // back to the list
+        #expect(log.outcomes.isEmpty)
+        #expect(!modal.handleText("x")) // list mode consumes nothing
+        modal.cancel()
+        #expect(log.outcomes == [.cancelled])
+    }
+
+    @Test("left/right only navigate when the wizard allows them")
+    func wizardNavGating() {
+        let single = OutcomeLog()
+        let singleModal = AskModal(prompt: prompt(singleQuestion()), onComplete: single.callback)
+        singleModal.left()
+        singleModal.right()
+        #expect(single.outcomes.isEmpty)
+
+        let wizard = OutcomeLog()
+        let wizardModal = AskModal(
+            prompt: prompt(singleQuestion(), allowBack: true, allowForward: true,
+                           previousSelection: ["A"]),
+            onComplete: wizard.callback
+        )
+        wizardModal.left()
+        #expect(wizard.outcomes == [.back(selected: ["A"], customInput: nil)])
+        // A finished modal reports exactly once.
+        wizardModal.right()
+        wizardModal.confirm()
+        #expect(wizard.outcomes == [.back(selected: ["A"], customInput: nil)])
+    }
+
+    @Test("wizard back carries the live multi selections")
+    func backCarriesMultiState() {
+        let log = OutcomeLog()
+        let modal = AskModal(
+            prompt: prompt(singleQuestion(multi: true), allowBack: true, allowForward: true),
+            onComplete: log.callback
+        )
+        modal.confirm() // toggle A
+        modal.left()
+        #expect(log.outcomes == [.back(selected: ["A"], customInput: nil)])
+    }
+
+    @Test("forward keeps the previous answer")
+    func forwardKeepsPrevious() {
+        let log = OutcomeLog()
+        let modal = AskModal(
+            prompt: prompt(singleQuestion(), allowBack: false, allowForward: true,
+                           previousSelection: ["B"]),
+            onComplete: log.callback
+        )
+        modal.right()
+        #expect(log.outcomes == [.answered(selected: ["B"], customInput: nil)])
+    }
+
+    @Test("render shows question, markers, recommended tag, and hints")
+    func renderLines() {
+        let log = OutcomeLog()
+        let question = AskQuestion(
+            id: "q", question: "Which auth?",
+            options: [
+                AskOption(label: "JWT", description: "Bearer tokens"),
+                AskOption(label: "Sessions", description: nil),
+            ],
+            multi: false, recommended: 0
+        )
+        let modal = AskModal(prompt: prompt(question), onComplete: log.callback)
+        let lines = modal.render(maxRows: 20)
+        #expect(lines.contains(where: { $0.contains("Which auth?") }))
+        #expect(lines.contains(where: { $0.contains("JWT") && $0.contains("(Recommended)") }))
+        #expect(lines.contains(where: { $0.contains("↳ Bearer tokens") }))
+        #expect(lines.contains(where: { $0.contains(Ask.otherOptionLabel) }))
+        #expect(lines.contains(where: { $0.contains("Esc: cancel") }))
+    }
+
+    @Test("other-input render shows the buffer and its own hints")
+    func renderOtherInput() {
+        let log = OutcomeLog()
+        let modal = AskModal(prompt: prompt(singleQuestion()), onComplete: log.callback)
+        modal.up()
+        modal.confirm()
+        _ = modal.handleText("custom")
+        let lines = modal.render(maxRows: 10)
+        #expect(lines.contains(where: { $0.contains("custom") }))
+        #expect(lines.contains(where: { $0.contains("Enter: submit") }))
+    }
+}
+
+// MARK: - Transcript rendering
+
+@MainActor
+@Suite("Ask transcript rendering")
+struct AskTranscriptTests {
+    @Test("header shows the first question instead of the raw array")
+    func headerSummary() {
+        let r = TranscriptRenderer()
+        let args = askArgs([
+            questionJSON(question: "Which auth method?"),
+            questionJSON(id: "q2", question: "Second?"),
+        ])
+        r.apply(.toolExecutionStart(toolCallId: "1", toolName: "ask", args: args))
+        #expect(r.liveLines.contains(where: { $0.contains("ask(\"Which auth method?\" +1 more)") }))
+
+        r.apply(.toolExecutionEnd(
+            toolCallId: "1",
+            toolName: "ask",
+            result: AgentToolResult(
+                content: [.text(TextContent(text: "User selected: JWT"))],
+                uiDisplay: ["Which auth method? → JWT"]
+            ),
+            isError: false
+        ))
+        let commits = r.drainCommits()
+        #expect(commits.contains(where: { $0.contains("ask(\"Which auth method?\" +1 more)") }))
+        #expect(commits.contains(where: { $0.contains("Which auth method? → JWT") }))
+    }
+}

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -301,6 +301,42 @@ struct AskExecuteTests {
         #expect(results.count == 2)
     }
 
+    @Test("an answer racing a cancellation never yields a normal result")
+    func answerRacingCancellationThrows() async throws {
+        let cancellation = CancellationHandle()
+        // Presenter simulating the race: the run is cancelled while the
+        // question is up, and the user's confirm still resumes with an answer.
+        let present: AskPresenter = { _, handle in
+            handle?.cancel()
+            return .answered(selected: ["A"], customInput: nil)
+        }
+        let tool = createAskTool(present: present, abortRun: {})
+        await #expect(throws: CancellationError.self) {
+            _ = try await tool.execute("t1", askArgs([questionJSON()]), cancellation, nil)
+        }
+    }
+
+    @Test("cancellation between wizard questions stops before the next one")
+    func cancellationBetweenQuestions() async throws {
+        let cancellation = CancellationHandle()
+        let presented = AbortFlag() // reused flag: set when a SECOND question is presented
+        let present: AskPresenter = { prompt, handle in
+            if prompt.question.id == "second" { presented.set() }
+            handle?.cancel()
+            return .answered(selected: ["A"], customInput: nil)
+        }
+        let tool = createAskTool(present: present, abortRun: {})
+        await #expect(throws: CancellationError.self) {
+            _ = try await tool.execute(
+                "t1",
+                askArgs([questionJSON(id: "first"), questionJSON(id: "second")]),
+                cancellation,
+                nil
+            )
+        }
+        #expect(!presented.aborted)
+    }
+
     @Test("multi answer and skipped question render omp-style lines")
     func multiAndSkipped() async throws {
         let q1 = questionJSON(id: "langs", question: "Which?", options: ["Swift", "Rust"], multi: true)


### PR DESCRIPTION
## Summary

Ports omp's `ask` tool to kwwk: the model can pause mid-turn and ask the user clarifying questions through a TUI selector modal. Schema and result text mirror omp (`questions: [{id, question, options: [{label, description?}], multi?, recommended?}]`; `User selected: X` / `User answers:` blocks).

- **`AskTool.swift`** — model-facing tool: argument parsing, wizard loop, omp-style result shaping, tool description with omp's usage constraints (default to action, 2-5 options, no self-supplied "Other").
- **`AskModal.swift`** — selector modal: radio single-select, checkbox multi-select with a Done row, `(Recommended)` tag as the initial cursor, dim `↳ description` sub-lines, auto-appended "Other (type your own)" inline free-text entry, edge-scroll windowing.
- **Wizard**: multi-question calls get `(1/2)` progress and ←/→ navigation; `.back` carries the question's in-progress state so selections survive a back/forward round trip (omp saves the answer before navigating).
- **Wiring (CodingTUI)**: UI-only — appended post-build like `goal` (and on `/new` / `/resume` session swaps), never registered by `makeCodingAgent`, so headless runs and subagents never see it. The tool call suspends on a continuation resumed exactly once, by the modal or by a run abort landing while it is up. Esc cancels the call and aborts the run, sharing the Esc-abort `/retry` bookkeeping.
- **Transcript**: `● ask("First question?" +N more)` headers instead of the opaque `questions: [2 items]`, and `⎿ question → answer` result lines via `uiDisplay`.

## Testing

- 20 new unit tests (parsing, result shaping, execute wizard flow incl. cancel-aborts and back-navigation state, modal key behavior, transcript rendering); full suite passes (1267 tests).
- Driven end-to-end in the real TUI via tmux against a live model: single question, two-question wizard with multi-select + back/forward state retention, Other free-text answer, and Esc-cancel aborting the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New interactive tool path blocks the agent mid-turn and ties Esc/cancellation to full run abort; concurrency and continuation races are handled explicitly but the behavior change is user-visible during streaming.
> 
> **Overview**
> Adds an **`ask` tool** so the model can pause mid-turn for user clarification via a TUI selector modal (ported from omp). The tool parses `questions` with single/multi select, optional descriptions and recommended index, runs a multi-question wizard with ←/→ navigation, and returns omp-style result text plus transcript `uiDisplay` lines.
> 
> **`AskModal`** implements radio/checkbox UI, a synthetic **Other (type your own)** free-text path, ANSI-aware wrapping/scrolling, and reports outcomes without closing itself. **`CodingTUI`** registers the tool only in the interactive coding session (like `goal`), suspends the tool on a continuation resumed exactly once (`AskPresentation`), wires cancel/abort with Esc-style `/retry` bookkeeping, and re-attaches on session replacement. Concurrent `ask` calls serialize through **`AskGate`** so one modal host cannot strand a second continuation.
> 
> **`TranscriptRenderer`** shows readable `ask("first question?" +N more)` headers instead of raw JSON. Esc on cancel **aborts the run** rather than returning a soft decline to the model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3366937ca5cf0278f1f94ef9b86caf4b5485db7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->