### PR TITLE
Release v0.1.34

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.33"
+    static let version = "0.1.34"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
## Summary
- bump the CLI version surface to 0.1.34
- prepare the latest main model catalog refresh for the v0.1.34 tag

## Validation
- `swift test` (1312 tests passed)
- `swift build -c release --product kwwk`
- `.build/release/kwwk --self-test`