### PR TITLE
chore(ai): drop the KWWK_NO_WEBP / excludeWebP image option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Inside the TUI, `/help` lists slash commands (`/model`, `/thinking`,
 LS, and background-task tools out of the box.
 
 Image inputs are resized and recompressed before entering the conversation.
-Set `KWWK_NO_WEBP=1` when the target backend cannot decode WebP (for example,
-llama.cpp builds that use stb_image).
 
 ---
 

--- a/Sources/KWWKAI/ImageNormalizer.swift
+++ b/Sources/KWWKAI/ImageNormalizer.swift
@@ -60,22 +60,8 @@ public struct NormalizedImage: Sendable, Hashable {
 }
 
 public enum ImageNormalizer {
-    public static func normalize(
-        _ data: Data,
-        excludingWebP: Bool? = nil
-    ) throws -> NormalizedImage {
-        try normalize(
-            data,
-            options: .default(
-                excludingWebP: excludingWebP
-                    ?? excludesWebP(in: ProcessInfo.processInfo.environment)
-            )
-        )
-    }
-
-    static func excludesWebP(in environment: [String: String]) -> Bool {
-        guard let raw = environment["KWWK_NO_WEBP"] else { return false }
-        return raw == "1" || raw.lowercased() == "true"
+    public static func normalize(_ data: Data) throws -> NormalizedImage {
+        try normalize(data, options: .default())
     }
 
     static func normalize(
@@ -113,7 +99,6 @@ public enum ImageNormalizer {
             && source.height <= options.maximumHeight
             && data.count <= options.maximumBytes / 4
             && orientation == .identity
-            && !(options.excludeWebP && sourceFormat == .webp)
 
         if isComfortablyWithinLimits {
             return NormalizedImage(
@@ -139,21 +124,13 @@ public enum ImageNormalizer {
         )
         let target = try resize(source, width: targetSize.width, height: targetSize.height)
 
-        var best = try encodeSmallest(
-            target,
-            quality: options.initialQuality,
-            excludingWebP: options.excludeWebP
-        )
+        var best = try encodeSmallest(target, quality: options.initialQuality)
         if best.data.count <= options.maximumBytes {
             return normalizedImage(best, source: source)
         }
 
         for quality in options.qualitySteps {
-            let candidate = try encodeSmallestLossy(
-                target,
-                quality: quality,
-                excludingWebP: options.excludeWebP
-            )
+            let candidate = try encodeSmallestLossy(target, quality: quality)
             if candidate.data.count < best.data.count {
                 best = candidate
             }
@@ -171,11 +148,7 @@ public enum ImageNormalizer {
 
             let scaled = try resize(source, width: width, height: height)
             for quality in options.qualitySteps {
-                let candidate = try encodeSmallestLossy(
-                    scaled,
-                    quality: quality,
-                    excludingWebP: options.excludeWebP
-                )
+                let candidate = try encodeSmallestLossy(scaled, quality: quality)
                 if candidate.data.count < best.data.count {
                     best = candidate
                 }
@@ -338,26 +311,21 @@ public enum ImageNormalizer {
 
     private static func encodeSmallest(
         _ image: RasterImage,
-        quality: Int,
-        excludingWebP: Bool
+        quality: Int
     ) throws -> EncodedImage {
-        var candidates = try [
+        let candidates = try [
             encodePNG(image),
             encodeJPEG(image, quality: quality),
+            encodeWebP(image, quality: quality),
         ]
-        if !excludingWebP {
-            candidates.append(try encodeWebP(image, quality: quality))
-        }
         return candidates.min(by: { $0.data.count < $1.data.count })!
     }
 
     private static func encodeSmallestLossy(
         _ image: RasterImage,
-        quality: Int,
-        excludingWebP: Bool
+        quality: Int
     ) throws -> EncodedImage {
         let jpeg = try encodeJPEG(image, quality: quality)
-        guard !excludingWebP else { return jpeg }
         let webP = try encodeWebP(image, quality: quality)
         return jpeg.data.count < webP.data.count ? jpeg : webP
     }
@@ -441,9 +409,8 @@ struct ImageNormalizationOptions: Sendable {
     let qualitySteps: [Int]
     let scaleSteps: [Double]
     let minimumFallbackDimension: Int
-    let excludeWebP: Bool
 
-    static func `default`(excludingWebP: Bool = false) -> ImageNormalizationOptions {
+    static func `default`() -> ImageNormalizationOptions {
         ImageNormalizationOptions(
             maximumWidth: 1568,
             maximumHeight: 1568,
@@ -452,8 +419,7 @@ struct ImageNormalizationOptions: Sendable {
             initialQuality: 80,
             qualitySteps: [70, 60, 50, 40],
             scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
-            minimumFallbackDimension: 100,
-            excludeWebP: excludingWebP
+            minimumFallbackDimension: 100
         )
     }
 }

--- a/Tests/KWWKAITests/ImageNormalizerTests.swift
+++ b/Tests/KWWKAITests/ImageNormalizerTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct ImageNormalizerTests {
     @Test("upscales undersized images to the 200px floor")
     func minimumDimension() throws {
-        let result = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+        let result = try ImageNormalizer.normalize(redPixelPNG)
 
         #expect(result.originalWidth == 1)
         #expect(result.originalHeight == 1)
@@ -27,8 +27,7 @@ struct ImageNormalizerTests {
             initialQuality: 80,
             qualitySteps: [70, 60, 50, 40],
             scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
-            minimumFallbackDimension: 1,
-            excludeWebP: false
+            minimumFallbackDimension: 1
         )
         let result = try ImageNormalizer.normalize(sixteenByOnePNG, options: options)
 
@@ -45,9 +44,9 @@ struct ImageNormalizerTests {
 
     @Test("keeps normalized images unchanged on the comfortable-size fast path")
     func fastPath() throws {
-        let first = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+        let first = try ImageNormalizer.normalize(redPixelPNG)
         let firstBytes = try #require(Data(base64Encoded: first.content.data))
-        let second = try ImageNormalizer.normalize(firstBytes, excludingWebP: false)
+        let second = try ImageNormalizer.normalize(firstBytes)
 
         #expect(!second.wasReencoded)
         #expect(second.content == first.content)
@@ -58,33 +57,10 @@ struct ImageNormalizerTests {
 
     @Test("chooses the smallest of PNG, JPEG, and WebP")
     func choosesSmallestFormat() throws {
-        let result = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
+        let result = try ImageNormalizer.normalize(redPixelPNG)
 
         #expect(result.content.mimeType == "image/webp")
         #expect(Data(base64Encoded: result.content.data)?.starts(with: Array("RIFF".utf8)) == true)
-    }
-
-    @Test("can exclude WebP and re-encodes WebP sources on the fast path")
-    func excludesWebP() throws {
-        let webP = try ImageNormalizer.normalize(redPixelPNG, excludingWebP: false)
-        let webPBytes = try #require(Data(base64Encoded: webP.content.data))
-
-        let result = try ImageNormalizer.normalize(webPBytes, excludingWebP: true)
-
-        #expect(webP.content.mimeType == "image/webp")
-        #expect(result.content.mimeType != "image/webp")
-        #expect(result.wasReencoded)
-        #expect(result.width == 200)
-        #expect(result.height == 200)
-    }
-
-    @Test("KWWK_NO_WEBP accepts only 1 or true")
-    func webPEnvironmentFlag() {
-        #expect(ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "1"]))
-        #expect(ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "TRUE"]))
-        #expect(!ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": "0"]))
-        #expect(!ImageNormalizer.excludesWebP(in: ["KWWK_NO_WEBP": ""]))
-        #expect(!ImageNormalizer.excludesWebP(in: [:]))
     }
 
     @Test("walks the quality and scale ladders when the target cannot be met")
@@ -97,8 +73,7 @@ struct ImageNormalizerTests {
             initialQuality: 80,
             qualitySteps: [70, 60, 50, 40],
             scaleSteps: [1.0, 0.75, 0.5, 0.35, 0.25],
-            minimumFallbackDimension: 100,
-            excludeWebP: false
+            minimumFallbackDimension: 100
         )
 
         let result = try ImageNormalizer.normalize(redPixelPNG, options: options)
@@ -160,7 +135,7 @@ struct ImageNormalizerTests {
     func orientationSixLandscapeSemantics() throws {
         let orientedJPEG = jpegWithEXIFOrientation(.rotated90Clockwise)
 
-        let result = try ImageNormalizer.normalize(orientedJPEG, excludingWebP: false)
+        let result = try ImageNormalizer.normalize(orientedJPEG)
 
         #expect(result.originalWidth == 3)
         #expect(result.originalHeight == 2)
@@ -169,7 +144,7 @@ struct ImageNormalizerTests {
         #expect(result.wasReencoded)
 
         let output = try #require(Data(base64Encoded: result.content.data))
-        let secondPass = try ImageNormalizer.normalize(output, excludingWebP: false)
+        let secondPass = try ImageNormalizer.normalize(output)
         #expect(secondPass.originalWidth == 300)
         #expect(secondPass.originalHeight == 200)
         #expect(!secondPass.wasReencoded)
@@ -205,12 +180,11 @@ struct ImageNormalizerTests {
     @Test("throws instead of retaining undecodable source bytes")
     func invalidImageThrows() {
         #expect(throws: ImageNormalizationError.unsupportedFormat) {
-            try ImageNormalizer.normalize(Data("not an image".utf8), excludingWebP: false)
+            try ImageNormalizer.normalize(Data("not an image".utf8))
         }
         #expect(throws: ImageNormalizationError.decodeFailed) {
             try ImageNormalizer.normalize(
-                Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
-                excludingWebP: false
+                Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
             )
         }
     }


### PR DESCRIPTION
## 改动

移除通过 `KWWK_NO_WEBP` 环境变量(以及配套的 `excludingWebP` / `excludeWebP` 参数)禁用 WebP 输出的能力。图像归一化现在始终把 WebP 作为编码候选,在 PNG/JPEG/WebP 中取最小体积。

- `ImageNormalizer.normalize` 去掉 `excludingWebP` 重载,统一为单一入口 `normalize(_:)`。
- `encodeSmallest` / `encodeSmallestLossy` 不再根据 WebP 排除分支,WebP 无条件参与竞争。
- `ImageNormalizationOptions` 去掉 `excludeWebP` 字段。
- 删除相关的过时测试(`excludesWebP`、`webPEnvironmentFlag`)以及 README 中关于 `KWWK_NO_WEBP` 的说明。

## 测试

- `swift test --filter ImageNormalizer` 全部通过(11 tests)。
- 全仓 `grep` 确认无 `KWWK_NO_WEBP` / `excludingWebP` / `excludeWebP` / `excludesWebP` 残留引用。

> 注:此改动与 #79(后台通知渲染修复)相互独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)