### PR TITLE
chore(models): refresh bundled model catalog

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -6366,13 +6366,13 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.1,
-        "cacheWrite" : 0,
+        "cacheWrite" : 1.25,
         "input" : 1,
         "output" : 6,
         "tiers" : [
           {
             "cacheRead" : 0.2,
-            "cacheWrite" : 0,
+            "cacheWrite" : 2.5,
             "input" : 2,
             "inputTokensAbove" : 200000,
             "output" : 9
@@ -6407,13 +6407,13 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
-        "cacheWrite" : 0,
+        "cacheWrite" : 6.25,
         "input" : 5,
         "output" : 30,
         "tiers" : [
           {
             "cacheRead" : 1,
-            "cacheWrite" : 0,
+            "cacheWrite" : 12.5,
             "input" : 10,
             "inputTokensAbove" : 272000,
             "output" : 45
@@ -6448,13 +6448,13 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
-        "cacheWrite" : 0,
+        "cacheWrite" : 3.125,
         "input" : 2.5,
         "output" : 15,
         "tiers" : [
           {
             "cacheRead" : 0.5,
-            "cacheWrite" : 0,
+            "cacheWrite" : 6.25,
             "input" : 5,
             "inputTokensAbove" : 272000,
             "output" : 22.5
@@ -13725,7 +13725,7 @@
       },
       "contextWindow" : 500000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -15168,19 +15168,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.3
+        "input" : 0.07000000000000001,
+        "output" : 0.34
       },
       "id" : "google\/gemma-4-26b-a4b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 256000,
+      "maxTokens" : 16384,
       "name" : "Google: Gemma 4 26B A4B ",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15640,10 +15640,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.03,
         "cacheWrite" : 0,
-        "input" : 0.255,
-        "output" : 1.02
+        "input" : 0.3,
+        "output" : 1.2
       },
       "id" : "minimax\/minimax-m2",
       "input" : [
@@ -16250,17 +16250,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.16,
+        "cacheRead" : 0.144,
         "cacheWrite" : 0,
-        "input" : 0.95,
-        "output" : 4
+        "input" : 0.6840000000000001,
+        "output" : 3.42
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 262144,
       "name" : "MoonshotAI: Kimi K2.6",
       "provider" : "openrouter",
       "reasoning" : true
@@ -16274,10 +16274,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.2,
+        "cacheRead" : 0.17,
         "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 4.4
+        "input" : 0.85,
+        "output" : 3.8
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -18309,18 +18309,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.24
+        "input" : 0.2275,
+        "output" : 0.91
       },
       "id" : "qwen\/qwen3-14b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 8192,
       "name" : "Qwen: Qwen3 14B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19578,7 +19578,7 @@
       },
       "contextWindow" : 500000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -19929,10 +19929,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.07722,
+        "cacheRead" : 0.04836,
         "cacheWrite" : 0,
-        "input" : 0.4158,
-        "output" : 1.3068
+        "input" : 0.2604,
+        "output" : 0.8184
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [


### PR DESCRIPTION
## Summary

- regenerate `Sources/KWWKAI/Resources/models.json` from authoritative badlogic/pi-mono main
- keep the catalog at 1,070 models across 35 providers: 0 added, 0 removed, 11 models with metadata changes
- refresh Cursor GetUsableModels; `cursor-models.json` is unchanged at 183 models

Metadata changes update pricing for GitHub Copilot GPT-5.6 Luna/Sol/Terra and several OpenRouter models, plus context/output limits for Gemma 4 26B, Kimi K2.6, and Qwen3 14B.

## Upstream

- badlogic/pi-mono commit: `3da591ab74ab9ab407e72ed882600b2c851fae21`
- source: `packages/ai/src/models.generated.ts` after running pi-mono’s official model generator

## Validation

- both bundled files parsed as JSON
- `git diff --check`
- suspicious endpoint and credential scan
- focused generator/catalog/Cursor tests: 43 tests in 7 suites passed
- full `swift test`: 1,308 tests in 193 suites passed