### PR TITLE
chore(models): refresh bundled catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -1189,6 +1189,326 @@
       "input" : 0,
       "output" : 0
     },
+    "id" : "claude-opus-5-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-high-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-low-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Medium",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-medium-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Medium Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Thinking",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-high-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Thinking Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Low Thinking",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-low-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Low Thinking Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-max",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Max Thinking",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-max-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Max Thinking Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Medium Thinking",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-medium-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Medium Thinking Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-xhigh",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Extra High Thinking",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-opus-5-thinking-xhigh-fast",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Opus 5 1M Extra High Thinking Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
     "id" : "claude-sonnet-5-high",
     "input" : [
       "text",

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -107,6 +107,9 @@
     "anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -147,6 +150,9 @@
     "anthropic.claude-opus-4-5-20251101-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -167,6 +173,9 @@
     "anthropic.claude-opus-4-6-v1" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -238,6 +247,9 @@
     "anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -258,6 +270,9 @@
     "anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -281,6 +296,9 @@
     "anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -305,6 +323,9 @@
     "au.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -325,6 +346,9 @@
     "au.anthropic.claude-opus-4-6-v1" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 1.65,
@@ -369,9 +393,36 @@
         "xhigh" : "xhigh"
       }
     },
+    "au.anthropic.claude-opus-5" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "au.anthropic.claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (AU)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "au.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -392,6 +443,9 @@
     "au.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.33,
@@ -415,6 +469,9 @@
     "au.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -458,6 +515,9 @@
     "deepseek.v3-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 163840,
       "cost" : {
         "cacheRead" : 0,
@@ -477,6 +537,9 @@
     "deepseek.v3.2" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 163840,
       "cost" : {
         "cacheRead" : 0,
@@ -521,6 +584,9 @@
     "eu.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.11,
@@ -541,6 +607,9 @@
     "eu.anthropic.claude-opus-4-5-20251101-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.55,
@@ -561,6 +630,9 @@
     "eu.anthropic.claude-opus-4-6-v1" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.55,
@@ -629,9 +701,36 @@
         "xhigh" : "xhigh"
       }
     },
+    "eu.anthropic.claude-opus-5" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.55,
+        "cacheWrite" : 6.875,
+        "input" : 5.5,
+        "output" : 27.5
+      },
+      "id" : "eu.anthropic.claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (EU)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.33,
@@ -652,6 +751,9 @@
     "eu.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.33,
@@ -675,6 +777,9 @@
     "eu.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.eu-central-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.22,
@@ -724,6 +829,9 @@
     "global.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -744,6 +852,9 @@
     "global.anthropic.claude-opus-4-5-20251101-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -764,6 +875,9 @@
     "global.anthropic.claude-opus-4-6-v1" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -832,9 +946,36 @@
         "xhigh" : "xhigh"
       }
     },
+    "global.anthropic.claude-opus-5" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "global.anthropic.claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -855,6 +996,9 @@
     "global.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -878,6 +1022,9 @@
     "global.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -922,6 +1069,9 @@
     "google.gemma-3-27b-it" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 202752,
       "cost" : {
         "cacheRead" : 0,
@@ -942,6 +1092,9 @@
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -1007,9 +1160,36 @@
         "xhigh" : "xhigh"
       }
     },
+    "jp.anthropic.claude-opus-5" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "jp.anthropic.claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (JP)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -1030,6 +1210,9 @@
     "jp.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -1053,6 +1236,9 @@
     "jp.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -1231,6 +1417,9 @@
     "mistral.devstral-2-123b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0,
@@ -1250,6 +1439,9 @@
     "mistral.magistral-small-2509" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1270,6 +1462,9 @@
     "mistral.ministral-3-3b-instruct" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0,
@@ -1290,6 +1485,9 @@
     "mistral.ministral-3-8b-instruct" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1309,6 +1507,9 @@
     "mistral.ministral-3-14b-instruct" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1328,6 +1529,9 @@
     "mistral.mistral-large-3-675b-instruct" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 256000,
       "cost" : {
         "cacheRead" : 0,
@@ -1368,6 +1572,9 @@
     "mistral.voxtral-mini-3b-2507" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1387,6 +1594,9 @@
     "mistral.voxtral-small-24b-2507" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 32000,
       "cost" : {
         "cacheRead" : 0,
@@ -1406,6 +1616,9 @@
     "moonshot.kimi-k2-thinking" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262143,
       "cost" : {
         "cacheRead" : 0,
@@ -1425,6 +1638,9 @@
     "moonshotai.kimi-k2.5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262143,
       "cost" : {
         "cacheRead" : 0,
@@ -1445,6 +1661,9 @@
     "nvidia.nemotron-nano-3-30b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1464,6 +1683,9 @@
     "nvidia.nemotron-nano-9b-v2" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1483,6 +1705,9 @@
     "nvidia.nemotron-nano-12b-v2" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1503,6 +1728,9 @@
     "nvidia.nemotron-super-3-120b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
@@ -1522,6 +1750,9 @@
     "openai.gpt-5.4" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.275,
@@ -1545,6 +1776,9 @@
     "openai.gpt-5.5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.55,
@@ -1568,6 +1802,9 @@
     "openai.gpt-5.6-luna" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -1591,6 +1828,9 @@
     "openai.gpt-5.6-sol" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -1614,6 +1854,9 @@
     "openai.gpt-5.6-terra" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 272000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -1637,6 +1880,9 @@
     "openai.gpt-oss-20b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1656,6 +1902,9 @@
     "openai.gpt-oss-20b-1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1675,6 +1924,9 @@
     "openai.gpt-oss-120b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1694,6 +1946,9 @@
     "openai.gpt-oss-120b-1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1713,6 +1968,9 @@
     "openai.gpt-oss-safeguard-20b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1732,6 +1990,9 @@
     "openai.gpt-oss-safeguard-120b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -1751,6 +2012,9 @@
     "qwen.qwen3-32b-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 16384,
       "cost" : {
         "cacheRead" : 0,
@@ -1770,6 +2034,9 @@
     "qwen.qwen3-235b-a22b-2507-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
@@ -1789,6 +2056,9 @@
     "qwen.qwen3-coder-30b-a3b-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
@@ -1808,6 +2078,9 @@
     "qwen.qwen3-coder-480b-a35b-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
@@ -1827,6 +2100,9 @@
     "qwen.qwen3-coder-next" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
@@ -1846,6 +2122,9 @@
     "qwen.qwen3-next-80b-a3b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262000,
       "cost" : {
         "cacheRead" : 0,
@@ -1865,6 +2144,9 @@
     "qwen.qwen3-vl-235b-a22b" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 262000,
       "cost" : {
         "cacheRead" : 0,
@@ -1910,6 +2192,9 @@
     "us.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -1950,6 +2235,9 @@
     "us.anthropic.claude-opus-4-5-20251101-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -1970,6 +2258,9 @@
     "us.anthropic.claude-opus-4-6-v1" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -2038,9 +2329,36 @@
         "xhigh" : "xhigh"
       }
     },
+    "us.anthropic.claude-opus-5" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "us.anthropic.claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (US)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -2061,6 +2379,9 @@
     "us.anthropic.claude-sonnet-4-6" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -2084,6 +2405,9 @@
     "us.anthropic.claude-sonnet-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -2205,6 +2529,9 @@
     "xai.grok-4.3" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.2,
@@ -2225,6 +2552,9 @@
     "zai.glm-4.7" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 204800,
       "cost" : {
         "cacheRead" : 0,
@@ -2244,6 +2574,9 @@
     "zai.glm-4.7-flash" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0,
@@ -2263,6 +2596,9 @@
     "zai.glm-5" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 202752,
       "cost" : {
         "cacheRead" : 0,
@@ -2376,7 +2712,8 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
-        "forceAdaptiveThinking" : true
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -2403,6 +2740,9 @@
     "claude-haiku-4-5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -2423,6 +2763,9 @@
     "claude-haiku-4-5-20251001" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -2443,6 +2786,9 @@
     "claude-opus-4-1" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 1.5,
@@ -2463,6 +2809,9 @@
     "claude-opus-4-1-20250805" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 1.5,
@@ -2483,6 +2832,9 @@
     "claude-opus-4-5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -2503,6 +2855,9 @@
     "claude-opus-4-5-20251101" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -2524,7 +2879,8 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
-        "forceAdaptiveThinking" : true
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -2551,6 +2907,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
         "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true,
         "supportsTemperature" : false
       },
       "contextWindow" : 1000000,
@@ -2579,6 +2936,7 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
         "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true,
         "supportsTemperature" : false
       },
       "contextWindow" : 1000000,
@@ -2602,9 +2960,41 @@
         "xhigh" : "xhigh"
       }
     },
+    "claude-opus-5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5",
+      "provider" : "anthropic",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "claude-sonnet-4-5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -2625,6 +3015,9 @@
     "claude-sonnet-4-5-20250929" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "supportsStrictTools" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
@@ -2646,7 +3039,8 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
-        "forceAdaptiveThinking" : true
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -2672,7 +3066,8 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
-        "forceAdaptiveThinking" : true
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -2899,6 +3294,9 @@
     "gpt-5" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -2922,6 +3320,9 @@
     "gpt-5-chat-latest" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -2942,32 +3343,12 @@
         "off" : null
       }
     },
-    "gpt-5-codex" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5-Codex",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
     "gpt-5-mini" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
@@ -2991,6 +3372,9 @@
     "gpt-5-nano" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.0050000000000000001,
@@ -3014,6 +3398,9 @@
     "gpt-5-pro" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0,
@@ -3037,6 +3424,9 @@
     "gpt-5.1" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -3057,101 +3447,12 @@
         "off" : null
       }
     },
-    "gpt-5.1-chat-latest" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-chat-latest",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.1 Chat",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex-max" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-codex-max",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex Max",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gpt-5.1-codex-mini" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 2
-      },
-      "id" : "gpt-5.1-codex-mini",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex mini",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
     "gpt-5.2" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -3176,6 +3477,9 @@
     "gpt-5.2-chat-latest" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -3197,33 +3501,12 @@
         "xhigh" : "xhigh"
       }
     },
-    "gpt-5.2-codex" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.2-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.2 Codex",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
     "gpt-5.2-pro" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0,
@@ -3248,6 +3531,9 @@
     "gpt-5.3-chat-latest" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -3272,6 +3558,9 @@
     "gpt-5.3-codex" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -3296,6 +3585,9 @@
     "gpt-5.3-codex-spark" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -3320,6 +3612,9 @@
     "gpt-5.4" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -3344,6 +3639,9 @@
     "gpt-5.4-mini" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.074999999999999997,
@@ -3368,6 +3666,9 @@
     "gpt-5.4-nano" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.02,
@@ -3392,6 +3693,9 @@
     "gpt-5.4-pro" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0,
@@ -3416,6 +3720,9 @@
     "gpt-5.5" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -3440,6 +3747,9 @@
     "gpt-5.5-pro" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0,
@@ -3466,6 +3776,9 @@
     "gpt-5.6-luna" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -3491,6 +3804,9 @@
     "gpt-5.6-sol" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -3516,6 +3832,9 @@
     "gpt-5.6-terra" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -3618,26 +3937,6 @@
       "provider" : "azure-openai-responses",
       "reasoning" : true
     },
-    "o3-deep-research" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 2.5,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 40
-      },
-      "id" : "o3-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o3-deep-research",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true
-    },
     "o3-mini" : {
       "api" : "azure-openai-responses",
       "baseUrl" : "",
@@ -3694,26 +3993,6 @@
       ],
       "maxTokens" : 100000,
       "name" : "o4-mini",
-      "provider" : "azure-openai-responses",
-      "reasoning" : true
-    },
-    "o4-mini-deep-research" : {
-      "api" : "azure-openai-responses",
-      "baseUrl" : "",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
-      },
-      "id" : "o4-mini-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o4-mini-deep-research",
       "provider" : "azure-openai-responses",
       "reasoning" : true
     }
@@ -4162,6 +4441,35 @@
         "xhigh" : "xhigh"
       }
     },
+    "claude-opus-5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "sendSessionAffinityHeaders" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "claude-sonnet-4" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
@@ -4345,6 +4653,9 @@
     "gpt-5.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.13,
@@ -4374,6 +4685,9 @@
     "gpt-5.1-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -4403,6 +4717,9 @@
     "gpt-5.2" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -4432,6 +4749,9 @@
     "gpt-5.2-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -4461,6 +4781,9 @@
     "gpt-5.3-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -4490,6 +4813,9 @@
     "gpt-5.4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -4519,6 +4845,9 @@
     "gpt-5.5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -4548,6 +4877,9 @@
     "gpt-5.6-luna" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -4577,6 +4909,9 @@
     "gpt-5.6-sol" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -4606,6 +4941,9 @@
     "gpt-5.6-terra" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -5632,7 +5970,8 @@
       },
       "id" : "accounts\/fireworks\/models\/minimax-m3",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 512000,
       "name" : "MiniMax-M3",
@@ -5995,6 +6334,40 @@
         "xhigh" : "xhigh"
       }
     },
+    "claude-opus-5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "headers" : {
+        "Copilot-Integration-Id" : "vscode-chat",
+        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
+        "Editor-Version" : "vscode\/1.107.0",
+        "User-Agent" : "GitHubCopilotChat\/0.35.0"
+      },
+      "id" : "claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Claude Opus 5",
+      "provider" : "github-copilot",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "claude-sonnet-4" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
@@ -6286,6 +6659,9 @@
     "gpt-5-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 264000,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
@@ -6321,6 +6697,9 @@
     "gpt-5.2" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -6352,6 +6731,9 @@
     "gpt-5.2-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -6383,6 +6765,9 @@
     "gpt-5.3-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -6418,6 +6803,9 @@
     "gpt-5.4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -6462,6 +6850,9 @@
     "gpt-5.4-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.074999999999999997,
@@ -6497,6 +6888,9 @@
     "gpt-5.4-nano" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.02,
@@ -6528,6 +6922,9 @@
     "gpt-5.5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -6572,6 +6969,9 @@
     "gpt-5.6-luna" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.1,
@@ -6616,6 +7016,9 @@
     "gpt-5.6-sol" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -6660,6 +7063,9 @@
     "gpt-5.6-terra" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -6768,6 +7174,46 @@
     }
   },
   "google" : {
+    "deep-research-max-preview-04-2026" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 12
+      },
+      "id" : "deep-research-max-preview-04-2026",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Deep Research Max Preview (Apr-21-2026)",
+      "provider" : "google",
+      "reasoning" : true
+    },
+    "deep-research-preview-04-2026" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 12
+      },
+      "id" : "deep-research-preview-04-2026",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Deep Research Preview (Apr-21-2026)",
+      "provider" : "google",
+      "reasoning" : true
+    },
     "gemini-2.0-flash" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -6807,6 +7253,26 @@
       "name" : "Gemini 2.0 Flash-Lite",
       "provider" : "google",
       "reasoning" : false
+    },
+    "gemini-2.5-computer-use-preview-10-2025" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 10
+      },
+      "id" : "gemini-2.5-computer-use-preview-10-2025",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 2.5 Computer Use Preview 10-2025",
+      "provider" : "google",
+      "reasoning" : true
     },
     "gemini-2.5-flash" : {
       "api" : "google-generative-ai",
@@ -6941,6 +7407,29 @@
         "off" : null
       }
     },
+    "gemini-3.1-flash-lite-image" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 65536,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 30
+      },
+      "id" : "gemini-3.1-flash-lite-image",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Nano Banana 2 Lite",
+      "provider" : "google",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
     "gemini-3.1-flash-lite-preview" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -6958,6 +7447,29 @@
       ],
       "maxTokens" : 65536,
       "name" : "Gemini 3.1 Flash Lite Preview",
+      "provider" : "google",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
+    "gemini-3.1-flash-live-preview" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 4.5
+      },
+      "id" : "gemini-3.1-flash-live-preview",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.1 Flash Live Preview",
       "provider" : "google",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -7132,6 +7644,26 @@
       "thinkingLevelMap" : {
         "off" : null
       }
+    },
+    "gemini-robotics-er-1.6-preview" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 5
+      },
+      "id" : "gemini-robotics-er-1.6-preview",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini Robotics-ER 1.6 Preview",
+      "provider" : "google",
+      "reasoning" : true
     },
     "gemma-4-26b-a4b-it" : {
       "api" : "google-generative-ai",
@@ -8854,6 +9386,41 @@
         "xhigh" : null
       }
     },
+    "k3-256k" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.kimi.com\/coding",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "User-Agent" : "KimiCLI\/1.5"
+      },
+      "id" : "k3-256k",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Kimi K3-256K",
+      "provider" : "kimi-coding",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "kimi-for-coding" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.kimi.com\/coding",
@@ -10385,68 +10952,6 @@
       "provider" : "nvidia",
       "reasoning" : true
     },
-    "mistralai\/mistral-large-3-675b-instruct-2512" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "mistralai\/mistral-large-3-675b-instruct-2512",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 262144,
-      "name" : "Mistral Large 3 675B Instruct 2512",
-      "provider" : "nvidia",
-      "reasoning" : false
-    },
-    "mistralai\/mistral-small-4-119b-2603" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "mistralai\/mistral-small-4-119b-2603",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "mistral-small-4-119b-2603",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
     "moonshotai\/kimi-k2.6" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -10689,36 +11194,6 @@
       "provider" : "nvidia",
       "reasoning" : true
     },
-    "stepfun-ai\/step-3.5-flash" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "stepfun-ai\/step-3.5-flash",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Step 3.5 Flash",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
     "stepfun-ai\/step-3.7-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -10785,6 +11260,9 @@
     "gpt-4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 8192,
       "cost" : {
         "cacheRead" : 0,
@@ -10804,6 +11282,9 @@
     "gpt-4-turbo" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -10824,6 +11305,9 @@
     "gpt-4.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1047576,
       "cost" : {
         "cacheRead" : 0.5,
@@ -10844,6 +11328,9 @@
     "gpt-4.1-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1047576,
       "cost" : {
         "cacheRead" : 0.1,
@@ -10864,6 +11351,9 @@
     "gpt-4.1-nano" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1047576,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
@@ -10884,6 +11374,9 @@
     "gpt-4o" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 1.25,
@@ -10904,6 +11397,9 @@
     "gpt-4o-2024-05-13" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -10924,6 +11420,9 @@
     "gpt-4o-2024-08-06" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 1.25,
@@ -10944,6 +11443,9 @@
     "gpt-4o-2024-11-20" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 1.25,
@@ -10964,6 +11466,9 @@
     "gpt-4o-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.074999999999999997,
@@ -10984,6 +11489,10 @@
     "gpt-5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -11013,6 +11522,10 @@
     "gpt-5-chat-latest" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -11033,38 +11546,13 @@
         "off" : null
       }
     },
-    "gpt-5-codex" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5-Codex",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "gpt-5-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
@@ -11094,6 +11582,10 @@
     "gpt-5-nano" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.0050000000000000001,
@@ -11123,6 +11615,10 @@
     "gpt-5-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0,
@@ -11152,6 +11648,10 @@
     "gpt-5.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.125,
@@ -11178,125 +11678,13 @@
         "xhigh" : null
       }
     },
-    "gpt-5.1-chat-latest" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-chat-latest",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.1 Chat",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : null,
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "gpt-5.1-codex" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "gpt-5.1-codex-max" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1-codex-max",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex Max",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.1-codex-mini" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 2
-      },
-      "id" : "gpt-5.1-codex-mini",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex mini",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "gpt-5.2" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -11326,6 +11714,10 @@
     "gpt-5.2-chat-latest" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -11352,38 +11744,13 @@
         "xhigh" : "xhigh"
       }
     },
-    "gpt-5.2-codex" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.2-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.2 Codex",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
     "gpt-5.2-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0,
@@ -11413,6 +11780,10 @@
     "gpt-5.3-chat-latest" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -11437,6 +11808,10 @@
     "gpt-5.3-codex" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -11466,6 +11841,10 @@
     "gpt-5.3-codex-spark" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -11496,6 +11875,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -11537,6 +11918,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 400000,
@@ -11568,6 +11951,10 @@
     "gpt-5.4-nano" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 400000,
       "cost" : {
         "cacheRead" : 0.02,
@@ -11598,6 +11985,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 1050000,
@@ -11639,6 +12028,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -11679,6 +12070,10 @@
     "gpt-5.5-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0,
@@ -11718,6 +12113,9 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsExplicitPromptCacheMode" : true,
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -11759,6 +12157,9 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsExplicitPromptCacheMode" : true,
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -11800,6 +12201,9 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
       "compat" : {
+        "supportsExplicitPromptCacheMode" : true,
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -11840,6 +12244,9 @@
     "gpt-realtime-2.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.4,
@@ -11869,6 +12276,9 @@
     "o1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 7.5,
@@ -11898,6 +12308,9 @@
     "o1-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0,
@@ -11927,6 +12340,9 @@
     "o3" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -11953,38 +12369,12 @@
         "xhigh" : null
       }
     },
-    "o3-deep-research" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 2.5,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 40
-      },
-      "id" : "o3-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o3-deep-research",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : null,
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "o3-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.55,
@@ -12013,6 +12403,9 @@
     "o3-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0,
@@ -12042,6 +12435,9 @@
     "o4-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.openai.com\/v1",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.275,
@@ -12067,41 +12463,15 @@
         "off" : null,
         "xhigh" : null
       }
-    },
-    "o4-mini-deep-research" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/api.openai.com\/v1",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
-      },
-      "id" : "o4-mini-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o4-mini-deep-research",
-      "provider" : "openai",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : null,
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
     }
   },
   "openai-codex" : {
     "gpt-5.3-codex-spark" : {
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.175,
@@ -12126,6 +12496,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12162,6 +12533,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12189,6 +12561,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12225,6 +12598,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12262,6 +12636,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12299,6 +12674,7 @@
       "api" : "openai-codex-responses",
       "baseUrl" : "https:\/\/chatgpt.com\/backend-api",
       "compat" : {
+        "supportsOpenAIGrammarTools" : true,
         "supportsToolSearch" : true
       },
       "contextWindow" : 272000,
@@ -12521,6 +12897,34 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 4.8",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "claude-opus-5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5",
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -12929,7 +13333,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -12961,7 +13366,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -12993,7 +13399,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13025,7 +13432,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13057,7 +13465,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13089,7 +13498,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13121,7 +13531,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13153,7 +13564,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13185,7 +13597,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13217,7 +13630,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13249,7 +13663,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 272000,
       "cost" : {
@@ -13281,7 +13696,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13313,7 +13729,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -13345,7 +13762,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13377,7 +13795,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13409,7 +13828,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13441,7 +13861,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13473,7 +13894,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13505,7 +13927,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
-        "sessionAffinityFormat" : "openai-nosession"
+        "sessionAffinityFormat" : "openai-nosession",
+        "supportsOpenAIGrammarTools" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -13697,6 +14120,39 @@
       ],
       "maxTokens" : 32000,
       "name" : "Laguna S 2.1 Free",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "ling-3.0-flash-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "ling-3.0-flash-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Ling-3.0-flash Free",
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -15090,6 +15546,62 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic\/claude-opus-5" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "cacheControlFormat" : "anthropic",
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "anthropic\/claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-5-fast" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "cacheControlFormat" : "anthropic",
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 1,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-opus-5-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (Fast)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic\/claude-sonnet-4" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -15204,14 +15716,14 @@
       "cost" : {
         "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 0.8
+        "input" : 0.22,
+        "output" : 0.85
       },
       "id" : "arcee-ai\/trinity-large-thinking",
       "input" : [
         "text"
       ],
-      "maxTokens" : 80000,
+      "maxTokens" : 262144,
       "name" : "Arcee AI: Trinity Large Thinking",
       "provider" : "openrouter",
       "reasoning" : true
@@ -15620,18 +16132,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048575,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.019599999999999999,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.098000000000000004,
-        "output" : 0.196
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 393216,
       "name" : "DeepSeek: DeepSeek V4 Flash",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -16043,19 +16555,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 110000,
+      "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.040000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.3
+        "input" : 0.080000000000000002,
+        "output" : 0.45
       },
       "id" : "google\/gemma-3-27b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 131072,
       "name" : "Google: Gemma 3 27B",
       "provider" : "openrouter",
       "reasoning" : false
@@ -16117,10 +16629,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.089999999999999997,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.35
+        "input" : 0.14,
+        "output" : 0.4
       },
       "id" : "google\/gemma-4-31b-it",
       "input" : [
@@ -16250,6 +16762,29 @@
       "name" : "inclusionAI: Ling-2.6-flash",
       "provider" : "openrouter",
       "reasoning" : false
+    },
+    "inclusionai\/ling-3.0-flash:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "inclusionai\/ling-3.0-flash:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Ling-3.0-flash (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "inclusionai\/ring-2.6-1t" : {
       "api" : "openai-completions",
@@ -16539,10 +17074,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 1.2
+        "input" : 0.255,
+        "output" : 1.02
       },
       "id" : "minimax\/minimax-m2",
       "input" : [
@@ -17149,10 +17684,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.144,
+        "cacheRead" : 0.1088,
         "cacheWrite" : 0,
-        "input" : 0.6840000000000001,
-        "output" : 3.42
+        "input" : 0.646,
+        "output" : 2.72
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -17173,10 +17708,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.16,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.82,
-        "output" : 3.75
+        "input" : 0.73,
+        "output" : 3.5
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -17341,14 +17876,14 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.45
+        "input" : 0.085000000000000006,
+        "output" : 0.4
       },
       "id" : "nvidia\/nemotron-3-super-120b-a12b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "NVIDIA: Nemotron 3 Super",
       "provider" : "openrouter",
       "reasoning" : true
@@ -17383,18 +17918,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 512288,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2.2
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 4096,
       "name" : "NVIDIA: Nemotron 3 Ultra",
       "provider" : "openrouter",
       "reasoning" : true
@@ -17978,7 +18513,7 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.125,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
         "input" : 1.25,
         "output" : 10
@@ -18591,10 +19126,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.029999999999999999,
-        "output" : 0.13
+        "output" : 0.14
       },
       "id" : "openai\/gpt-oss-20b",
       "input" : [
@@ -19277,18 +19812,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.13,
-        "output" : 0.52
+        "input" : 0.12,
+        "output" : 0.5
       },
       "id" : "qwen\/qwen3-30b-a3b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19300,18 +19835,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.3
+        "input" : 0.048149999999999998,
+        "output" : 0.19305
       },
       "id" : "qwen\/qwen3-30b-a3b-instruct-2507",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 32000,
       "name" : "Qwen: Qwen3 30B A3B Instruct 2507",
       "provider" : "openrouter",
       "reasoning" : false
@@ -19601,10 +20136,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.070000000000000007,
         "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 1.2
+        "input" : 0.1,
+        "output" : 1.1
       },
       "id" : "qwen\/qwen3-next-80b-a3b-instruct",
       "input" : [
@@ -19841,15 +20376,15 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26,
-        "output" : 2.6
+        "input" : 0.195,
+        "output" : 1.56
       },
       "id" : "qwen\/qwen3.5-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 81920,
+      "maxTokens" : 65536,
       "name" : "Qwen: Qwen3.5-27B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20007,17 +20542,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.12,
+        "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.6,
-        "output" : 3.6
+        "input" : 0.3,
+        "output" : 2
       },
       "id" : "qwen\/qwen3.6-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 65536,
       "name" : "Qwen: Qwen3.6 27B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20314,16 +20849,16 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.033000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.58
+        "input" : 0.132,
+        "output" : 0.528
       },
       "id" : "tencent\/hy3",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 128000,
       "name" : "Tencent: Hy3",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20805,10 +21340,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14196,
+        "cacheRead" : 0.12428,
         "cacheWrite" : 0,
-        "input" : 0.7644,
-        "output" : 2.4024
+        "input" : 0.6692,
+        "output" : 2.1032
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
@@ -21028,7 +21563,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 98304,
       "name" : "Kimi K2.5",
       "provider" : "qwen-token-plan",
       "reasoning" : true
@@ -21053,7 +21588,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 262144,
       "name" : "Kimi K2.6",
       "provider" : "qwen-token-plan",
       "reasoning" : true
@@ -21102,7 +21637,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 24576,
+      "maxTokens" : 32768,
       "name" : "MiniMax-M2.5",
       "provider" : "qwen-token-plan",
       "reasoning" : true
@@ -21176,7 +21711,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 131072,
       "name" : "Qwen3.7 Max",
       "provider" : "qwen-token-plan",
       "reasoning" : true
@@ -21201,7 +21736,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 64000,
+      "maxTokens" : 65536,
       "name" : "Qwen3.7 Plus",
       "provider" : "qwen-token-plan",
       "reasoning" : true
@@ -21413,7 +21948,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 98304,
       "name" : "Kimi K2.5",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
@@ -21438,7 +21973,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 262144,
       "name" : "Kimi K2.6",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
@@ -21487,7 +22022,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 24576,
+      "maxTokens" : 32768,
       "name" : "MiniMax-M2.5",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
@@ -21561,7 +22096,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 131072,
       "name" : "Qwen3.7 Max",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
@@ -21586,7 +22121,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 64000,
+      "maxTokens" : 65536,
       "name" : "Qwen3.7 Plus",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
@@ -22579,10 +23114,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 991000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 1.5625,
-        "input" : 1.25,
-        "output" : 3.75
+        "cacheRead" : 0.5,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 7.5
       },
       "id" : "alibaba\/qwen3.7-max",
       "input" : [
@@ -22874,34 +23409,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "anthropic\/claude-opus-4.7-fast" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "compat" : {
-        "forceAdaptiveThinking" : true,
-        "supportsTemperature" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 3,
-        "cacheWrite" : 37.5,
-        "input" : 30,
-        "output" : 150
-      },
-      "id" : "anthropic\/claude-opus-4.7-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Claude Opus 4.7 (Fast)",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "max" : "max",
-        "xhigh" : "xhigh"
-      }
-    },
     "anthropic\/claude-opus-4.8" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -22951,6 +23458,62 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 4.8 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "anthropic\/claude-opus-5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-opus-5-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 1,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-opus-5-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -23365,10 +23928,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.089999999999999997,
+        "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.9,
-        "output" : 5.4
+        "input" : 0.5,
+        "output" : 3
       },
       "id" : "google\/gemini-3-flash",
       "input" : [
@@ -23417,26 +23980,6 @@
       ],
       "maxTokens" : 65000,
       "name" : "Gemini 3.1 Flash Lite",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "google\/gemini-3.1-flash-lite-preview" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 1.5
-      },
-      "id" : "google\/gemini-3.1-flash-lite-preview",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65000,
-      "name" : "Gemini 3.1 Flash Lite Preview",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -23597,6 +24140,25 @@
       "name" : "Mercury Coder Small Beta",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
+    },
+    "inclusionai\/ling-3.0-flash-free" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "inclusionai\/ling-3.0-flash-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 256000,
+      "name" : "Ling 3.0 Flash",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
     },
     "interfaze\/interfaze-beta" : {
       "api" : "anthropic-messages",
@@ -24632,26 +25194,6 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
-    "openai\/gpt-5-chat" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "openai\/gpt-5-chat",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT 5 Chat",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
     "openai\/gpt-5-codex" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -24855,29 +25397,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "openai\/gpt-5.2-chat" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "openai\/gpt-5.2-chat",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT 5.2 Chat",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false,
-      "thinkingLevelMap" : {
-        "xhigh" : "xhigh"
-      }
-    },
     "openai\/gpt-5.2-codex" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -24975,10 +25494,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 30
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "openai\/gpt-5.4",
       "input" : [
@@ -25067,10 +25586,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1.25,
+        "cacheRead" : 0.5,
         "cacheWrite" : 0,
-        "input" : 12.5,
-        "output" : 75
+        "input" : 5,
+        "output" : 30
       },
       "id" : "openai\/gpt-5.5",
       "input" : [
@@ -25092,8 +25611,8 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 15,
-        "output" : 90
+        "input" : 30,
+        "output" : 180
       },
       "id" : "openai\/gpt-5.5-pro",
       "input" : [
@@ -25116,10 +25635,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.2,
+        "cacheRead" : 0.1,
         "cacheWrite" : 1.25,
-        "input" : 2,
-        "output" : 12
+        "input" : 1,
+        "output" : 6
       },
       "id" : "openai\/gpt-5.6-luna",
       "input" : [
@@ -25139,10 +25658,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 1,
+        "cacheRead" : 0.5,
         "cacheWrite" : 6.25,
-        "input" : 10,
-        "output" : 60
+        "input" : 5,
+        "output" : 30
       },
       "id" : "openai\/gpt-5.6-sol",
       "input" : [
@@ -25162,10 +25681,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.25,
         "cacheWrite" : 3.125,
-        "input" : 5,
-        "output" : 30
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "openai\/gpt-5.6-terra",
       "input" : [


### PR DESCRIPTION
## Summary

- Refresh the regular catalog from authoritative badlogic/pi-mono `main` commit `cee5ff7520d8828bed9955ef00419e995d1f91e0`.
- Regular catalog remains 1,108 models across 37 providers: 23 additions, 23 removals, and 229 metadata updates. Additions include Claude Opus 5 across supported providers, new Google previews, Kimi K3, and Ling 3.0; removals are superseded OpenAI/Azure, NVIDIA, and Vercel entries. Metadata changes are primarily compatibility flags, pricing, and token limits.
- Refresh Cursor GetUsableModels catalog to 184 models: 16 Claude Opus 5 variants added, 0 removed, 0 existing entries changed.

## Validation

- `jq empty` on both JSON files
- `git diff --check`
- private/localhost endpoint and credential-pattern scans
- focused catalog/Cursor tests: 35 tests in 6 suites
- full `swift test`: 1,311 tests in 194 suites