### PR TITLE
fix: support JSON-backed pi model catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,10 +463,19 @@ don't update one without the other:
    Cursor catalog).
 
 ```sh
+# In the pi-mono checkout, materialize the generated provider JSON first.
+node packages/ai/scripts/generate-models.ts
+
+# In the kwwk checkout, use that exact pi-mono checkout as the input.
 swift run kwwk-generate-models /path/to/pi-mono/packages/ai/src/models.generated.ts
 swift run kwwk-generate-cursor-models
 swift test
 ```
+
+Current pi-mono provider catalogs import their values from generated
+`packages/ai/src/providers/data/*.json` files. Those files are intentionally
+Git-ignored upstream, so the pi-mono generator must run in that checkout before
+`kwwk-generate-models`. Older inline provider catalogs remain supported.
 
 `kwwk-generate-cursor-models` authenticates via `CURSOR_ACCESS_TOKEN`,
 an existing `cursor` login in `~/.kwwk/oauth.json`, or — with neither

--- a/Scripts/GenerateModels/main.swift
+++ b/Scripts/GenerateModels/main.swift
@@ -9,6 +9,10 @@ import KWWKGenerateModelsCore
 ///   swift run kwwk-generate-models \
 ///       /path/to/pi-mono/packages/ai/src/models.generated.ts
 ///
+/// Current pi-mono checkouts must first run their own
+/// `node packages/ai/scripts/generate-models.ts` command to materialize the
+/// Git-ignored provider JSON files referenced by the generated TypeScript.
+///
 /// By default the output is written to:
 ///
 ///   Sources/KWWKAI/Resources/models.json
@@ -86,6 +90,10 @@ struct GenerateModels {
 
     note: also run `swift run kwwk-generate-cursor-models` when syncing —
     the Cursor catalog (cursor-models.json) is regenerated separately.
+
+    current pi-mono checkouts must first run
+    `node packages/ai/scripts/generate-models.ts` in the pi-mono repository to
+    materialize the Git-ignored provider JSON files.
     """
 }
 

--- a/Scripts/GenerateModelsCore/GenerateModelsCore.swift
+++ b/Scripts/GenerateModelsCore/GenerateModelsCore.swift
@@ -115,15 +115,106 @@ public enum GenerateModelsCore {
 
             let importedURL = URL(fileURLWithPath: importPath, relativeTo: baseURL).standardizedFileURL
             let importedRaw = try String(contentsOf: importedURL, encoding: .utf8)
-            let object = try objectLiteral(named: reference.constant, in: importedRaw)
+            let object = try providerModelsObject(
+                named: reference.constant,
+                in: importedRaw,
+                sourceURL: importedURL
+            )
             lines.append(#""\#(reference.provider)": \#(object),"#)
         }
         lines.append("} as const;")
         return lines.joined(separator: "\n")
     }
 
+    /// pi-mono provider catalogs were originally emitted as inline TypeScript
+    /// object literals. Newer generated catalogs import their values from a
+    /// sibling JSON file and retain only a type map in the `.models.ts` file.
+    /// Prefer the inline object for backwards compatibility, otherwise resolve
+    /// the exported identifier to its JSON import and inline that JSON object.
+    private static func providerModelsObject(
+        named constant: String,
+        in raw: String,
+        sourceURL: URL
+    ) throws -> String {
+        let marker = "export const \(constant) ="
+        guard let markerRange = raw.range(of: marker) else {
+            throw GenerateModelsCoreError.conversion("could not find exported constant \(constant)")
+        }
+
+        let expression = raw[markerRange.upperBound...]
+            .drop(while: { $0.isWhitespace })
+        guard let first = expression.first else {
+            throw GenerateModelsCoreError.conversion("missing value for exported constant \(constant)")
+        }
+
+        if first == "{" {
+            let end = try matchingBrace(in: raw, from: expression.startIndex)
+            return String(raw[expression.startIndex...end])
+        }
+
+        let matches = regexMatches(#"^([A-Za-z_][A-Za-z0-9_]*)\s+as\b"#, in: String(expression))
+        guard let importedName = matches.first?.first else {
+            throw GenerateModelsCoreError.conversion(
+                "unsupported value for exported constant \(constant)"
+            )
+        }
+
+        let jsonImports = importedJSONValues(in: raw)
+        guard let importPath = jsonImports[importedName] else {
+            throw GenerateModelsCoreError.conversion(
+                "missing JSON import for provider constant \(constant)"
+            )
+        }
+
+        let jsonURL = URL(
+            fileURLWithPath: importPath,
+            relativeTo: sourceURL.deletingLastPathComponent()
+        ).standardizedFileURL
+        let json: String
+        do {
+            json = try String(contentsOf: jsonURL, encoding: .utf8)
+        } catch {
+            throw GenerateModelsCoreError.conversion(
+                "could not read provider JSON for \(constant) at \(jsonURL.path); "
+                    + "run pi-mono's `node packages/ai/scripts/generate-models.ts` first: \(error)"
+            )
+        }
+
+        guard let data = json.data(using: .utf8) else {
+            throw GenerateModelsCoreError.conversion(
+                "could not decode provider JSON for \(constant) as UTF-8"
+            )
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw GenerateModelsCoreError.conversion(
+                "invalid provider JSON for \(constant): \(error)"
+            )
+        }
+        guard parsed is [String: Any] else {
+            throw GenerateModelsCoreError.conversion(
+                "provider JSON for \(constant) is not an object"
+            )
+        }
+        return json
+    }
+
     private static func importedModelConstants(in raw: String) -> [String: String] {
         let pattern = #"(?m)^\s*import\s+\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\s+from\s+"([^"]+)";"#
+        let matches = regexMatches(pattern, in: raw)
+
+        var imports: [String: String] = [:]
+        for match in matches {
+            guard match.count == 2 else { continue }
+            imports[match[0]] = match[1]
+        }
+        return imports
+    }
+
+    private static func importedJSONValues(in raw: String) -> [String: String] {
+        let pattern = #"(?m)^\s*import\s+([A-Za-z_][A-Za-z0-9_]*)\s+from\s+"([^"]+\.json)""#
         let matches = regexMatches(pattern, in: raw)
 
         var imports: [String: String] = [:]

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -6006,7 +6006,16 @@
         "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
-        "output" : 12
+        "output" : 12,
+        "tiers" : [
+          {
+            "cacheRead" : 0.4,
+            "cacheWrite" : 0,
+            "input" : 4,
+            "inputTokensAbove" : 200000,
+            "output" : 18
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -6217,7 +6226,16 @@
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2.5,
-        "output" : 15
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 0,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -6310,7 +6328,16 @@
         "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 5,
-        "output" : 30
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 0,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -6341,7 +6368,16 @@
         "cacheRead" : 0.1,
         "cacheWrite" : 0,
         "input" : 1,
-        "output" : 6
+        "output" : 6,
+        "tiers" : [
+          {
+            "cacheRead" : 0.2,
+            "cacheWrite" : 0,
+            "input" : 2,
+            "inputTokensAbove" : 200000,
+            "output" : 9
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -6373,7 +6409,16 @@
         "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 5,
-        "output" : 30
+        "output" : 30,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 0,
+            "input" : 10,
+            "inputTokensAbove" : 272000,
+            "output" : 45
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -6405,7 +6450,16 @@
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2.5,
-        "output" : 15
+        "output" : 15,
+        "tiers" : [
+          {
+            "cacheRead" : 0.5,
+            "cacheWrite" : 0,
+            "input" : 5,
+            "inputTokensAbove" : 272000,
+            "output" : 22.5
+          }
+        ]
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -8338,10 +8392,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.95,
+        "output" : 4
       },
       "headers" : {
         "User-Agent" : "KimiCLI\/1.5"
@@ -8365,10 +8419,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 3,
+        "output" : 15
       },
       "headers" : {
         "User-Agent" : "KimiCLI\/1.5"
@@ -8392,33 +8446,6 @@
         "xhigh" : null
       }
     },
-    "kimi-for-coding" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.kimi.com\/coding",
-      "compat" : {
-        "allowEmptySignature" : true,
-        "forceAdaptiveThinking" : true
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
-      },
-      "id" : "kimi-for-coding",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Kimi For Coding",
-      "provider" : "kimi-coding",
-      "reasoning" : true
-    },
     "kimi-for-coding-highspeed" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.kimi.com\/coding",
@@ -8427,10 +8454,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.38,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.9,
+        "output" : 8
       },
       "headers" : {
         "User-Agent" : "KimiCLI\/1.5"
@@ -8442,31 +8469,6 @@
       ],
       "maxTokens" : 32768,
       "name" : "Kimi For Coding HighSpeed",
-      "provider" : "kimi-coding",
-      "reasoning" : true
-    },
-    "kimi-k2-thinking" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.kimi.com\/coding",
-      "compat" : {
-        "forceAdaptiveThinking" : true
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
-      },
-      "id" : "kimi-k2-thinking",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Kimi K2 Thinking",
       "provider" : "kimi-coding",
       "reasoning" : true
     }
@@ -13153,10 +13155,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0145,
+        "cacheRead" : 0.003625,
         "cacheWrite" : 0,
-        "input" : 1.74,
-        "output" : 3.48
+        "input" : 0.435,
+        "output" : 0.87
       },
       "id" : "deepseek-v4-pro",
       "input" : [
@@ -13334,7 +13336,7 @@
         "image"
       ],
       "maxTokens" : 131072,
-      "name" : "Kimi K3",
+      "name" : "Kimi K3 (2x usage)",
       "provider" : "opencode-go",
       "reasoning" : true
     },
@@ -13373,10 +13375,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0145,
+        "cacheRead" : 0.003625,
         "cacheWrite" : 0,
-        "input" : 1.74,
-        "output" : 3.48
+        "input" : 0.435,
+        "output" : 0.87
       },
       "id" : "mimo-v2.5-pro",
       "input" : [
@@ -15142,19 +15144,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 110000,
       "cost" : {
-        "cacheRead" : 0.04,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.08,
-        "output" : 0.45
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "google\/gemma-3-27b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 4096,
       "name" : "Google: Gemma 3 27B",
       "provider" : "openrouter",
       "reasoning" : false
@@ -15705,12 +15707,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 204800,
+      "contextWindow" : 196608,
       "cost" : {
-        "cacheRead" : 0.06,
+        "cacheRead" : 0.05,
         "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 1.2
+        "input" : 0.25,
+        "output" : 1
       },
       "id" : "minimax\/minimax-m2.7",
       "input" : [
@@ -16200,7 +16202,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
         "input" : 0.6,
         "output" : 2.5
@@ -16209,7 +16211,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 100352,
       "name" : "MoonshotAI: Kimi K2 Thinking",
       "provider" : "openrouter",
       "reasoning" : true
@@ -16272,10 +16274,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.16,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.75,
-        "output" : 3.5
+        "input" : 1,
+        "output" : 4.4
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -16356,29 +16358,6 @@
       ],
       "maxTokens" : 262144,
       "name" : "Nex AGI: Nex-N2-Pro",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "nvidia\/llama-3.3-nemotron-super-49b-v1.5" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.4,
-        "output" : 0.4
-      },
-      "id" : "nvidia\/llama-3.3-nemotron-super-49b-v1.5",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -18022,6 +18001,30 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "openrouter\/auto-beta" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : -1000000,
+        "output" : -1000000
+      },
+      "id" : "openrouter\/auto-beta",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Auto Router (Beta)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "openrouter\/free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -18329,18 +18332,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.5
+        "input" : 0.13,
+        "output" : 0.52
       },
       "id" : "qwen\/qwen3-30b-a3b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 8192,
       "name" : "Qwen: Qwen3 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -18939,15 +18942,15 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.195,
-        "output" : 1.56
+        "input" : 0.26,
+        "output" : 2.6
       },
       "id" : "qwen\/qwen3.5-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 81920,
       "name" : "Qwen: Qwen3.5-27B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19009,10 +19012,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.225,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.45,
-        "output" : 3
+        "input" : 0.39,
+        "output" : 2.34
       },
       "id" : "qwen\/qwen3.5-397b-a17b",
       "input" : [
@@ -19495,6 +19498,30 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "thinkingmachines\/inkling" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 524288,
+      "cost" : {
+        "cacheRead" : 0.17,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 4.05
+      },
+      "id" : "thinkingmachines\/inkling",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Thinking Machines: Inkling",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "upstage\/solar-pro-3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -19902,10 +19929,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.16874,
+        "cacheRead" : 0.07722,
         "cacheWrite" : 0,
-        "input" : 0.9086,
-        "output" : 2.8556
+        "input" : 0.4158,
+        "output" : 1.3068
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
@@ -20485,6 +20512,40 @@
       "name" : "Qwen3.7 Max",
       "provider" : "together",
       "reasoning" : false
+    },
+    "thinkingmachines\/Inkling" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 524288,
+      "cost" : {
+        "cacheRead" : 0.17,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 4.05
+      },
+      "id" : "thinkingmachines\/Inkling",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Inkling",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
     },
     "zai-org\/GLM-5" : {
       "api" : "openai-completions",
@@ -22128,46 +22189,6 @@
       ],
       "maxTokens" : 8192,
       "name" : "Llama 3.1 70B Instruct",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "meta\/llama-3.2-11b" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.16,
-        "output" : 0.16
-      },
-      "id" : "meta\/llama-3.2-11b",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Llama 3.2 11B Vision Instruct",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "meta\/llama-3.2-90b" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.72,
-        "output" : 0.72
-      },
-      "id" : "meta\/llama-3.2-90b",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Llama 3.2 90B Vision Instruct",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },

--- a/Tests/KWWKAITests/GenerateModelsCoreTests.swift
+++ b/Tests/KWWKAITests/GenerateModelsCoreTests.swift
@@ -93,6 +93,75 @@ struct GenerateModelsCoreTests {
         #expect(model["contextWindow"] as? Int == 400_000)
     }
 
+    @Test("inlines JSON-backed split pi provider catalogs")
+    func inlinesJSONBackedSplitProviderCatalogs() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwwk-generate-models-\(UUID().uuidString)")
+        let providers = root.appendingPathComponent("providers")
+        let data = providers.appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: data, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let generated = """
+        import { OPENAI_MODELS } from "./providers/openai.models.ts";
+
+        export const MODELS = {
+          "openai": OPENAI_MODELS,
+        } as const;
+        """
+        try generated.write(
+            to: root.appendingPathComponent("models.generated.ts"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let provider = """
+        import values from "./data/openai.json" with { type: "json" };
+        import type { Model } from "../types.ts";
+
+        export const OPENAI_MODELS = values as {
+          "gpt-5.5": Model<"openai-responses"> & {
+            id: "gpt-5.5";
+            provider: "openai";
+          };
+        };
+        """
+        try provider.write(
+            to: providers.appendingPathComponent("openai.models.ts"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let values = """
+        {
+          "gpt-5.5": {
+            "id": "gpt-5.5",
+            "name": "GPT-5.5",
+            "api": "openai-responses",
+            "provider": "openai",
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 128000
+          }
+        }
+        """
+        try values.write(
+            to: data.appendingPathComponent("openai.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try GenerateModelsCore.generate(
+            fromFile: root.appendingPathComponent("models.generated.ts")
+        )
+        let openai = try #require(result.root["openai"] as? [String: Any])
+        let model = try #require(openai["gpt-5.5"] as? [String: Any])
+
+        #expect(model["id"] as? String == "gpt-5.5")
+        #expect(model["api"] as? String == "openai-responses")
+        #expect(model["contextWindow"] as? Int == 400_000)
+    }
+
     @Test("preserves providers from the source catalog")
     func preservesSourceProviders() throws {
         let raw = """

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -151,14 +151,17 @@ struct MultiProviderAuthTests {
             #expect(resolved?.model.provider == "kimi-coding")
             #expect(resolved?.model.api == "anthropic-messages")
             #expect(resolved?.model.baseURL == "https://api.kimi.com/coding")
-            // The KimiCLI agent string rides along from the catalog so the
-            // coding endpoint accepts the request.
+            // The KimiCLI agent string comes from the catalog when present;
+            // if pi-mono no longer lists the legacy default id, the resolver
+            // supplies the same metadata so the coding endpoint accepts it.
             #expect(resolved?.model.headers?["User-Agent"]?.hasPrefix("KimiCLI/") == true)
-            let catalogEntry = try #require(ModelsCatalog.model(provider: "kimi-coding", id: "kimi-for-coding"))
-            #expect(resolved?.model.contextWindow == catalogEntry.contextWindow)
+            let resolvedModel = try #require(resolved?.model)
+            #expect(resolvedModel.contextWindow == 262_144)
+            #expect(resolvedModel.compat?.forceAdaptiveThinking == true)
+            #expect(resolvedModel.compat?.allowEmptySignature == true)
             #expect(resolved?.modelLabel == "kimi-for-coding · Kimi For Coding")
             // The OAuth resolver supplies a bearer token per request.
-            let auth = try await resolved?.authResolver?(catalogEntry, nil)
+            let auth = try await resolved?.authResolver?(resolvedModel, nil)
             #expect(auth?.token == "kimi-token")
             let scoped = await APIRegistry.shared.provider(scope: "kimi-coding", api: "anthropic-messages")
             #expect(scoped is AnthropicProvider)


### PR DESCRIPTION
## Summary

- Teach kwwk-generate-models to resolve both legacy inline provider objects and the new JSON-backed pi-mono provider catalogs.
- Document the required pi-mono generation step that materializes Git-ignored provider JSON files, with a clear generator error when they are absent.
- Refresh the bundled regular catalog and retain the existing Kimi default fallback regression coverage.
- Regenerate Cursor GetUsableModels; cursor-models.json remains unchanged at 183 models.

## Catalog changes

- Regular models: 1,072 -> 1,070 across 35 providers.
- Added 3: openrouter/openrouter/auto-beta, openrouter/thinkingmachines/inkling, together/thinkingmachines/Inkling.
- Removed 5: kimi-coding/kimi-for-coding, kimi-coding/kimi-k2-thinking, openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5, vercel-ai-gateway/meta/llama-3.2-11b, vercel-ai-gateway/meta/llama-3.2-90b.
- Updated metadata for 20 existing models, primarily pricing plus a few context-window, max-token, and name changes.

## Upstream

- Authoritative badlogic/pi-mono main SHA: 3da591ab74ab9ab407e72ed882600b2c851fae21
- Ran its official packages/ai/scripts/generate-models.ts before kwwk regeneration because current provider JSON is intentionally Git-ignored upstream.

## Validation

- Both bundled files validated with jq.
- git diff --check passed.
- Diff inspected for mass deletion, malformed entries, private or localhost endpoints, and credential material; none found.
- Focused generator, catalog, Cursor, and multi-provider auth tests passed: 56 tests in 8 suites.
- Full swift test passed: 1,308 tests in 193 suites.