### PR TITLE
fix(tui): manual width fitting + in-modal hardware cursor for all modals

### DIFF
--- a/Sources/KWWKCli/ANSI.swift
+++ b/Sources/KWWKCli/ANSI.swift
@@ -207,6 +207,35 @@ enum ANSI {
         return out
     }
 
+    /// Truncate to at most `width` visible columns like `truncate`, but mark
+    /// a cut with a trailing `…` so the user can tell content was dropped.
+    /// Strings that already fit come back unchanged.
+    static func fit(_ s: String, to width: Int) -> String {
+        if visibleWidth(s) <= width { return s }
+        guard width > 1 else { return truncate(s, to: width) }
+        return truncate(s, to: width - 1) + "…"
+    }
+
+    /// Keep the TAIL of a plain (escape-free) string within `width` columns,
+    /// prefixing `…` when the head was cut — the scrolled-input idiom for a
+    /// caret pinned at the end of a buffer (form fields, filter queries).
+    /// Plain text only: a single backward grapheme walk, so embedded escape
+    /// sequences would be miscounted (and could be split mid-sequence).
+    static func fitTail(_ s: String, to width: Int) -> String {
+        guard width > 0 else { return "" }
+        if visibleWidth(s) <= width { return s }
+        var cols = 0
+        var cut = s.endIndex
+        while cut > s.startIndex {
+            let prev = s.index(before: cut)
+            let w = graphemeWidth(s[prev])
+            if cols + w > width - 1 { break }
+            cols += w
+            cut = prev
+        }
+        return "…" + s[cut...]
+    }
+
     /// Soft-wrap a styled string into rows that fit `width` visible columns.
     /// ANSI SGR sequences are treated as zero-width metadata and are carried
     /// across wrapped rows so foreground/background styling does not leak or

--- a/Sources/KWWKCli/AskModal.swift
+++ b/Sources/KWWKCli/AskModal.swift
@@ -43,14 +43,6 @@ final class AskModal: Modal {
     }
 
     private let prompt: AskPrompt
-    /// Live display width, queried per render (a resize reflow must re-fit).
-    /// Every emitted line is pre-wrapped to it: the frame wraps overlong
-    /// modal lines into extra physical rows and then keeps only the bottom
-    /// of an overflowing modal, so one emitted line MUST be one terminal row
-    /// for the `maxRows` windowing contract to hold. Content is never
-    /// truncated — long labels and descriptions wrap with a hanging indent
-    /// and the window scrolls over physical rows.
-    private let displayWidth: () -> Int
     private let onComplete: @MainActor (AskOutcome) -> Void
     private var completed = false
 
@@ -66,11 +58,9 @@ final class AskModal: Modal {
 
     init(
         prompt: AskPrompt,
-        displayWidth: @escaping () -> Int,
         onComplete: @MainActor @escaping (AskOutcome) -> Void
     ) {
         self.prompt = prompt
-        self.displayWidth = displayWidth
         self.onComplete = onComplete
 
         var entries: [Entry] = prompt.question.options.indices.map { .option($0) }
@@ -235,8 +225,16 @@ final class AskModal: Modal {
         return max(0, min(scroll, max(0, count - windowSize)))
     }
 
-    func render(maxRows: Int) -> [String] {
-        let width = max(24, displayWidth())
+    /// Every emitted line is pre-wrapped to `width`: the frame wraps overlong
+    /// modal lines into extra physical rows and then keeps only the bottom
+    /// of an overflowing modal, so one emitted line MUST be one terminal row
+    /// for the `maxRows` windowing contract to hold. Content is never
+    /// truncated — long labels and descriptions wrap with a hanging indent
+    /// and the window scrolls over physical rows.
+    func render(maxRows: Int, width: Int) -> [String] {
+        // No local floor: lines wider than the host's width would soft-wrap
+        // in the frame and break the one-line-one-row windowing contract.
+        let width = max(1, width)
         // The question is content — wrap it (charged against `maxRows` as
         // chrome) rather than cutting it off.
         var title = "  ? \(prompt.question.question)"
@@ -248,9 +246,12 @@ final class AskModal: Modal {
         if mode == .otherInput {
             let footer = Style.dimmed("  Enter: submit   Esc: back to options")
             let footerLines = ANSI.wrap(footer, width: width)
+            // The zero-width CURSOR_MARKER rides at the caret (end of the
+            // typed text, or before the placeholder) so the hardware cursor
+            // blinks here instead of in the prompt box below the modal.
             let display = buffer.isEmpty
-                ? Style.dimmed("(type your answer)")
-                : Style.prompt(buffer)
+                ? CURSOR_MARKER + Style.dimmed("(type your answer)")
+                : Style.prompt(buffer) + CURSOR_MARKER
             var inputLines = wrapHanging(first: Style.prompt("  ❯ "), content: display, width: width)
             let roomy = maxRows >= titleLines.count + inputLines.count + footerLines.count + 3
             // A very long pasted answer overflows the viewport: keep the

--- a/Sources/KWWKCli/CodingTUI.swift
+++ b/Sources/KWWKCli/CodingTUI.swift
@@ -292,7 +292,11 @@ func runCodingTUIInternal(
         requestRender: { runner.tui.requestRender() },
         // Rows available for the modal above the prompt box. Reserve ~4 for
         // the prompt box + a margin; queried per redraw so it tracks resizes.
-        availableRows: { max(4, runner.terminal.height - 4) }
+        availableRows: { max(4, runner.terminal.height - 4) },
+        // The live zone draws at width − 1 (last column left free so autowrap
+        // never fires); modals must fit the same drawable width — no floor,
+        // or lines would outgrow the frame on very narrow terminals.
+        availableWidth: { runner.terminal.width - 1 }
     )
 
     // Focus target: a thin router in front of the prompt row. While a modal
@@ -636,14 +640,7 @@ func runCodingTUIInternal(
         await withCheckedContinuation { continuation in
             Task { @MainActor in
                 let presentation = AskPresentation(continuation)
-                let askModal = AskModal(
-                    prompt: prompt,
-                    // The live zone renders children one column narrow
-                    // (TUI reserves the last column against pending-wrap);
-                    // wrapping at the full width would get every exactly-full
-                    // row re-wrapped by the frame into a spilled orphan cell.
-                    displayWidth: { max(0, runner.terminal.width - 1) }
-                ) { outcome in
+                let askModal = AskModal(prompt: prompt) { outcome in
                     modal.close()
                     // The cancel teardown below reaches this actor on a Task
                     // hop, so a user confirm can race in after the run was

--- a/Sources/KWWKCli/FormModal.swift
+++ b/Sources/KWWKCli/FormModal.swift
@@ -144,7 +144,7 @@ final class FormModal: Modal {
         return true
     }
 
-    func render(maxRows: Int) -> [String] {
+    func render(maxRows: Int, width: Int) -> [String] {
         // Per-field blank spacers are cosmetic; drop them (with the outer
         // spacer) when the terminal is too short so the render fits maxRows.
         // Chrome: title + footer (+ error block when set — itself dropped on
@@ -153,7 +153,7 @@ final class FormModal: Modal {
         let errorRows = showError ? 2 : 0
         let roomy = maxRows >= 2 + fields.count * 3 + errorRows + 2
         var out: [String] = []
-        out.append(Style.header("  \(title)"))
+        out.append(ANSI.fit(Style.header("  \(title)"), to: width))
         if roomy { out.append("") }
 
         // Window whole field blocks when even the compact layout overflows,
@@ -174,26 +174,35 @@ final class FormModal: Modal {
             if let hint = field.hint, !hint.isEmpty {
                 labelLine += "  " + Style.dimmed(hint)
             }
-            out.append(labelLine)
+            out.append(ANSI.fit(labelLine, to: width))
             let buf = buffers[i]
+            // Input row: `  ❯ ` vs `    ` swaps on focus change; both are 4
+            // visible cols. The value never soft-wraps: a value too wide for
+            // the row shows its TAIL when focused (that's where typing lands;
+            // the caret must stay visible) and is tail-truncated when not.
+            // The focused row carries the zero-width CURSOR_MARKER at the
+            // caret so the hardware cursor blinks in the form, not in the
+            // prompt box below the modal.
+            let prefix = active ? Style.prompt("  ❯ ") : "    "
+            let avail = max(4, width - 4)
             let display: String
             if buf.isEmpty {
                 let placeholder = field.placeholder ?? ""
-                display = Style.dimmed(placeholder.isEmpty ? "(empty)" : placeholder)
+                let dim = Style.dimmed(placeholder.isEmpty ? "(empty)" : placeholder)
+                display = (active ? CURSOR_MARKER : "") + ANSI.fit(dim, to: avail)
+            } else if active {
+                display = Style.prompt(ANSI.fitTail(buf, to: avail)) + CURSOR_MARKER
             } else {
-                display = active ? Style.prompt(buf) : buf
+                display = ANSI.fit(buf, to: avail)
             }
-            // Input row: `  ❯ ` vs `    ` swaps on focus change. Both are
-            // 4 visible cols, so soft-wrap behavior matches across focus.
-            let prefix = active ? Style.prompt("  ❯ ") : "    "
             out.append(prefix + display)
             if roomy { out.append("") }
         }
         if showError, let errorLine {
-            out.append(Style.error(errorLine))
+            out.append(ANSI.fit(Style.error(errorLine), to: width))
             out.append("")
         }
-        out.append(Style.dimmed("  Tab/↑/↓: next field   Enter: submit   Esc: cancel"))
+        out.append(ANSI.fit(Style.dimmed("  Tab/↑/↓: next field   Enter: submit   Esc: cancel"), to: width))
         return out
     }
 

--- a/Sources/KWWKCli/FormModal.swift
+++ b/Sources/KWWKCli/FormModal.swift
@@ -183,8 +183,13 @@ final class FormModal: Modal {
             // The focused row carries the zero-width CURSOR_MARKER at the
             // caret so the hardware cursor blinks in the form, not in the
             // prompt box below the modal.
+            // No floor on the value budget: flooring above the space that
+            // actually remains would compose a row wider than `width`, and
+            // the host's fit backstop would then cut the trailing cursor
+            // marker. On degenerate widths the value shrinks to nothing and
+            // the marker (zero-width, right after the prefix) survives.
             let prefix = active ? Style.prompt("  ❯ ") : "    "
-            let avail = max(4, width - 4)
+            let avail = max(0, width - 4)
             let display: String
             if buf.isEmpty {
                 let placeholder = field.placeholder ?? ""

--- a/Sources/KWWKCli/ListSelectorModal.swift
+++ b/Sources/KWWKCli/ListSelectorModal.swift
@@ -88,7 +88,17 @@ final class ModalListCore {
     /// chrome lines between the title and the list (e.g. a provider tab bar
     /// or a filter line) and are charged against the `maxRows` budget so
     /// windowing never overflows.
-    func render(title: String, headerLines: [String] = [], maxRows: Int) -> [String] {
+    ///
+    /// Every emitted line is fitted to `width` (tail-truncated with `…`) so
+    /// one row is always one terminal row: list entries deliberately never
+    /// soft-wrap — a wrapped row would break the `maxRows` height contract
+    /// and let the terminal push the title/header chrome off-screen.
+    func render(title: String, headerLines: [String] = [], maxRows: Int, width: Int) -> [String] {
+        renderUnfitted(title: title, headerLines: headerLines, maxRows: maxRows)
+            .map { ANSI.fit($0, to: width) }
+    }
+
+    private func renderUnfitted(title: String, headerLines: [String], maxRows: Int) -> [String] {
         // Cosmetic blank spacers (above the list and above the footer) are
         // dropped on short terminals so the render stays within `maxRows` —
         // title + headers + body + footer is the irreducible minimum.
@@ -215,7 +225,7 @@ final class ListSelectorModal: Modal {
 
     func cancel() { onCancel() }
 
-    func render(maxRows: Int) -> [String] {
-        core.render(title: title, maxRows: maxRows)
+    func render(maxRows: Int, width: Int) -> [String] {
+        core.render(title: title, maxRows: maxRows, width: width)
     }
 }

--- a/Sources/KWWKCli/Modal.swift
+++ b/Sources/KWWKCli/Modal.swift
@@ -25,7 +25,11 @@ protocol Modal: AnyObject {
     /// `maxRows` is the height budget (terminal rows available above the
     /// prompt box); modals with long lists must window their content to fit
     /// and keep the selection visible rather than overflow the viewport.
-    func render(maxRows: Int) -> [String]
+    /// `width` is the display width in visible columns: every emitted line
+    /// MUST fit it (truncate or manually wrap). The frame keeps only the
+    /// BOTTOM of an overflowing modal, so a line the terminal would soft-wrap
+    /// breaks the `maxRows` contract and pushes the title off-screen.
+    func render(maxRows: Int, width: Int) -> [String]
 }
 
 extension Modal {
@@ -52,17 +56,22 @@ final class ModalHost {
     /// Height budget (terminal rows available for the modal above the prompt
     /// box), queried fresh on every redraw so windowing tracks resizes.
     private let availableRows: () -> Int
+    /// Display width in visible columns (the live zone's drawable width),
+    /// queried fresh on every redraw so truncation tracks resizes.
+    private let availableWidth: () -> Int
 
     init(
         renderModalLines: @escaping ([String]?) -> Void,
         restoreTranscript: @escaping () -> Void,
         requestRender: @escaping () -> Void,
-        availableRows: @escaping () -> Int = { 24 }
+        availableRows: @escaping () -> Int = { 24 },
+        availableWidth: @escaping () -> Int = { 80 }
     ) {
         self.renderModalLines = renderModalLines
         self.restoreTranscript = restoreTranscript
         self.requestRender = requestRender
         self.availableRows = availableRows
+        self.availableWidth = availableWidth
     }
 
     func open(_ modal: Modal) {
@@ -121,7 +130,16 @@ final class ModalHost {
 
     private func redraw() {
         guard let active else { return }
-        renderModalLines(active.render(maxRows: max(4, availableRows())))
+        // The width handed to the modal must never exceed the drawable width
+        // (no artificial floor): a floor above the real width would defeat
+        // the modal-side truncation on exactly the narrow terminals the
+        // contract exists for. The trailing `fit` is a backstop that enforces
+        // the contract once at the host — a no-op for compliant modals, and
+        // it keeps a stray overlong line from soft-wrapping and pushing the
+        // modal's title off-screen.
+        let width = max(1, availableWidth())
+        let lines = active.render(maxRows: max(4, availableRows()), width: width)
+        renderModalLines(lines.map { ANSI.fit($0, to: width) })
         requestRender()
     }
 }

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -243,8 +243,11 @@ final class ModelSelectorModal: Modal {
     /// hidden neighbors on either side.
     private func tabBarLine(width: Int) -> String? {
         guard tabs.count > 1 else { return nil }
+        // Active tab as a white-on-dark chip so the current provider filter
+        // pops; the chip pads one space each side (+2 columns, mirrored in
+        // `cols` below).
         func paint(_ i: Int) -> String {
-            i == activeTab ? Theme.accentText(tabs[i], bold: true) : Style.dimmed(tabs[i])
+            i == activeTab ? Theme.chipText(tabs[i]) : Style.dimmed(tabs[i])
         }
         let fullBar = "  " + tabs.indices.map(paint).joined(separator: Style.dimmed(" · "))
         let withHint = fullBar + "   " + Style.dimmed("tab / ←→: filter provider")
@@ -258,7 +261,7 @@ final class ModelSelectorModal: Modal {
             var w = 2 // leading indent
             for i in range {
                 if i > range.lowerBound { w += sep.count }
-                w += ANSI.visibleWidth(tabs[i])
+                w += ANSI.visibleWidth(tabs[i]) + (i == activeTab ? 2 : 0)
             }
             // A hidden-neighbor "…" joins like a tab: 1 col + the separator.
             if range.lowerBound > 0 { w += 1 + sep.count }

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -229,7 +229,10 @@ final class ModelSelectorModal: Modal {
             suffix = ""
             budget = width - labelCols
         }
-        let shown = ANSI.fitTail(query, to: max(4, budget))
+        // No floor: a floored budget on a sub-14-column terminal would push
+        // the row past `width` and the host's fit backstop would drop the
+        // cursor marker along with the overflow.
+        let shown = ANSI.fitTail(query, to: max(0, budget))
         return "  " + label + Theme.accentText(shown, bold: true) + CURSOR_MARKER + suffix
     }
 

--- a/Sources/KWWKCli/ModelSelectorModal.swift
+++ b/Sources/KWWKCli/ModelSelectorModal.swift
@@ -191,37 +191,87 @@ final class ModelSelectorModal: Modal {
         return true
     }
 
-    func render(maxRows: Int) -> [String] {
-        var headers = [tabBarLine(), filterLine(maxRows: maxRows)].compactMap { $0 }
+    func render(maxRows: Int, width: Int) -> [String] {
+        var headers = [tabBarLine(width: width), filterLine(width: width)].compactMap { $0 }
         // Irreducible chrome is title + footer + one body row; when the
-        // header lines would push the render past maxRows, drop the tab bar
-        // first — an active filter query must stay visible.
+        // header lines would push the render past maxRows, drop one. With a
+        // typed query the filter line must survive (it shows the query and
+        // hosts the cursor), so the tab bar goes; with no query the filter
+        // line is just a placeholder, and the tab bar — the only indicator
+        // of the active provider filter — is the one worth keeping.
         while headers.count > 1, maxRows < 3 + headers.count {
-            headers.removeFirst()
+            if query.isEmpty { headers.removeLast() } else { headers.removeFirst() }
         }
-        return core.render(title: title, headerLines: headers, maxRows: maxRows)
+        return core.render(title: title, headerLines: headers, maxRows: maxRows, width: width)
     }
 
-    /// One-line filter status: a dim typing hint while the query is empty
-    /// (dropped on short terminals — it's cosmetic), the highlighted query
-    /// with a match count once the user has typed.
-    private func filterLine(maxRows: Int) -> String? {
+    /// One-line filter status. Typed input lands here, so the line always
+    /// renders and carries the zero-width `CURSOR_MARKER` right after the
+    /// query — the TUI parks the hardware cursor on the marker, putting the
+    /// blinking cursor where the typing happens instead of the prompt box.
+    /// While the query is empty the marker sits before a dim placeholder
+    /// hint; a query too long for the row shows its tail (the cursor end).
+    private func filterLine(width: Int) -> String {
+        let label = Style.dimmed("filter: ")
         guard !query.isEmpty else {
-            guard maxRows >= 9 else { return nil }
-            return "  " + Style.dimmed("type to filter by model id")
+            return "  " + label + CURSOR_MARKER + Style.dimmed("type a model id")
         }
-        return "  " + Style.dimmed("filter: ") + Theme.accentText(query, bold: true)
-            + Style.dimmed("   \(visible.count) match\(visible.count == 1 ? "" : "es")   Esc: clear")
+        // The query owns the row: the dim match-count suffix renders only
+        // while the query still gets a comfortable share of the width —
+        // otherwise a truncated suffix fragment would crowd out the very
+        // text the user is typing. An overlong query shows its TAIL (where
+        // the cursor is).
+        let suffixText = "   \(visible.count) match\(visible.count == 1 ? "" : "es")   Esc: clear"
+        let labelCols = ANSI.visibleWidth("  ") + ANSI.visibleWidth(label)
+        var suffix = Style.dimmed(suffixText)
+        var budget = width - labelCols - ANSI.visibleWidth(suffixText)
+        if budget < 16 {
+            suffix = ""
+            budget = width - labelCols
+        }
+        let shown = ANSI.fitTail(query, to: max(4, budget))
+        return "  " + label + Theme.accentText(shown, bold: true) + CURSOR_MARKER + suffix
     }
 
     /// One-line provider tab bar (nil when a single provider makes it noise).
-    /// Selected tab in bold accent, the rest dim, plus a dim key hint.
-    private func tabBarLine() -> String? {
+    /// Selected tab in bold accent, the rest dim, plus a dim key hint. Fitted
+    /// to `width` in stages: full bar + hint → bar without the hint → a
+    /// window of tabs that always contains the active one, with `…` marking
+    /// hidden neighbors on either side.
+    private func tabBarLine(width: Int) -> String? {
         guard tabs.count > 1 else { return nil }
-        let rendered = tabs.enumerated().map { i, label in
-            i == activeTab ? Theme.accentText(label, bold: true) : Style.dimmed(label)
+        func paint(_ i: Int) -> String {
+            i == activeTab ? Theme.accentText(tabs[i], bold: true) : Style.dimmed(tabs[i])
         }
-        return "  " + rendered.joined(separator: Style.dimmed(" · "))
-            + "   " + Style.dimmed("tab / ←→: filter provider")
+        let fullBar = "  " + tabs.indices.map(paint).joined(separator: Style.dimmed(" · "))
+        let withHint = fullBar + "   " + Style.dimmed("tab / ←→: filter provider")
+        if ANSI.visibleWidth(withHint) <= width { return withHint }
+        if ANSI.visibleWidth(fullBar) <= width { return fullBar }
+
+        // Window the tabs around the active one: grow right first (reading
+        // order), then left, stopping when the next tab no longer fits.
+        let sep = " · "
+        func cols(_ range: ClosedRange<Int>) -> Int {
+            var w = 2 // leading indent
+            for i in range {
+                if i > range.lowerBound { w += sep.count }
+                w += ANSI.visibleWidth(tabs[i])
+            }
+            // A hidden-neighbor "…" joins like a tab: 1 col + the separator.
+            if range.lowerBound > 0 { w += 1 + sep.count }
+            if range.upperBound < tabs.count - 1 { w += 1 + sep.count }
+            return w
+        }
+        var lo = activeTab, hi = activeTab
+        while true {
+            if hi + 1 < tabs.count, cols(lo...(hi + 1)) <= width { hi += 1; continue }
+            if lo > 0, cols((lo - 1)...hi) <= width { lo -= 1; continue }
+            break
+        }
+        var parts: [String] = []
+        if lo > 0 { parts.append(Style.dimmed("…")) }
+        parts.append(contentsOf: (lo...hi).map(paint))
+        if hi < tabs.count - 1 { parts.append(Style.dimmed("…")) }
+        return "  " + parts.joined(separator: Style.dimmed(sep))
     }
 }

--- a/Sources/KWWKCli/SessionResumeModal.swift
+++ b/Sources/KWWKCli/SessionResumeModal.swift
@@ -61,7 +61,7 @@ final class SessionResumeModal: Modal {
 
     func cancel() { onCancel() }
 
-    func render(maxRows: Int) -> [String] {
-        core.render(title: "Resume a session", maxRows: maxRows)
+    func render(maxRows: Int, width: Int) -> [String] {
+        core.render(title: "Resume a session", maxRows: maxRows, width: width)
     }
 }

--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -57,6 +57,15 @@ enum Theme {
         }
     }
 
+    /// Selected-chip style: bold near-white text on a dark forest background,
+    /// padded one space each side so the label reads as a solid block (the
+    /// /model provider tab bar's active tab). Adds 2 visible columns.
+    static func chipText(_ s: String) -> String {
+        bg(chipBg) + "\u{1B}[1m" + fg(chipFg) + " " + s + " " + reset
+    }
+    static let chipBg = (r: 34, g: 72, b: 52)     // dark green selected-chip fill
+    static let chipFg = (r: 245, g: 250, b: 246)  // near-white chip label
+
     static func accentText(_ s: String, bold: Bool = true) -> String { paint(s, accent, bold: bold) }
     static func mutedText(_ s: String) -> String { paint(s, muted) }
     static func faintText(_ s: String) -> String { paint(s, faint) }

--- a/Tests/KWWKCliTests/APIKeyFormTests.swift
+++ b/Tests/KWWKCliTests/APIKeyFormTests.swift
@@ -38,9 +38,9 @@ struct APIKeyFormLayoutTests {
     @Test("line count is stable across focus changes")
     func stableLineCount() {
         let f = form()
-        let before = f.render(maxRows: 24).count
+        let before = f.render(maxRows: 24, width: 80).count
         f.down()
-        let after = f.render(maxRows: 24).count
+        let after = f.render(maxRows: 24, width: 80).count
         #expect(before == after, "moving focus must not grow/shrink the frame")
     }
 
@@ -50,9 +50,9 @@ struct APIKeyFormLayoutTests {
         // The "exactly one focused row" invariant is owned by
         // FormModalTests.focusMovement; this test pins layout stability only.
         let f = form()
-        let first = f.render(maxRows: 24)
+        let first = f.render(maxRows: 24, width: 80)
         f.down()
-        let second = f.render(maxRows: 24)
+        let second = f.render(maxRows: 24, width: 80)
         #expect(first.count == second.count, "focus swap must not change the row count")
         let focusedA = first.filter { $0.contains("❯") }
         let focusedB = second.filter { $0.contains("❯") }
@@ -63,9 +63,9 @@ struct APIKeyFormLayoutTests {
     @Test("input rows are width-parallel on focus toggle")
     func widthParallelInputs() {
         let f = form()
-        let a = f.render(maxRows: 24)
+        let a = f.render(maxRows: 24, width: 80)
         f.down()
-        let b = f.render(maxRows: 24)
+        let b = f.render(maxRows: 24, width: 80)
         // Same count — check per-index visible width matches where layout
         // matters most (label + blank rows are text-stable; input rows
         // swap prefixes of equal visible length).

--- a/Tests/KWWKCliTests/AskToolTests.swift
+++ b/Tests/KWWKCliTests/AskToolTests.swift
@@ -96,10 +96,9 @@ private final class OutcomeLog {
 @MainActor
 private func makeModal(
     _ prompt: AskPrompt,
-    width: Int = 80,
     onComplete: @MainActor @escaping (AskOutcome) -> Void
 ) -> AskModal {
-    AskModal(prompt: prompt, displayWidth: { width }, onComplete: onComplete)
+    AskModal(prompt: prompt, onComplete: onComplete)
 }
 
 // MARK: - Argument parsing
@@ -491,7 +490,7 @@ struct AskModalTests {
             multi: false, recommended: 0
         )
         let modal = makeModal(prompt(question), onComplete: log.callback)
-        let lines = modal.render(maxRows: 20)
+        let lines = modal.render(maxRows: 20, width: 80)
         #expect(lines.contains(where: { $0.contains("Which auth?") }))
         #expect(lines.contains(where: { $0.contains("JWT") && $0.contains("(Recommended)") }))
         #expect(lines.contains(where: { $0.contains("↳ Bearer tokens") }))
@@ -514,10 +513,10 @@ struct AskModalTests {
         )
         let width = 60
         let maxRows = 20
-        let modal = makeModal(prompt(question), width: width, onComplete: log.callback)
+        let modal = makeModal(prompt(question), onComplete: log.callback)
 
         for step in 0..<40 {
-            let lines = modal.render(maxRows: maxRows)
+            let lines = modal.render(maxRows: maxRows, width: width)
             #expect(lines.count <= maxRows)
             #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
             // The cursor row must be inside the window at every position.
@@ -536,7 +535,7 @@ struct AskModalTests {
         // a windowed position indicator is shown.
         for _ in 0..<25 { modal.down() } // wrap around and land mid-list again
         modal.down()
-        let deep = modal.render(maxRows: maxRows)
+        let deep = modal.render(maxRows: maxRows, width: width)
         #expect(!deep.contains(where: { $0.contains("选项 01") }))
         #expect(deep.contains(where: { $0.contains("/\(options.count + 2)") }))
     }
@@ -554,10 +553,10 @@ struct AskModalTests {
         )
         let width = 40
         let maxRows = 12
-        let modal = makeModal(prompt(question), width: width, onComplete: log.callback)
+        let modal = makeModal(prompt(question), onComplete: log.callback)
 
         modal.down() // onto Huge
-        let lines = modal.render(maxRows: maxRows)
+        let lines = modal.render(maxRows: maxRows, width: width)
         #expect(lines.count <= maxRows)
         #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
         #expect(lines.contains(where: { $0.contains("Huge") }))
@@ -565,13 +564,13 @@ struct AskModalTests {
 
         // The rest of the list stays reachable past the clamped monster.
         modal.down() // Other row
-        let after = modal.render(maxRows: maxRows)
+        let after = modal.render(maxRows: maxRows, width: width)
         #expect(after.contains(where: { $0.contains(Ask.otherOptionLabel) && $0.contains("❯") }))
 
         // A normal multi-row entry below the window threshold is NOT clamped.
         modal.up() // Huge
         modal.up() // Small
-        let back = modal.render(maxRows: maxRows)
+        let back = modal.render(maxRows: maxRows, width: width)
         let plain = back.map { ANSI.stripEscapes($0) }.joined()
         #expect(plain.contains("short"))
     }
@@ -579,11 +578,11 @@ struct AskModalTests {
     @Test("other-input wraps an overlong buffer and keeps the tail visible")
     func otherInputLongBuffer() {
         let log = OutcomeLog()
-        let modal = makeModal(prompt(singleQuestion()), width: 40, onComplete: log.callback)
+        let modal = makeModal(prompt(singleQuestion()), onComplete: log.callback)
         modal.up()
         modal.confirm()
         _ = modal.handleText(String(repeating: "a", count: 60) + "TAIL")
-        let lines = modal.render(maxRows: 10)
+        let lines = modal.render(maxRows: 10, width: 40)
         #expect(lines.count <= 10)
         #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= 40 })
         // Wrapped, not truncated: the full buffer reassembles from the rows.
@@ -598,7 +597,7 @@ struct AskModalTests {
         modal.up()
         modal.confirm()
         _ = modal.handleText("custom")
-        let lines = modal.render(maxRows: 10)
+        let lines = modal.render(maxRows: 10, width: 80)
         #expect(lines.contains(where: { $0.contains("custom") }))
         #expect(lines.contains(where: { $0.contains("Enter: submit") }))
     }

--- a/Tests/KWWKCliTests/FormModalTests.swift
+++ b/Tests/KWWKCliTests/FormModalTests.swift
@@ -66,10 +66,10 @@ struct FormModalTests {
         let modal = makeModal(onSubmit: { submitted.value = $0 })
         modal.confirm()
         #expect(submitted.value == nil)
-        #expect(modal.render(maxRows: 24).contains(where: { $0.contains("API key is required") }))
+        #expect(modal.render(maxRows: 24, width: 80).contains(where: { $0.contains("API key is required") }))
         // Typing clears the inline error.
         _ = modal.handleText("s")
-        #expect(!modal.render(maxRows: 24).contains(where: { $0.contains("is required") }))
+        #expect(!modal.render(maxRows: 24, width: 80).contains(where: { $0.contains("is required") }))
     }
 
     @MainActor
@@ -103,7 +103,7 @@ struct FormModalTests {
     func focusMovement() {
         let modal = makeModal()
         func focusedRows() -> Int {
-            modal.render(maxRows: 24).filter { $0.contains("❯") }.count
+            modal.render(maxRows: 24, width: 80).filter { $0.contains("❯") }.count
         }
         #expect(focusedRows() == 1)
         modal.down()
@@ -127,7 +127,7 @@ struct FormModalTests {
         let modal = FormModal(title: "t", fields: fields, onSubmit: { _ in }, onCancel: {})
         for maxRows in [4, 6, 9, 12, 40] {
             for _ in 0..<8 {
-                let lines = modal.render(maxRows: maxRows)
+                let lines = modal.render(maxRows: maxRows, width: 80)
                 #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows)")
                 #expect(lines.contains(where: { $0.contains("❯") }),
                         "focused field must stay visible at maxRows \(maxRows)")
@@ -162,7 +162,7 @@ struct ModalHostRoutingTests {
             texts.append(data)
             return true
         }
-        func render(maxRows: Int) -> [String] { ["stub"] }
+        func render(maxRows: Int, width: Int) -> [String] { ["stub"] }
     }
 
     @MainActor
@@ -267,7 +267,7 @@ struct ModalHostRoutingTests {
         func down() {}
         func confirm() { host?.close() }
         func cancel() {}
-        func render(maxRows: Int) -> [String] { ["closing"] }
+        func render(maxRows: Int, width: Int) -> [String] { ["closing"] }
     }
 
     @MainActor

--- a/Tests/KWWKCliTests/ModalInputRouterTests.swift
+++ b/Tests/KWWKCliTests/ModalInputRouterTests.swift
@@ -26,7 +26,7 @@ private final class RecordingModal: Modal {
         texts.append(data)
         return consumesText
     }
-    func render(maxRows: Int) -> [String] { ["stub modal"] }
+    func render(maxRows: Int, width: Int) -> [String] { ["stub modal"] }
 }
 
 /// Direct coverage of the router the coding TUI installs in front of the

--- a/Tests/KWWKCliTests/ModalWidthCursorTests.swift
+++ b/Tests/KWWKCliTests/ModalWidthCursorTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+@testable import KWWKAI
+@testable import KWWKCli
+
+@MainActor
+private func model(_ id: String, name: String? = nil, provider: String = "anthropic") -> Model {
+    Model(
+        id: id,
+        name: name ?? id,
+        api: "anthropic-messages",
+        provider: provider,
+        baseURL: "https://api.anthropic.com",
+        reasoning: false,
+        input: [.text],
+        contextWindow: 0,
+        maxTokens: 0
+    )
+}
+
+/// Width-contract + hardware-cursor coverage for the modal system.
+///
+/// The frame keeps only the BOTTOM of a modal that overflows its height
+/// budget, so any emitted line wider than the terminal (which the terminal
+/// would soft-wrap into extra physical rows) silently pushes the title off
+/// screen. Every modal must therefore emit lines that fit `width`.
+///
+/// Text-input surfaces (the /model filter, ask's "Other" input, form fields)
+/// must carry the zero-width `CURSOR_MARKER` so the TUI parks the hardware
+/// cursor at the modal's caret instead of the prompt box below it.
+@MainActor
+@Suite("Modal width contract + cursor markers")
+struct ModalWidthCursorTests {
+
+    /// The /model regression: long ids + long display names on a narrow
+    /// terminal. One entry must stay one row (tail-truncated with `…`), and
+    /// the whole render must respect both budgets so the title/tab bar/filter
+    /// chrome is never pushed out.
+    @Test("model selector rows never exceed the width, so maxRows holds")
+    func modelSelectorWidthContract() {
+        let models = (1...40).map { i in
+            model(
+                "claude-fable-5-thinking-extra-high-\(String(format: "%02d", i))",
+                name: "Fable 5 1M Extra High Thinking (NO ZDR) variant \(i)",
+                provider: i % 2 == 0 ? "cursor" : "anthropic (claude pro/max)"
+            )
+        }
+        let modal = ModelSelectorModal(
+            title: "Select a model",
+            models: models,
+            currentModelId: models[0].id,
+            groupLabels: models.map(\.provider),
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        let width = 60
+        let maxRows = 18
+        for step in 0..<45 {
+            let lines = modal.render(maxRows: maxRows, width: width)
+            #expect(lines.count <= maxRows, "overflowed maxRows at step \(step)")
+            #expect(
+                lines.allSatisfy { ANSI.visibleWidth($0) <= width },
+                "line wider than terminal at step \(step)"
+            )
+            // The title must survive scrolling — it is exactly what the
+            // suffix-clipping bug used to eat.
+            #expect(lines.contains(where: { $0.contains("Select a model") }))
+            modal.down()
+        }
+    }
+
+    @Test("model selector filter line carries the cursor marker at the caret")
+    func modelSelectorFilterCursor() {
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: [model("alpha"), model("beta")],
+            currentModelId: "alpha",
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        // Empty query: marker sits before the placeholder hint.
+        let idle = modal.render(maxRows: 20, width: 80)
+        #expect(idle.contains(where: { $0.contains(CURSOR_MARKER) }))
+
+        _ = modal.handleText("alp")
+        let typing = modal.render(maxRows: 20, width: 80)
+        let filterRow = typing.first(where: { $0.contains(CURSOR_MARKER) })
+        #expect(filterRow != nil)
+        // Marker directly after the typed query.
+        #expect(ANSI.stripEscapes(filterRow ?? "").contains("alp"))
+    }
+
+    @Test("overlong filter query shows its tail and keeps the marker visible")
+    func modelSelectorLongQueryTail() {
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: [model("alpha")],
+            currentModelId: "alpha",
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        _ = modal.handleText(String(repeating: "x", count: 100) + "TAIL")
+        let width = 50
+        let lines = modal.render(maxRows: 20, width: width)
+        #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+        let filterRow = lines.first(where: { $0.contains(CURSOR_MARKER) })
+        #expect(filterRow != nil)
+        #expect(ANSI.stripEscapes(filterRow ?? "").contains("TAIL"))
+    }
+
+    @Test("provider tab bar is windowed to the width and keeps the active tab")
+    func modelSelectorTabBarFits() {
+        let providers = [
+            "ChatGPT Codex", "Anthropic (Claude Pro/Max)", "Cursor",
+            "Kimi For Coding", "Z.AI Coding Plan",
+        ]
+        let models = providers.enumerated().map { i, p in
+            model("m\(i)", provider: p)
+        }
+        let modal = ModelSelectorModal(
+            title: "t",
+            models: models,
+            currentModelId: "m0",
+            groupLabels: providers,
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        let width = 44
+        for _ in 0..<providers.count + 1 {
+            modal.tab()
+            let lines = modal.render(maxRows: 20, width: width)
+            #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+        }
+        // Whatever tab is active must always be visible in the fitted bar.
+        var sawLastTab = false
+        for _ in 0...providers.count {
+            let lines = modal.render(maxRows: 20, width: width).map(ANSI.stripEscapes)
+            if lines.contains(where: { $0.contains("Z.AI Coding Plan") }) { sawLastTab = true }
+            modal.tab()
+        }
+        #expect(sawLastTab, "active tab scrolled out of the fitted tab bar")
+    }
+
+    @Test("list selector + session-style rows are tail-truncated, not wrapped")
+    func listSelectorWidthContract() {
+        let items = (1...20).map { i in
+            ListSelectorModal.Item(
+                label: "provider-with-a-very-long-name-number-\(i)",
+                detail: "an extremely long detail string that would surely wrap on a narrow terminal"
+            )
+        }
+        let modal = ListSelectorModal(title: "Pick", items: items, onSelect: { _ in }, onCancel: {})
+        let width = 40
+        let maxRows = 10
+        let lines = modal.render(maxRows: maxRows, width: width)
+        #expect(lines.count <= maxRows)
+        #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+        #expect(lines.contains(where: { $0.contains("Pick") }))
+    }
+
+    @Test("form modal focused field carries the cursor marker")
+    func formModalCursorMarker() {
+        let modal = FormModal(
+            title: "Log in",
+            fields: [
+                APIKeyFormField(key: "apiKey", label: "API key", placeholder: "sk-…"),
+                APIKeyFormField(key: "baseURL", label: "Base URL", required: false),
+            ],
+            onSubmit: { _ in },
+            onCancel: {}
+        )
+        // Placeholder state: marker on the focused (first) input row.
+        let idle = modal.render(maxRows: 24, width: 80)
+        #expect(idle.filter { $0.contains(CURSOR_MARKER) }.count == 1)
+
+        _ = modal.handleText("secret")
+        let typed = modal.render(maxRows: 24, width: 80)
+        let row = typed.first(where: { $0.contains(CURSOR_MARKER) })
+        #expect(ANSI.stripEscapes(row ?? "").contains("secret"))
+
+        // Focus moves → so does the marker.
+        modal.tab()
+        let second = modal.render(maxRows: 24, width: 80)
+        let secondRow = second.first(where: { $0.contains(CURSOR_MARKER) })
+        #expect(!(ANSI.stripEscapes(secondRow ?? "").contains("secret")))
+    }
+
+    @Test("form modal shows the tail of an overlong value with the cursor")
+    func formModalLongValueTail() {
+        let modal = FormModal(
+            title: "Log in",
+            fields: [APIKeyFormField(key: "apiKey", label: "API key")],
+            onSubmit: { _ in },
+            onCancel: {}
+        )
+        _ = modal.handleText(String(repeating: "k", count: 120) + "TAIL")
+        let width = 50
+        let lines = modal.render(maxRows: 24, width: width)
+        #expect(lines.allSatisfy { ANSI.visibleWidth($0) <= width })
+        let row = lines.first(where: { $0.contains(CURSOR_MARKER) })
+        let plain = ANSI.stripEscapes(row ?? "")
+        #expect(plain.contains("TAIL"))
+        #expect(plain.contains("…"))
+    }
+
+    @Test("fitTail keeps the tail within the width, wide-char aware")
+    func fitTailBasics() {
+        #expect(ANSI.fitTail("short", to: 10) == "short")
+        #expect(ANSI.fitTail("abcdefghij", to: 5) == "…ghij")
+        // CJK: each char is 2 columns; the "…" costs 1.
+        let cjk = ANSI.fitTail("一二三四五六", to: 5)
+        #expect(cjk == "…五六")
+        #expect(ANSI.visibleWidth(cjk) <= 5)
+        #expect(ANSI.fitTail("anything", to: 0) == "")
+    }
+
+    @Test("ask other-input carries the cursor marker at the buffer end")
+    func askOtherInputCursorMarker() {
+        let question = AskQuestion(
+            id: "q", question: "Q?",
+            options: [AskOption(label: "A", description: nil)],
+            multi: false, recommended: nil
+        )
+        let prompt = AskPrompt(
+            question: question, progressText: nil,
+            allowBack: false, allowForward: false,
+            previousSelection: [], previousCustomInput: nil
+        )
+        let modal = AskModal(prompt: prompt) { _ in }
+        modal.up() // onto "Other"
+        modal.confirm()
+
+        // Placeholder state.
+        let idle = modal.render(maxRows: 12, width: 60)
+        #expect(idle.contains(where: { $0.contains(CURSOR_MARKER) }))
+
+        _ = modal.handleText("my answer")
+        let typed = modal.render(maxRows: 12, width: 60)
+        let row = typed.first(where: { $0.contains(CURSOR_MARKER) })
+        #expect(ANSI.stripEscapes(row ?? "").contains("my answer"))
+
+        // List mode never claims the cursor — typing falls through to the
+        // prompt box there, and the marker must follow the actual target.
+        modal.cancel() // back to list
+        let list = modal.render(maxRows: 12, width: 60)
+        #expect(!list.contains(where: { $0.contains(CURSOR_MARKER) }))
+    }
+}

--- a/Tests/KWWKCliTests/ModalWidthCursorTests.swift
+++ b/Tests/KWWKCliTests/ModalWidthCursorTests.swift
@@ -203,6 +203,46 @@ struct ModalWidthCursorTests {
         #expect(plain.contains("…"))
     }
 
+    @Test("degenerate widths never compose rows wider than the budget")
+    func degenerateWidthsKeepMarker() {
+        // Input rows are prefix (4 cols) + value; a floored value budget used
+        // to overflow `width` below ~8 columns, and the host's fit backstop
+        // then cut the trailing cursor marker. Rows must fit as long as the
+        // prefix itself fits, keeping the marker alive.
+        let form = FormModal(
+            title: "t",
+            fields: [APIKeyFormField(key: "k", label: "Key")],
+            onSubmit: { _ in },
+            onCancel: {}
+        )
+        _ = form.handleText("supercalifragilistic")
+        let selector = ModelSelectorModal(
+            title: "t",
+            models: [model("alpha"), model("beta")],
+            currentModelId: "alpha",
+            onSelect: { _ in },
+            onCancel: {}
+        )
+        _ = selector.handleText("alphabetically-long-query")
+        // Each surface is checked from the width its fixed prefix needs
+        // (4-col form prefix; 10-col "  filter: " label) — below that even
+        // the chrome cannot fit and the host backstop takes over.
+        func assertMarkerRowsFit(_ lines: [String], width: Int) {
+            for line in lines where line.contains(CURSOR_MARKER) {
+                #expect(
+                    ANSI.visibleWidth(line) <= width,
+                    "marker row wider than width \(width): \(ANSI.stripEscapes(line))"
+                )
+            }
+        }
+        for width in 4...14 {
+            assertMarkerRowsFit(form.render(maxRows: 24, width: width), width: width)
+        }
+        for width in 10...14 {
+            assertMarkerRowsFit(selector.render(maxRows: 24, width: width), width: width)
+        }
+    }
+
     @Test("fitTail keeps the tail within the width, wide-char aware")
     func fitTailBasics() {
         #expect(ANSI.fitTail("short", to: 10) == "short")

--- a/Tests/KWWKCliTests/ModelSelectorModalTests.swift
+++ b/Tests/KWWKCliTests/ModelSelectorModalTests.swift
@@ -95,7 +95,7 @@ struct ModelSelectorModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        let lines = modal.render(maxRows: 40).map(strip)
+        let lines = modal.render(maxRows: 40, width: 80).map(strip)
         // Current (`b`) should get the pre-selection + "· current" tag.
         // Match the row body ("b  b" = id + name detail) so chrome lines
         // that merely contain the letter b (e.g. the filter hint) don't win.
@@ -126,7 +126,7 @@ struct ModelSelectorModalTests {
             // 50 downs on a 50-item list wraps back to selection 0, so each
             // outer iteration starts from the top.
             for step in 0..<50 {
-                let lines = modal.render(maxRows: maxRows).map(strip)
+                let lines = modal.render(maxRows: maxRows, width: 80).map(strip)
                 #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows), selection \(step)")
                 #expect(lines.contains(where: { $0.contains("❯ m\(step)  ") }),
                         "selected row m\(step) must be within the window at maxRows \(maxRows)")
@@ -134,7 +134,7 @@ struct ModelSelectorModalTests {
             }
         }
         // Position indicator shows while windowed.
-        #expect(modal.render(maxRows: 12).contains(where: { $0.contains("/50") }))
+        #expect(modal.render(maxRows: 12, width: 80).contains(where: { $0.contains("/50") }))
     }
 
     // MARK: - Provider tab bar
@@ -169,7 +169,7 @@ struct ModelSelectorModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        func body() -> [String] { modal.render(maxRows: 40).map(strip) }
+        func body() -> [String] { modal.render(maxRows: 40, width: 80).map(strip) }
 
         // "All" tab: every row + the tab bar with the filter hint.
         var lines = body()
@@ -238,12 +238,12 @@ struct ModelSelectorModalTests {
             groupLabels: ["Anthropic", "Anthropic"],
             onSelect: { _ in }, onCancel: {}
         )
-        #expect(!plain.render(maxRows: 40).contains(where: { $0.contains("filter provider") }))
-        #expect(!grouped.render(maxRows: 40).contains(where: { $0.contains("filter provider") }))
+        #expect(!plain.render(maxRows: 40, width: 80).contains(where: { $0.contains("filter provider") }))
+        #expect(!grouped.render(maxRows: 40, width: 80).contains(where: { $0.contains("filter provider") }))
         // A single-label grouping still renders its group header, as today —
         // but tab/left/right are no-ops.
         grouped.tab(); grouped.left(); grouped.right()
-        #expect(grouped.render(maxRows: 40).map(strip)
+        #expect(grouped.render(maxRows: 40, width: 80).map(strip)
             .contains(where: { $0.contains("── Anthropic ──") }))
     }
 
@@ -292,7 +292,7 @@ struct ModelSelectorModalTests {
         )
         for maxRows in [4, 6, 9, 12, 40] {
             for _ in 0..<60 {
-                let lines = modal.render(maxRows: maxRows)
+                let lines = modal.render(maxRows: maxRows, width: 80)
                 #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows)")
                 modal.down()
             }
@@ -314,7 +314,7 @@ struct ModelSelectorModalTests {
             onCancel: {}
         )
         #expect(modal.handleText("SON") == true)
-        let lines = modal.render(maxRows: 40).map(strip)
+        let lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("sonnet-4") }))
         #expect(!lines.contains(where: { $0.contains("opus-4") }))
         #expect(lines.contains(where: { $0.contains("filter: SON") }))
@@ -335,7 +335,7 @@ struct ModelSelectorModalTests {
             onCancel: {}
         )
         _ = modal.handleText("zzz")
-        var lines = modal.render(maxRows: 40).map(strip)
+        var lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("no models match \"zzz\"") }))
         modal.confirm()
         #expect(picked.value == nil)
@@ -344,7 +344,7 @@ struct ModelSelectorModalTests {
         _ = modal.handleText("\u{7F}")
         _ = modal.handleText("\u{7F}")
         _ = modal.handleText("\u{7F}")
-        lines = modal.render(maxRows: 40).map(strip)
+        lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("opus-4") }))
         #expect(lines.contains(where: { $0.contains("sonnet-4") }))
     }
@@ -363,7 +363,7 @@ struct ModelSelectorModalTests {
         _ = modal.handleText("opus")
         modal.cancel()
         #expect(cancelled.value == false)
-        let lines = modal.render(maxRows: 40).map(strip)
+        let lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("sonnet-4") })) // filter cleared
         modal.cancel()
         #expect(cancelled.value == true)
@@ -384,12 +384,12 @@ struct ModelSelectorModalTests {
         )
         _ = modal.handleText("sonnet")
         modal.tab() // → Anthropic
-        var lines = modal.render(maxRows: 40).map(strip)
+        var lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("sonnet-4") }))
         #expect(!lines.contains(where: { $0.contains("opus-4") }))
         #expect(lines.filter { $0.contains("sonnet-4") }.count == 1)
         modal.tab() // → OpenAI: its own sonnet-4 copy
-        lines = modal.render(maxRows: 40).map(strip)
+        lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("sonnet-4") }))
         #expect(!lines.contains(where: { $0.contains("gpt-5") }))
     }
@@ -407,7 +407,7 @@ struct ModelSelectorModalTests {
         )
         #expect(modal.handleText("\u{1B}[200~son\u{1B}[201~") == true)
         #expect(modal.handleText("\u{1B}[1;5C") == true) // swallowed, not typed
-        let lines = modal.render(maxRows: 40).map(strip)
+        let lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("filter: son") }))
         #expect(lines.contains(where: { $0.contains("sonnet-4") }))
         #expect(!lines.contains(where: { $0.contains("opus-4") }))
@@ -428,7 +428,7 @@ struct ModelSelectorModalTests {
         // Safe to call navigation/confirm on an empty list.
         modal.up(); modal.down(); modal.confirm()
         #expect(picked.value == nil)
-        let lines = modal.render(maxRows: 40)
+        let lines = modal.render(maxRows: 40, width: 80)
         #expect(lines.contains(where: { $0.contains("no models") }))
     }
 }

--- a/Tests/KWWKCliTests/SessionResumeModalTests.swift
+++ b/Tests/KWWKCliTests/SessionResumeModalTests.swift
@@ -96,7 +96,7 @@ struct SessionResumeModalTests {
             onSelect: { _ in },
             onCancel: {}
         )
-        let lines = modal.render(maxRows: 40).map(strip)
+        let lines = modal.render(maxRows: 40, width: 80).map(strip)
         #expect(lines.contains(where: { $0.contains("Resume a session") }))
         let first = lines.first(where: { $0.contains("myproj") })
         #expect(first?.contains("1 msg") == true)
@@ -120,7 +120,7 @@ struct SessionResumeModalTests {
         // confirm on an empty list must not fire the callback.
         modal.confirm()
         for maxRows in 4...40 {
-            let lines = modal.render(maxRows: maxRows)
+            let lines = modal.render(maxRows: maxRows, width: 80)
             #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows)")
             #expect(lines.contains(where: { strip($0).contains("no saved sessions") }))
         }
@@ -141,7 +141,7 @@ struct SessionResumeModalTests {
         // visible — the pre-ModalListCore implementation overflowed by one.
         for maxRows in 4...40 {
             for step in 0..<50 {
-                let lines = modal.render(maxRows: maxRows).map(strip)
+                let lines = modal.render(maxRows: maxRows, width: 80).map(strip)
                 #expect(lines.count <= maxRows, "overflow at maxRows \(maxRows), selection \(step)")
                 #expect(lines.contains(where: { $0.contains("❯ s\(step)  ") }),
                         "selected row s\(step) must be within the window at maxRows \(maxRows)")


### PR DESCRIPTION
## Problem

Two modal issues, both reproduced in tmux at 60×24 / 40×16:

1. **Soft-wrapped rows push the title off-screen.** `Modal.render(maxRows:)` had no idea how wide the terminal is; `CodingFrame` wraps overlong modal lines into extra physical rows and keeps only the **bottom** of an overflowing modal. In `/model`, long entries (e.g. the Cursor catalog's `claude-fable-5-thinking-medium  Fable 5 1M Medium Thinking (NO ZDR)`) wrapped and silently ate the title, tab bar, and even the active filter query.
2. **Hardware cursor stayed in the prompt box while typing into a modal.** The TUI parks the cursor on the first zero-width `CURSOR_MARKER` in the frame, and no modal ever emitted one — so typing into the `/model` filter, `ask`'s "type your answer", or the `/login` form left the blinking cursor in the bottom input box.

## Fix

- `Modal.render(maxRows:width:)`: every modal now fits its own lines to the drawable width. `ModalListCore` (shared by `/model`, `/login`, `/resume`) tail-truncates with `…` so one entry is always exactly one terminal row; `AskModal` keeps its manual wrapping (content is never cut) minus a width floor that disagreed with the host.
- `ModalHost` passes the frame's exact drawable width (`terminal.width − 1`, no artificial floor) and re-fits the returned lines as a backstop, so a future non-compliant modal can't reintroduce the clipping bug.
- `/model`'s provider tab bar windows around the active tab with `…` for hidden neighbors; the filter line always renders and gives the typed query priority over the match-count suffix.
- Text-input surfaces (filter line, ask "Other" input, form fields) embed `CURSOR_MARKER` at the caret — modal lines precede the prompt box in the frame, so the hardware cursor lands in the modal. Overlong input tail-scrolls via a new shared one-pass `ANSI.fitTail` (wide-char aware).

## Verification

- tmux: 60-col `/model` deep-scroll keeps title/tab bar/filter pinned; cursor follows the filter query and form fields; long form values tail-scroll (`…aaaa…TAIL`); 40×16 stress-test clean.
- 1297 tests pass (13 new: width contract per modal, cursor markers, `fitTail` edges).
- Self-review (5 parallel finder agents) surfaced 6 issues — all fixed in this PR, notably a width-floor mismatch that would have re-broken 21–24-col terminals and an O(n²) tail-scroll on paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all modal rendering and terminal layout contracts on narrow viewports; regressions would show as clipped titles, wrong cursor placement, or broken list scrolling, but changes are localized to TUI presentation with substantial new test coverage.
> 
> **Overview**
> Fixes narrow-terminal modal layout and moves the blinking caret into modals while typing.
> 
> **Width contract:** `Modal.render` now takes **`width`** alongside **`maxRows`**. **`ModalHost`** supplies the live drawable width (`terminal.width − 1`, no minimum) and applies **`ANSI.fit`** as a backstop so each line is one physical row—avoiding frame soft-wrap that used to push titles and chrome off-screen. List modals tail-truncate with **`…`**; **`AskModal`** still soft-wraps content but drops its old per-modal width callback and minimum width floor.
> 
> **New helpers:** **`ANSI.fit`** (truncate + ellipsis) and **`ANSI.fitTail`** (show tail of long plain text for scrolled inputs).
> 
> **In-modal cursor:** Form fields, **`/model`** filter line, and ask “Other” input embed **`CURSOR_MARKER`** at the caret; focused form values use **`fitTail`** so the caret stays visible. **`/model`** gets a width-aware provider tab bar (chip style via **`Theme.chipText`**, windowed with **`…`**) and smarter header dropping when height is tight.
> 
> Tests updated for the new **`render(..., width:)`** signature; **`ModalWidthCursorTests`** adds width/cursor coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921bbe454dbbd599d7636e910496c4d4bdee9f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->