### PR TITLE
fix(cli): fold failed/killed background notifications instead of dumping raw XML

### DIFF
--- a/Sources/KWWKCli/BgNotificationSummary.swift
+++ b/Sources/KWWKCli/BgNotificationSummary.swift
@@ -22,14 +22,21 @@ struct BgNotificationSummary {
     let isIncomplete: Bool
 
     /// Return nil if `text` isn't a background-task notification. We only
-    /// recognise the two lead-ins the bridge emits so genuine user
+    /// recognise the lead-ins the bridge emits (see
+    /// `BackgroundTaskNotification.messageText()`) so genuine user
     /// messages that happen to contain XML-looking strings pass through
-    /// untouched.
+    /// untouched. All four terminal/stall lead-ins must stay in sync with
+    /// the emitter — a missing one falls through to the raw user-bar render
+    /// and dumps the full `<task-notification>` XML into the transcript.
     static func parse(_ text: String) -> BgNotificationSummary? {
         let completedLead = "A background task completed:"
+        let failedLead    = "A background task failed:"
+        let killedLead    = "A background task was killed:"
         let stalledLead   = "A background task appears stuck"
         let isStalled: Bool
-        if text.hasPrefix(completedLead) {
+        if text.hasPrefix(completedLead)
+            || text.hasPrefix(failedLead)
+            || text.hasPrefix(killedLead) {
             isStalled = false
         } else if text.hasPrefix(stalledLead) {
             isStalled = true
@@ -51,6 +58,7 @@ struct BgNotificationSummary {
         let truncated = tag(text, "output-truncated") == "true"
         let isError = !isIncomplete && (
             rawStatus == "failed"
+                || rawStatus == "killed"
                 || summary?.contains("exit") == true
                     && summary?.contains("exit 0") == false
                     && rawStatus != "completed"

--- a/Tests/KWWKCliTests/BgNotificationSummaryTests.swift
+++ b/Tests/KWWKCliTests/BgNotificationSummaryTests.swift
@@ -58,6 +58,53 @@ struct BgNotificationSummaryTests {
         #expect(summary?.outputTail == ["Enter password:"])
     }
 
+    @Test("parses a failed notification")
+    func failed() {
+        let text = """
+        A background task failed:
+        <task-notification>
+          <task-id>bg_fail</task-id>
+          <kind>bash</kind>
+          <label>build</label>
+          <status>failed</status>
+          <summary>exit 1</summary>
+          <exit-code>1</exit-code>
+          <duration-ms>3400</duration-ms>
+          <output-tail><untrusted-output>error: linker failed</untrusted-output></output-tail>
+        </task-notification>
+        """
+        let summary = BgNotificationSummary.parse(text)
+        #expect(summary != nil)
+        #expect(summary?.label == "build")
+        #expect(summary?.status == "failed")
+        #expect(summary?.isError == true)
+        #expect(summary?.isStalled == false)
+        #expect(summary?.outputTail == ["error: linker failed"])
+        let rendered = ANSI.stripEscapes(summary?.render().joined(separator: "\n") ?? "")
+        #expect(rendered.contains("● bg(build) · failed · exit 1"))
+        #expect(!rendered.contains("<task-notification>"))
+    }
+
+    @Test("parses a killed notification")
+    func killed() {
+        let text = """
+        A background task was killed:
+        <task-notification>
+          <task-id>bg_kill</task-id>
+          <kind>bash</kind>
+          <label>server</label>
+          <status>killed</status>
+          <duration-ms>500</duration-ms>
+        </task-notification>
+        """
+        let summary = BgNotificationSummary.parse(text)
+        #expect(summary != nil)
+        #expect(summary?.label == "server")
+        #expect(summary?.status == "killed")
+        #expect(summary?.isError == true)
+        #expect(summary?.isStalled == false)
+    }
+
     @Test("explicitly incomplete agent result renders as a warning, not an error")
     func incompleteAgentResult() {
         let text = """


### PR DESCRIPTION
## 问题

用户在 TUI 里看到大段 `A background task failed:` + 完整 `<task-notification>` XML 被当成**用户消息条**渲染出来。这类后台任务通知本应被静默折叠成紧凑摘要,而不是作为用户输入展示。

## 根因

后台通知在 `BackgroundTaskManager.drainMessages()` 里被包成 `UserMessage(source: .runtime)`。`TranscriptRenderer` 对 `source == .runtime` 的消息会调用 `BgNotificationSummary.parse` 折叠成一行 `● bg(...)` 的工具结果式摘要。

但发射端 `BackgroundTaskNotification.messageText()` 会产生**四种**开头:`completed` / `failed` / `killed` / `stalled`,而 `BgNotificationSummary.parse` 只认 `completed` 和 `stalled` 两种。于是 **failed / killed** 通知 `parse` 返回 `nil`,渲染跌落到 `TranscriptRenderer` 的 `else` 分支,把整段 XML 当用户消息条原样打印。

## 改动

- `BgNotificationSummary.parse` 增加对 `"A background task failed:"` 和 `"A background task was killed:"` 两个开头的识别,并加注释强调这四个 lead-in 必须与发射端同步。
- `isError` 现在把 `killed` 也视为错误状态(此前仅 `failed`)。
- 新增 `failed` / `killed` 两个解析测试,断言渲染为紧凑摘要且不含原始 XML。

## 测试

- `swift test --filter BgNotificationSummary` 全部通过。
- 全量 `swift test`:除既有的 `SessionStoreTests/latestForCwd`(依赖时间戳、并行下偶发 flaky,单独跑稳定通过)外无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)