### PR TITLE
chore(models): refresh bundled catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -1807,10 +1807,10 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.021999999999999999,
+        "cacheWrite" : 0.275,
+        "input" : 0.22,
+        "output" : 1.32
       },
       "id" : "openai.gpt-5.6-luna",
       "input" : [
@@ -1833,10 +1833,10 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.55,
+        "cacheWrite" : 6.88,
+        "input" : 5.5,
+        "output" : 33
       },
       "id" : "openai.gpt-5.6-sol",
       "input" : [
@@ -1859,10 +1859,10 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.22,
+        "cacheWrite" : 2.75,
+        "input" : 2.2,
+        "output" : 13.2
       },
       "id" : "openai.gpt-5.6-terra",
       "input" : [
@@ -3781,10 +3781,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "gpt-5.6-luna",
       "input" : [
@@ -3837,10 +3837,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12
       },
       "id" : "gpt-5.6-terra",
       "input" : [
@@ -4882,10 +4882,19 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2,
+        "tiers" : [
+          {
+            "cacheRead" : 0.040000000000000001,
+            "cacheWrite" : 0.5,
+            "input" : 0.4,
+            "inputTokensAbove" : 272000,
+            "output" : 1.8
+          }
+        ]
       },
       "id" : "gpt-5.6-luna",
       "input" : [
@@ -4946,10 +4955,19 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12,
+        "tiers" : [
+          {
+            "cacheRead" : 0.4,
+            "cacheWrite" : 5,
+            "input" : 4,
+            "inputTokensAbove" : 272000,
+            "output" : 18
+          }
+        ]
       },
       "id" : "gpt-5.6-terra",
       "input" : [
@@ -9100,6 +9118,69 @@
         "xhigh" : null
       }
     },
+    "tencent\/Hy3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.14,
+        "output" : 0.58
+      },
+      "id" : "tencent\/Hy3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Hy3",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "thinkingmachines\/Inkling" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 4.05
+      },
+      "id" : "thinkingmachines\/Inkling",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "Inkling",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "XiaomiMiMo\/MiMo-V2-Flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -12582,17 +12663,17 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6,
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2,
         "tiers" : [
           {
-            "cacheRead" : 0.2,
-            "cacheWrite" : 2.5,
-            "input" : 2,
+            "cacheRead" : 0.040000000000000001,
+            "cacheWrite" : 0.5,
+            "input" : 0.4,
             "inputTokensAbove" : 272000,
-            "output" : 9
+            "output" : 1.8
           }
         ]
       },
@@ -12670,17 +12751,17 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15,
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12,
         "tiers" : [
           {
-            "cacheRead" : 0.5,
-            "cacheWrite" : 6.25,
-            "input" : 5,
+            "cacheRead" : 0.4,
+            "cacheWrite" : 5,
+            "input" : 4,
             "inputTokensAbove" : 272000,
-            "output" : 22.5
+            "output" : 18
           }
         ]
       },
@@ -13065,17 +13146,17 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6,
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2,
         "tiers" : [
           {
-            "cacheRead" : 0.2,
-            "cacheWrite" : 2.5,
-            "input" : 2,
+            "cacheRead" : 0.040000000000000001,
+            "cacheWrite" : 0.5,
+            "input" : 0.4,
             "inputTokensAbove" : 272000,
-            "output" : 9
+            "output" : 1.8
           }
         ]
       },
@@ -13141,17 +13222,17 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15,
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12,
         "tiers" : [
           {
-            "cacheRead" : 0.5,
-            "cacheWrite" : 6.25,
-            "input" : 5,
+            "cacheRead" : 0.4,
+            "cacheWrite" : 5,
+            "input" : 4,
             "inputTokensAbove" : 272000,
-            "output" : 22.5
+            "output" : 18
           }
         ]
       },
@@ -15459,7 +15540,7 @@
         "cacheRead" : 0.29,
         "cacheWrite" : 0,
         "input" : 2.9,
-        "output" : 15
+        "output" : 14
       },
       "id" : "~moonshotai\/kimi-latest",
       "input" : [
@@ -18656,10 +18737,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.1088,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.646,
-        "output" : 2.72
+        "input" : 0.95,
+        "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -18776,7 +18857,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.029999999999999999,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
         "output" : 0.2
@@ -18785,7 +18866,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 228000,
+      "maxTokens" : 262144,
       "name" : "NVIDIA: Nemotron 3 Nano 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19336,29 +19417,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/gpt-5-codex" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "openai\/gpt-5-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 Codex",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -20091,10 +20149,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0.625,
-        "input" : 0.5,
-        "output" : 3
+        "cacheRead" : 0.01,
+        "cacheWrite" : 0.125,
+        "input" : 0.1,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-5.6-luna",
       "input" : [
@@ -20118,10 +20176,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0.625,
-        "input" : 0.5,
-        "output" : 3
+        "cacheRead" : 0.01,
+        "cacheWrite" : 0.125,
+        "input" : 0.1,
+        "output" : 0.6
       },
       "id" : "openai\/gpt-5.6-luna-pro",
       "input" : [
@@ -20199,10 +20257,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 1.5625,
-        "input" : 1.25,
-        "output" : 7.5
+        "cacheRead" : 0.1,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
       },
       "id" : "openai\/gpt-5.6-terra",
       "input" : [
@@ -20226,10 +20284,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 1.5625,
-        "input" : 1.25,
-        "output" : 7.5
+        "cacheRead" : 0.1,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 6
       },
       "id" : "openai\/gpt-5.6-terra-pro",
       "input" : [
@@ -20446,29 +20504,6 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "openai\/o3-deep-research" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 2.5,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 40
-      },
-      "id" : "openai\/o3-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o3 Deep Research",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
     "openai\/o3-mini" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -20556,29 +20591,6 @@
       ],
       "maxTokens" : 100000,
       "name" : "OpenAI: o4 Mini",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/o4-mini-deep-research" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
-      },
-      "id" : "openai\/o4-mini-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o4 Mini Deep Research",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -20709,10 +20721,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.01,
+        "cacheRead" : 0.0089999999999999993,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.2
+        "input" : 0.089999999999999997,
+        "output" : 0.18
       },
       "id" : "poolside\/laguna-s-2.1",
       "input" : [
@@ -21102,14 +21114,14 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 3
+        "input" : 0.23,
+        "output" : 2.3
       },
       "id" : "qwen\/qwen3-235b-a22b-thinking-2507",
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 4096,
       "name" : "Qwen: Qwen3 235B A22B Thinking 2507",
       "provider" : "openrouter",
       "reasoning" : true
@@ -22512,10 +22524,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.11427,
+        "cacheRead" : 0.221,
         "cacheWrite" : 0,
-        "input" : 0.6153,
-        "output" : 1.9338
+        "input" : 1.19,
+        "output" : 3.74
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
@@ -26955,10 +26967,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "openai\/gpt-5.6-luna",
       "input" : [
@@ -27001,10 +27013,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12
       },
       "id" : "openai\/gpt-5.6-terra",
       "input" : [
@@ -27328,6 +27340,26 @@
       ],
       "maxTokens" : 256000,
       "name" : "Inkling",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "thinkingmachines\/inkling-small" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.1,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 1.2
+      },
+      "id" : "thinkingmachines\/inkling-small",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1000000,
+      "name" : "Inkling Small",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },


### PR DESCRIPTION
## Summary

Refresh the bundled model catalogs from their canonical sources.

- Regenerated `models.json` from `badlogic/pi-mono` main at `74caa2649f10ed71b4378ce69f5d9fbfd2466ca5`.
- Added 3 models: `huggingface/tencent/Hy3`, `huggingface/thinkingmachines/Inkling`, and `vercel-ai-gateway/thinkingmachines/inkling-small`.
- Removed 3 OpenRouter models: `openai/gpt-5-codex`, `openai/o3-deep-research`, and `openai/o4-mini-deep-research`.
- Updated pricing, token limits, or tier metadata for 23 existing models.
- Regenerated `cursor-models.json` from Cursor GetUsableModels: 187 models, byte-for-byte unchanged.

Regular catalog count remains 1,153 models across 37 providers. Cursor catalog count remains 187.

## Validation

- Both catalog files parse as JSON with `jq`.
- `git diff --check` passes.
- No localhost/private endpoints or credential patterns found.
- `KWWKAITests.GenerateModelsCoreTests`: 5 passed.
- `KWWKAITests.ModelsCatalogTests`: 8 passed.
- `KWWKAITests.CursorModelRoutingTests`: 2 passed.
- `KWWKAITests.CursorProtoTests`: 13 passed.
- Full `swift test`: 1,311 tests ran; one unrelated background-task ledger test failed with 3 expectations in `ReviewFixesTests.swift:412-417` (`recap message includes a <running-background-tasks> block when tasks are live`). Catalog and Cursor suites passed.