### PR TITLE
Support Swift musl libc imports

### DIFF
--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -4,6 +4,8 @@ import FoundationNetworking
 #endif
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/KWWKAgent/BashBackgroundRunner.swift
+++ b/Sources/KWWKAgent/BashBackgroundRunner.swift
@@ -1,9 +1,11 @@
 import Foundation
 import KWWKAI
-#if os(Linux)
-import Glibc
-#else
+#if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
 #endif
 
 /// `BackgroundTaskRunner` backed by `Process`. Spawns the command with
@@ -258,7 +260,7 @@ struct SpawnedBashProcess: Sendable {
         guard inputFd >= 0 else { throw SpawnError.openDevNull }
         defer { close(inputFd) }
 
-        // Glibc imports these spawn handles as concrete structs, Darwin as
+        // Linux libc modules import these spawn handles as concrete structs, Darwin as
         // optional opaque pointers — declare each per-platform so `&handle`
         // matches the C function's pointee on both.
         #if os(Linux)

--- a/Sources/KWWKAgent/EditTool.swift
+++ b/Sources/KWWKAgent/EditTool.swift
@@ -2,6 +2,8 @@ import Foundation
 import KWWKAI
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -39,7 +41,7 @@ public struct LocalEditOperations: EditOperations {
     }
 }
 
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
 private let editAccessExistsMode: Int32 = F_OK
 private let editAccessReadWriteMode: Int32 = R_OK | W_OK
 #else
@@ -50,6 +52,8 @@ private let editAccessReadWriteMode: Int32 = 6
 private func checkPOSIXAccess(_ absolutePath: String, mode: Int32) throws {
     #if canImport(Darwin)
     let accessResult = Darwin.access(absolutePath, mode)
+    #elseif canImport(Musl)
+    let accessResult = Musl.access(absolutePath, mode)
     #elseif canImport(Glibc)
     let accessResult = Glibc.access(absolutePath, mode)
     #else
@@ -63,6 +67,8 @@ private func checkPOSIXAccess(_ absolutePath: String, mode: Int32) throws {
     #endif
     if accessResult != 0 {
         #if canImport(Darwin)
+        let errorCode = errno
+        #elseif canImport(Musl)
         let errorCode = errno
         #elseif canImport(Glibc)
         let errorCode = errno

--- a/Sources/KWWKAgent/FileMutationQueue.swift
+++ b/Sources/KWWKAgent/FileMutationQueue.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -53,7 +55,7 @@ public actor FileMutationQueue {
         // "../"-relative spellings collapse onto one queue. realpath fails when
         // the final component does not exist yet (a fresh write) — fall back to
         // the normalized absolute path, matching pi's realpathSync fallback.
-        #if canImport(Darwin) || canImport(Glibc)
+        #if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
         if let resolved = realpath(path, nil) {
             defer { free(resolved) }
             return String(cString: resolved)

--- a/Sources/KWWKAgent/PathUtils.swift
+++ b/Sources/KWWKAgent/PathUtils.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -159,6 +161,9 @@ public enum PathUtils {
         #if canImport(Darwin)
         var info = Darwin.stat()
         let result = path.withCString { Darwin.lstat($0, &info) }
+        #elseif canImport(Musl)
+        var info = Musl.stat()
+        let result = path.withCString { Musl.lstat($0, &info) }
         #elseif canImport(Glibc)
         var info = Glibc.stat()
         let result = path.withCString { Glibc.lstat($0, &info) }
@@ -166,7 +171,7 @@ public enum PathUtils {
         let result: Int32 = FileManager.default.fileExists(atPath: path) ? 0 : -1
         #endif
         if result == 0 { return .exists }
-        #if canImport(Darwin) || canImport(Glibc)
+        #if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
         if errno == ENOENT || errno == ENOTDIR { return .missing }
         return .inaccessible
         #else
@@ -187,7 +192,7 @@ public enum PathUtils {
     /// atomic temp-file rename which allocates a new inode and detaches
     /// symlinks/hard links.
     public static func writeFileInPlace(_ path: String, data: Data, createMode: mode_t = 0o644) throws {
-        #if canImport(Darwin) || canImport(Glibc)
+        #if canImport(Darwin) || canImport(Musl) || canImport(Glibc)
         let fd = path.withCString { open($0, O_WRONLY | O_CREAT | O_TRUNC, createMode) }
         if fd < 0 {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)

--- a/Sources/KWWKCli/StdoutTerminal.swift
+++ b/Sources/KWWKCli/StdoutTerminal.swift
@@ -2,7 +2,9 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/KWWKCli/TUIRunner.swift
+++ b/Sources/KWWKCli/TUIRunner.swift
@@ -2,7 +2,9 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.31"
+    static let version = "0.1.32"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The

--- a/Sources/kwwk/main.swift
+++ b/Sources/kwwk/main.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif


### PR DESCRIPTION
Add explicit `Musl` platform imports alongside Darwin and Glibc so KWWK builds with the official Swift Static Linux SDK. Linux `posix_spawn` handle representation remains shared across libc implementations.