### PR TITLE
Add Homebrew bottle release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,24 @@ on:
 
 jobs:
   build-macos:
-    # macos-15 = oldest supported toolchain; macos-26 tracks the newest Swift,
-    # which is what `brew install` users compile the release tarball with.
-    # Newer compilers enforce stricter concurrency checking, so green on the
-    # newest image is what guarantees source builds don't break on user machines.
+    # macos-15 covers the oldest supported toolchain on both Apple Silicon and
+    # Intel; macos-26 tracks the newest Swift. Normal Homebrew installs use a
+    # prebuilt package, but this matrix keeps each bottle architecture plus
+    # source/HEAD installs and SwiftPM consumers buildable.
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-26]
+        os: [macos-15, macos-15-intel, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+      - name: Select Swift 6.1 toolchain
+        if: startsWith(matrix.os, 'macos-15')
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: swift build
         run: swift build --product kwwk
+      - name: bundled resource self-test
+        run: .build/debug/kwwk --self-test
       - name: swift test
         run: swift test
 
@@ -36,5 +41,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: swift build
         run: swift build --product kwwk
+      - name: bundled resource self-test
+        run: .build/debug/kwwk --self-test
       - name: swift test
         run: swift test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,35 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  # Verify the tag builds on BOTH toolchain extremes before anything is
-  # published: macos-26 tracks the newest Swift (what `brew install` users
-  # compile with — strictest concurrency checking), macos-15 guards the old
-  # floor. The release job below only runs if both pass, so a tag that fails
-  # either never reaches the tap.
+  # Verify the tag across both macOS architectures and both toolchain extremes
+  # before publishing: macos-15 covers Apple Silicon and Intel at the old floor,
+  # while macos-26 supplies the newest Swift concurrency checking. Homebrew
+  # normally installs a prebuilt package, but source/HEAD installs and SwiftPM
+  # consumers still need every tagged release to compile across this range.
   verify:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-26]
+        os: [macos-15, macos-15-intel, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+      - name: Select Swift 6.1 toolchain
+        if: startsWith(matrix.os, 'macos-15')
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Verify release build
         run: swift build -c release --product kwwk
+      - name: Verify bundled resources
+        run: .build/release/kwwk --self-test
 
   release:
     needs: verify
     runs-on: macos-15
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
@@ -50,26 +57,113 @@ jobs:
           gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
             || gh release create "${GITHUB_REF_NAME}" --generate-notes
 
-      - name: Update homebrew-tap formula
+      - name: Open or update homebrew-tap bump PR
         env:
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAG:    ${{ steps.hash.outputs.tag }}
-          URL:    ${{ steps.hash.outputs.url }}
-          SHA256: ${{ steps.hash.outputs.sha256 }}
+          GH_TOKEN:       ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPOSITORY: EYHN/homebrew-tap
+          TAG:            ${{ steps.hash.outputs.tag }}
+          URL:            ${{ steps.hash.outputs.url }}
+          SHA256:         ${{ steps.hash.outputs.sha256 }}
         run: |
           set -euo pipefail
-          git clone "https://x-access-token:${TAP_TOKEN}@github.com/EYHN/homebrew-tap.git" tap
+          branch="automation/kwwk-${TAG}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPOSITORY}.git" tap
           cd tap
-          # Stable anchors: `url "<...>"` and `sha256 "<...>"` — one occurrence each.
-          sed -i '' -E \
-            -e "s|(url \")[^\"]*(\")|\\1${URL}\\2|" \
-            -e "s|(sha256 \")[^\"]*(\")|\\1${SHA256}\\2|" \
-            Formula/kwwk.rb
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet; then
-            echo "formula already matches ${TAG} — nothing to push"
+
+          remote_branch=""
+          if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+            remote_branch="$(git rev-parse "origin/${branch}")"
+          fi
+          git switch --create "${branch}" origin/main
+
+          # Only replace the formula's top-level source archive fields. A new
+          # source version must drop the previous version's bottle block;
+          # `brew pr-pull` writes the new checksums after all builders pass.
+          ruby <<'RUBY'
+          require "rubygems"
+
+          path = "Formula/kwwk.rb"
+          formula = File.read(path)
+          url_pattern = /^  url "[^"]*"$/
+          sha_pattern = /^  sha256 "[^"]*"$/
+          bottle_pattern = /\n  bottle do\n.*?^  end\n/m
+
+          abort "expected exactly one top-level source url" unless formula.scan(url_pattern).one?
+          abort "expected exactly one top-level source sha256" unless formula.scan(sha_pattern).one?
+
+          target_url = %(  url "#{ENV.fetch("URL")}")
+          target_sha = %(  sha256 "#{ENV.fetch("SHA256")}")
+          current_url = formula.match(url_pattern)&.to_s
+          current_sha = formula.match(sha_pattern)&.to_s
+          source_changed = current_url != target_url || current_sha != target_sha
+
+          current_tag = current_url&.match(%r{/archive/refs/tags/([^/]+)\.tar\.gz"$})&.[](1)
+          target_tag = ENV.fetch("TAG")
+          abort "cannot determine the current formula tag" unless current_tag
+
+          begin
+            current_version = Gem::Version.new(current_tag.delete_prefix("v"))
+            target_version = Gem::Version.new(target_tag.delete_prefix("v"))
+          rescue ArgumentError => error
+            abort "cannot compare formula versions: #{error.message}"
+          end
+          if target_version < current_version
+            abort "refusing to downgrade kwwk from #{current_tag} to #{target_tag}"
+          end
+
+          if source_changed
+            formula.sub!(url_pattern, target_url)
+            formula.sub!(sha_pattern, target_sha)
+            bottle_blocks = formula.scan(bottle_pattern)
+            abort "expected at most one bottle block" if bottle_blocks.length > 1
+            formula.sub!(bottle_pattern, "") if bottle_blocks.one?
+          end
+          File.write(path, formula)
+          RUBY
+
+          if git diff --quiet -- Formula/kwwk.rb; then
+            echo "tap main already matches ${TAG} — no PR needed"
+            exit 0
+          fi
+
+          if [[ -n "${remote_branch}" ]] && git diff --quiet "origin/${branch}" -- .; then
+            echo "remote bump branch already matches ${TAG}"
           else
-            git commit -am "kwwk: bump to ${TAG}"
-            git push origin main
+            git add Formula/kwwk.rb
+            git commit -m "kwwk: bump to ${TAG}"
+            if [[ -n "${remote_branch}" ]]; then
+              git push \
+                --force-with-lease="refs/heads/${branch}:${remote_branch}" \
+                origin "HEAD:refs/heads/${branch}"
+            else
+              git push --set-upstream origin "${branch}"
+            fi
+          fi
+
+          title="kwwk: bump to ${TAG}"
+          body="$(printf 'Automated source release bump for %s.\n\nSource: %s\nSHA-256: %s\n' \
+            "${TAG}" "${URL}" "${SHA256}")"
+          pr_number="$(gh pr list \
+            --repo "${TAP_REPOSITORY}" \
+            --head "${branch}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${pr_number}" ]]; then
+            gh api \
+              --method PATCH \
+              "repos/${TAP_REPOSITORY}/pulls/${pr_number}" \
+              -f title="${title}" \
+              -f body="${body}" >/dev/null
+            echo "updated tap PR #${pr_number}"
+          else
+            gh pr create \
+              --repo "${TAP_REPOSITORY}" \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}"
           fi

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ A Swift-native coding agent with two faces:
 
 ## Requirements
 
-- macOS 14+
-- Swift 6.1 toolchain (Xcode 16.3+ or the matching `swift` toolchain)
+- macOS 14+ runtime; Homebrew release bottles target macOS 15+ on Apple
+  Silicon and Intel.
+- A bottled Homebrew install has no Swift or Xcode runtime dependency.
+- Building from source requires the Swift 6.1 toolchain (Xcode 16.3+ or the
+  matching `swift` toolchain).
 
 ---
 
@@ -30,9 +33,19 @@ brew install EYHN/tap/kwwk
 Or build from source:
 
 ```sh
-swift build -c release
-cp .build/release/kwwk /usr/local/bin/
+swift build -c release --product kwwk
+bin_dir="$(swift build -c release --show-bin-path)"
+sudo install -d /usr/local/libexec/kwwk /usr/local/bin
+sudo install -m 0755 "$bin_dir/kwwk" /usr/local/libexec/kwwk/kwwk
+sudo cp -R "$bin_dir/kwwk_KWWKAI.bundle" /usr/local/libexec/kwwk/
+printf '%s\n' '#!/bin/sh' 'exec /usr/local/libexec/kwwk/kwwk "$@"' \
+  | sudo tee /usr/local/bin/kwwk >/dev/null
+sudo chmod 0755 /usr/local/bin/kwwk
 ```
+
+The resource bundle must stay beside the real executable. The launcher above
+executes that path directly; replacing it with a symlink can make SwiftPM look
+for `kwwk_KWWKAI.bundle` beside the symlink instead.
 
 ### Run
 

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -4,6 +4,7 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
+import KWWKAI
 import KWWKAgent
 import KWWKCli
 
@@ -12,6 +13,7 @@ import KWWKCli
 ///   kwwk                    → interactive coding TUI (sign in via `/login`)
 ///   kwwk -p <prompt>        → one-shot, non-interactive run (stdout = reply)
 ///   kwwk --help             → usage
+///   kwwk --self-test        → verify bundled model resources without network access
 ///
 /// Global flags (apply to both TUI and headless `-p`):
 ///   `--thinking <off|minimal|low|medium|high|xhigh|max>` — reasoning effort,
@@ -66,6 +68,8 @@ struct KwwkCLI {
             )
         case "-h", "--help":
             printUsage()
+        case "--self-test":
+            runSelfTest()
         default:
             FileHandle.standardError.write(Data("kwwk: unknown subcommand '\(subcommand!)'\n\n".utf8))
             printUsage()
@@ -82,6 +86,7 @@ struct KwwkCLI {
           kwwk -p <prompt>            run a one-shot prompt and print the reply
           kwwk -p                     read the prompt from stdin
           kwwk --help                 show this message
+          kwwk --self-test            verify bundled installation resources
 
         global options:
           --thinking <level>          reasoning effort: off, minimal, low,
@@ -108,6 +113,27 @@ struct KwwkCLI {
         neither configured, launch kwwk and run /login to sign in to a
         provider (OAuth subscription or API key).
         """)
+    }
+
+    /// Exercise both SwiftPM resource catalogs through `Bundle.module` without
+    /// resolving credentials or constructing a provider. Homebrew runs this
+    /// against the installed executable so a bottle missing its sidecar
+    /// `kwwk_KWWKAI.bundle` fails before publication.
+    static func runSelfTest() -> Never {
+        guard !ModelsCatalog.models(for: "anthropic").isEmpty else {
+            FileHandle.standardError.write(Data(
+                "kwwk: self-test failed: primary model catalog is empty\n".utf8
+            ))
+            Foundation.exit(1)
+        }
+        guard ModelsCatalog.model(provider: "cursor", id: "default") != nil else {
+            FileHandle.standardError.write(Data(
+                "kwwk: self-test failed: Cursor model catalog is missing\n".utf8
+            ))
+            Foundation.exit(1)
+        }
+        print("resources: ok")
+        Foundation.exit(0)
     }
 
     /// Pull `--thinking <level>` out of argv and return the remaining args


### PR DESCRIPTION
## What changed

- verify every change on macOS 15 Apple Silicon, macOS 15 Intel, and the newest macOS runner
- add an offline `kwwk --self-test` that exercises both bundled model catalogs
- run that self-test in CI and before creating a release
- replace direct writes to the tap's `main` branch with an idempotent formula-bump pull request
- remove stale bottle checksums on source bumps and reject attempts to publish an older version
- document bottle availability and the required resource-aware source installation layout

## Why

Homebrew currently builds `kwwk` locally, so users need a matching Xcode and Swift toolchain and every install recompiles the package. Together with EYHN/homebrew-tap#1, this enables reviewed Apple Silicon and Intel bottles while keeping source and HEAD builds covered.

## Release flow

Merge EYHN/homebrew-tap#1 before merging/tagging this change. A future `vX.Y.Z` tag will verify the release, create its GitHub Release, and open a tap bump PR. After both tap builders pass, a maintainer publishes the reviewed artifacts with the tap's manual `brew pr-pull` workflow and exact PR head SHA.

## Validation

- `swift build -c release --product kwwk`
- release and relocated-launcher `kwwk --self-test` (`resources: ok`)
- `swift test` (1,298 tests passed)
- `actionlint` and YAML syntax checks
- updater idempotence, stale-bottle removal, and version-guard probes
- `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release automation now gates publishing on multi-arch builds and changes how the tap is updated; mistakes in the Ruby formula editor could break installs, but downgrade refusal and self-test reduce worst-case impact.
> 
> **Overview**
> Adds **Homebrew bottle** support by hardening install/CI/release around bundled `KWWKAI` resources and automating tap updates via reviewed PRs instead of direct pushes to `main`.
> 
> **`kwwk --self-test`** loads both model catalogs through `Bundle.module` offline; CI (macOS/Linux) and release verification run it after every build so a missing `kwwk_KWWKAI.bundle` fails before ship.
> 
> **CI/release matrices** add `macos-15-intel`, pin Swift 6.1 on `macos-15*` runners via Xcode 16.4, and document that bottles are prebuilt while the matrix still covers source/HEAD and SwiftPM builds.
> 
> **Release workflow** scopes `contents: write` to the release job only and replaces direct tap commits with an idempotent **`automation/kwwk-<tag>`** branch: Ruby updates top-level `url`/`sha256`, strips stale **`bottle do`** blocks on source bumps, refuses version downgrades, then opens or updates a tap PR.
> 
> **README** separates bottled vs from-source requirements and documents a **libexec + launcher** layout so the resource bundle stays beside the real binary (symlink pitfalls called out).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa8efc6117d28b7577e75ba76688c8bd6d656e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->