### PR TITLE
Fix Swift 6.3 musl ownership compilation

### DIFF
--- a/Sources/KWWKAI/Cursor/CursorAgentMessages.swift
+++ b/Sources/KWWKAI/Cursor/CursorAgentMessages.swift
@@ -620,7 +620,10 @@ enum CursorProto {
             case 2: args.fileText = f.value.asString ?? ""
             case 3: args.toolCallId = f.value.asString ?? ""
             case 4: args.returnFileContentAfterWrite = f.value.asBool ?? false
-            case 5: args.fileBytes = f.value.asData ?? Data()
+            case 5:
+                if let fileBytes = f.value.asData {
+                    args.fileBytes = fileBytes
+                }
             default: break
             }
         }

--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.32"
+    static let version = "0.1.33"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The

--- a/Tests/KWWKAITests/CursorProtoTests.swift
+++ b/Tests/KWWKAITests/CursorProtoTests.swift
@@ -355,6 +355,22 @@ struct CursorExecDecodeTests {
         #expect(args.toolCallId == "call-9")
     }
 
+    @Test("write args decode text and binary content")
+    func writeArgs() {
+        var w = ProtoWriter()
+        w.stringField(1, "/tmp/output.bin")
+        w.stringField(2, "fallback")
+        w.stringField(3, "call-10")
+        w.boolField(4, true)
+        w.bytesField(5, Data([0x00, 0x7F, 0xFF]))
+        let args = CursorProto.decodeWriteArgs(w.data)
+        #expect(args.path == "/tmp/output.bin")
+        #expect(args.fileText == "fallback")
+        #expect(args.toolCallId == "call-10")
+        #expect(args.returnFileContentAfterWrite)
+        #expect(args.fileBytes == Data([0x00, 0x7F, 0xFF]))
+    }
+
     @Test("mcp args decode the raw map into loose JSON")
     func mcpArgs() {
         var w = ProtoWriter()


### PR DESCRIPTION
## Summary
- avoid a Swift 6.3.3 SIL ownership assertion while decoding Cursor write bytes
- cover binary write argument decoding
- bump the CLI version surface to 0.1.33

## Validation
- backend CI will compile this revision with the official Swift 6.3.3 Static Linux SDK
- local test execution was not used because the existing shared module cache was created at a different absolute path