### PR TITLE
Enable background tasks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,33 +142,31 @@ let reviewer = SubagentDefinition(
     model: .inherit
 )
 
-let bg = BackgroundTaskManager()
 let shellEnvironment = ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
 let coding = await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet5,
     cwd: FileManager.default.currentDirectoryPath,
     tools: .standard,
-    backgroundManager: bg,
     subagents: [reviewer],
     bashEnvironment: shellEnvironment
 ))
 
 try await coding.agent.prompt("Use the reviewer subagent to review Sources/KWWKAgent.")
 
-// With a backgroundManager, completed background tasks auto-continue the
-// agent (new LLM runs start on their own). Call `coding.detachBackground?()`
-// to unsubscribe when embedding.
+// A BackgroundTaskManager is created by default. Completed background tasks
+// auto-continue the agent (new LLM runs start on their own). Call
+// `coding.detachBackground?()` to unsubscribe when embedding, or pass
+// `backgroundManager: nil` to disable background execution entirely.
 ```
 
-For the same built-ins that the CLI uses, SDK users can opt in without
-copying prompts:
+SDK users can enable the same built-ins that the CLI uses without copying
+prompts:
 
 ```swift
 let agent = await makeCodingAgent(CodingAgentConfig(
     model: Models.claudeSonnet5,
     cwd: FileManager.default.currentDirectoryPath,
     tools: .standard,
-    backgroundManager: BackgroundTaskManager(),
     bashEnvironment: shellEnvironment
 ).withBuiltinSubagents([.general, .explore, .plan, .codeReviewer, .testRunner])).agent
 ```
@@ -283,14 +281,19 @@ containment for read/grep/find/ls (including `..` and symlink checks). That
 path policy still does not constrain Bash/custom tools and is not an OS-level
 sandbox or a defense against hostile concurrent symlink replacement.
 
-One-shot `kwwk -p` deliberately disables background execution: it does not
-expose the background-task tools or background bash options, and rejects
-background subagent requests instead of exiting after reporting a task as started.
+One-shot `kwwk -p` exposes the same background-task and background Bash
+capabilities while its top-level Agent loop is running. It does not wait for
+background-only work or start a fresh model run after the loop becomes idle:
+when that loop returns, headless teardown retires the Agent, kills unfinished
+tasks, and exits.
 
 When an SDK application is done with an agent session, call
-`await agent.closeSession()` to release provider-owned resources keyed by
-that session id. For OpenAI Responses WebSocket transport, this closes the
-stored WebSocket connection for the session.
+`await agent.closeSession()`. This permanently stops the agent, kills its
+active background tasks, waits for the current run to finish cancelling, and
+releases provider-owned resources keyed by that session id. For OpenAI
+Responses WebSocket transport, this also closes the stored WebSocket
+connection. Use `await agent.stop()` for the same deterministic agent/task
+shutdown without closing provider session resources.
 
 ### Streaming events
 

--- a/Sources/KWWKAgent/Agent+Background.swift
+++ b/Sources/KWWKAgent/Agent+Background.swift
@@ -26,33 +26,36 @@ final class BackgroundAttachment: @unchecked Sendable {
 }
 
 /// Bridges a `BackgroundTaskManager` to an `Agent`: receives notifications and
-/// injects them through the Agent's internal runtime-aside queue, kicking off
-/// a fresh run when the Agent is idle.
+/// injects them through the Agent's internal runtime-aside queue, optionally
+/// kicking off a fresh run when the Agent is idle.
 ///
 /// Delivery strategy:
 ///   - Enqueue the notification as runtime context, separate from the user's
 ///     editable steering queue. A running loop picks it up at the next turn
 ///     boundary automatically.
-///   - If the Agent is not currently streaming when the notification arrives,
-///     kick off `agent.continue()`. If the Agent just started a run in the
-///     meantime, `continue()` throws `alreadyRunning` and we swallow — the
-///     runtime aside is safe in its queue and will be drained next turn.
-///   - After `agentEnd`, wait for the Agent to truly finalize (post
-///     `runLifecycle` teardown), then if the queue still has anything in it,
-///     fire `continue()` once more. This handles the narrow race where a
-///     notification arrives during final teardown.
+///   - When idle auto-continue is enabled and the Agent is not streaming, kick
+///     off `agent.continue()`. If the Agent just started a run in the meantime,
+///     `continue()` throws `alreadyRunning` and we swallow — the runtime aside
+///     is safe in its queue and will be drained next turn.
+///   - With the same option enabled, after `agentEnd` wait for the Agent to
+///     truly finalize (post `runLifecycle` teardown), then fire `continue()` if
+///     the queue still has anything in it. This handles the narrow race where
+///     a notification arrives during final teardown.
 final class BackgroundAgentBridge: @unchecked Sendable {
     let id: UUID
     weak var agent: Agent?
     let sessionId: String?
+    let autoContinueWhenIdle: Bool
 
-    init(agent: Agent, sessionId: String?) {
+    init(agent: Agent, sessionId: String?, autoContinueWhenIdle: Bool) {
         self.id = UUID()
         self.agent = agent
         self.sessionId = sessionId
+        self.autoContinueWhenIdle = autoContinueWhenIdle
     }
 
     func onDeliveryAvailable() {
+        guard autoContinueWhenIdle else { return }
         guard let agent else { return }
         // Always install an idle waiter. This also covers the teardown sliver
         // after Agent.continue drained an empty mailbox but before it publishes
@@ -66,6 +69,7 @@ final class BackgroundAgentBridge: @unchecked Sendable {
     }
 
     func onAgentEvent(_ event: AgentEvent) async {
+        guard autoContinueWhenIdle else { return }
         guard case .agentEnd = event else { return }
         let ref = agent
         Task { [weak ref] in
@@ -83,18 +87,23 @@ final class BackgroundAgentBridge: @unchecked Sendable {
 extension Agent {
     /// Attach a `BackgroundTaskManager`. Notifications from the manager are
     /// injected into this agent as internal runtime asides (drained at a turn
-    /// boundary; fresh `continue()` when idle).
+    /// boundary; fresh `continue()` when idle if enabled).
     ///
     /// Passing a `sessionId` scopes both notification delivery AND the
     /// `abortAndKillBackgroundTasks` sweep: only tasks spawned with the same
     /// sessionId are killed.
+    ///
+    /// Set `autoContinueWhenIdle` to `false` for one-shot hosts that retain the
+    /// background tool interface but must not let completion notifications
+    /// extend the top-level run lifetime.
     ///
     /// Returns an async unsubscribe handle. Safe to call multiple times with
     /// different managers.
     public func attachBackgroundManager(
         _ manager: BackgroundTaskManager,
         sessionId: String? = nil,
-        deliveryConsumer explicitConsumer: BackgroundTaskDeliveryConsumer? = nil
+        deliveryConsumer explicitConsumer: BackgroundTaskDeliveryConsumer? = nil,
+        autoContinueWhenIdle: Bool = true
     ) async -> @Sendable () async -> Void {
         // An explicit mailbox is reusable only when its scope exactly matches
         // the attachment. Accepting a broader/narrower consumer here would let
@@ -108,7 +117,11 @@ extension Agent {
                 return tool.backgroundDeliveryConsumer
             }.first(where: { $0.sessionId == sessionId })
             ?? BackgroundTaskDeliveryConsumer(sessionId: sessionId)
-        let bridge = BackgroundAgentBridge(agent: self, sessionId: sessionId)
+        let bridge = BackgroundAgentBridge(
+            agent: self,
+            sessionId: sessionId,
+            autoContinueWhenIdle: autoContinueWhenIdle
+        )
         let attachment = BackgroundAttachment(
             manager: manager,
             sessionId: sessionId,

--- a/Sources/KWWKAgent/Agent+Session.swift
+++ b/Sources/KWWKAgent/Agent+Session.swift
@@ -2,12 +2,24 @@ import Foundation
 import KWWKAI
 
 extension Agent {
-    /// Close provider-owned resources associated with this agent's session id.
+    /// Permanently stop this Agent and all background work it owns.
     ///
-    /// This does not mutate the transcript and does not kill background
-    /// tasks; callers that own session-scoped task managers should close those
-    /// resources separately.
+    /// The current model/tool run is cancelled, queued input is discarded, and
+    /// active tasks in every attached `BackgroundTaskManager` are killed. This
+    /// waits for the current run to release ownership before returning. Use
+    /// `abort()` instead when cancelling only the current run while keeping the
+    /// Agent reusable.
+    public func stop() async {
+        retire()
+        await abortAndKillBackgroundTasks()
+        clearAllQueues()
+        await waitForIdle()
+    }
+
+    /// Stop the Agent, including its background tasks, then close
+    /// provider-owned resources associated with its session id.
     public func closeSession() async {
+        await stop()
         guard let sessionId, !sessionId.isEmpty else { return }
         await KWWKAI.closeProviderSession(sessionId: sessionId)
     }

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -35,8 +35,8 @@ public struct CodingTools: OptionSet, Sendable {
 }
 
 /// Configuration for `makeCodingAgent`. Bundles the model, working directory,
-/// tool selection, optional background task manager, and an optional
-/// system-prompt override.
+/// tool selection, background task manager, and an optional system-prompt
+/// override.
 public struct CodingAgentConfig: Sendable {
     public var model: Model
     public var cwd: String
@@ -53,11 +53,17 @@ public struct CodingAgentConfig: Sendable {
     /// Skill directories to scan for `<available_skills>`. Empty by default so
     /// library callers do not implicitly read project or user config.
     public var skillDirectories: [String]
-    /// When non-nil, wired into both the bash tool (for
+    /// A fresh manager is created by default. Pass `nil` to disable background
+    /// execution. When non-nil, wired into both the bash tool (for
     /// `run_in_background` + auto-background-on-timeout) and the
     /// agent's notification bridge (so task results arrive as internal runtime
     /// asides at turn boundaries).
     public var backgroundManager: BackgroundTaskManager?
+    /// Whether a completed background task may start a fresh model run while
+    /// the Agent is idle. This does not change the tool schema or prevent
+    /// explicit task polling. Enabled by default; one-shot hosts can disable it
+    /// while retaining background execution during their top-level loop.
+    public var backgroundAutoContinue: Bool
     /// Programmatic subagents available to the model through the `agent` tool.
     /// When empty, no `agent` tool is registered.
     public var subagents: [SubagentDefinition]
@@ -90,7 +96,8 @@ public struct CodingAgentConfig: Sendable {
         systemPrompt: String? = nil,
         contextFiles: [(path: String, content: String)] = [],
         skillDirectories: [String] = [],
-        backgroundManager: BackgroundTaskManager? = nil,
+        backgroundManager: BackgroundTaskManager? = BackgroundTaskManager(),
+        backgroundAutoContinue: Bool = true,
         subagents: [SubagentDefinition] = [],
         subagentLimits: SubagentLimits = .init(),
         allowedSubagentModels: [Model] = [],
@@ -112,6 +119,7 @@ public struct CodingAgentConfig: Sendable {
         self.contextFiles = contextFiles
         self.skillDirectories = skillDirectories
         self.backgroundManager = backgroundManager
+        self.backgroundAutoContinue = backgroundAutoContinue
         self.subagents = subagents
         self.subagentLimits = subagentLimits
         self.allowedSubagentModels = allowedSubagentModels
@@ -148,10 +156,12 @@ public extension CodingAgentConfig {
 public struct CodingAgent: Sendable {
     public let agent: Agent
     /// Detaches the auto-continue background bridge that `makeCodingAgent`
-    /// installs when a `backgroundManager` is supplied. `nil` when no manager
-    /// was attached. The bridge autonomously starts a new (billable) model run
-    /// when a background task completes while the agent is idle; call this to
-    /// stop that behavior. In-flight background tasks keep running.
+    /// installs for the default or explicitly supplied `backgroundManager`.
+    /// This is `nil` only when background execution was explicitly disabled.
+    /// Unless `backgroundAutoContinue` was disabled, the bridge autonomously
+    /// starts a new (billable) model run when a background task completes while
+    /// the agent is idle; call this to stop delivery entirely. In-flight
+    /// background tasks keep running.
     public let detachBackground: (@Sendable () async -> Void)?
 
     public init(agent: Agent, detachBackground: (@Sendable () async -> Void)?) {
@@ -167,17 +177,18 @@ public struct CodingAgent: Sendable {
 ///     model: model,
 ///     cwd: "/Users/me/project",
 ///     tools: .standard,
-///     backgroundManager: BackgroundTaskManager(),
 ///     bashEnvironment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
 /// )).agent
 /// try await agent.prompt("list the swift files")
 /// ```
 ///
-/// If `config.backgroundManager` is non-nil, the agent is automatically
-/// attached so completion notifications surface as internal runtime asides — and
-/// that bridge will autonomously start new (billable) model runs when
-/// background tasks complete. Call the returned `CodingAgent.detachBackground`
-/// handle to stop that; ignore it to keep the default auto-continue behavior.
+/// A fresh background manager is configured by default. The agent is
+/// automatically attached so completion notifications surface as internal
+/// runtime asides. With the default `backgroundAutoContinue` setting, that
+/// bridge will autonomously start new (billable) model runs when background
+/// tasks complete. Call the returned `CodingAgent.detachBackground` handle to
+/// stop delivery, set `backgroundAutoContinue: false` for one-shot execution,
+/// or use `backgroundManager: nil` to disable background execution entirely.
 public func makeCodingAgent(_ config: CodingAgentConfig) async -> CodingAgent {
     let cwd = config.cwd
     let bgManager = config.backgroundManager
@@ -273,7 +284,8 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> CodingAgent {
         detachBackground = await agent.attachBackgroundManager(
             bgManager,
             sessionId: sessionId,
-            deliveryConsumer: backgroundDeliveryConsumer
+            deliveryConsumer: backgroundDeliveryConsumer,
+            autoContinueWhenIdle: config.backgroundAutoContinue
         )
     }
 

--- a/Sources/KWWKCli/Headless.swift
+++ b/Sources/KWWKCli/Headless.swift
@@ -13,6 +13,8 @@ import KWWKAgent
 ///   - genuine failures — auth missing, stream error, abort — *do* print
 ///     a one-line message to stderr so the user isn't left staring at a
 ///     silent non-zero exit;
+///   - background tools are available while the top-level Agent loop is live,
+///     but unfinished tasks are cancelled as soon as that loop returns;
 ///   - exit code is `0` when the model reached a clean stop, `1` otherwise.
 ///
 /// Credentials are resolved exactly like `runCodingTUIInternal`: the CLI checks
@@ -50,6 +52,7 @@ func runHeadlessInternal(
         tools: tools,
         contextFiles: loadProjectContextFiles(cwd: cwd),
         skillDirectories: Skills.defaultDirectories(cwd: cwd, includeUserDirectory: true),
+        backgroundAutoContinue: false,
         subagents: defaultCLISubagents(for: tools, selection: builtinSubagents),
         sessionId: sessionId,
         authResolver: resolved.authResolver,
@@ -139,65 +142,22 @@ func runHeadlessInternal(
     return stop == .stop ? 0 : 1
 }
 
-/// Build a one-shot agent with background execution forcibly disabled.
-///
-/// The caller may hand us a reusable config that has a manager attached; copy
-/// it and clear that capability so `kwwk -p` can never report "started in the
-/// background" immediately before its process exits. Without a manager the
-/// bash schema omits background options, the background-task tools are absent, and
-/// a subagent request that smuggles `run_in_background=true` is rejected by the
-/// agent tool at runtime.
+/// Build a one-shot Agent with the config's normal background capabilities.
+/// The caller owns the top-level loop boundary and must call
+/// `cleanupHeadlessAgent` immediately after it returns; cleanup retires the
+/// Agent and kills unfinished work instead of waiting for background tasks to
+/// extend the one-shot process lifetime.
 func makeHeadlessCodingAgent(_ input: CodingAgentConfig) async -> Agent {
     var config = input
-    config.backgroundManager = nil
-    // Reusable interactive definitions may default to background execution.
-    // Hiding the explicit flag is not enough: an omitted argument would still
-    // select that default and then fail because headless intentionally has no
-    // manager. Make the semantic default foreground before building the tool.
-    config.subagents = config.subagents.map { definition in
-        var foreground = definition
-        foreground.runInBackgroundByDefault = false
-        return foreground
-    }
-    let agent = await makeCodingAgent(config).agent
-    agent.state.tools = removingHeadlessBackgroundOptions(from: agent.state.tools)
-    return agent
+    config.backgroundAutoContinue = false
+    return await makeCodingAgent(config).agent
 }
 
-private func removingHeadlessBackgroundOptions(from tools: [AgentTool]) -> [AgentTool] {
-    tools.map { original in
-        guard original.name == "agent" else { return original }
-        var tool = original
-        if case .object(var schema) = tool.parameters,
-           case .object(var properties) = schema["properties"] ?? .null {
-            properties.removeValue(forKey: "run_in_background")
-            schema["properties"] = .object(properties)
-            tool.parameters = .object(schema)
-        }
-        tool.description = tool.description
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .filter { line in
-                !line.contains("run_in_background")
-                    && !line.contains("Background tasks started by the subagent")
-            }
-            .joined(separator: "\n")
-        return tool
-    }
-}
-
-/// Deterministic one-shot teardown for both success and failure paths. The
-/// headless builder currently installs no background attachment, but keeping
-/// the ownership cleanup here prevents future configuration changes (or an SDK
-/// attachment added around this helper) from leaving work behind at exit.
+/// Deterministic one-shot teardown for both success and failure paths. This is
+/// deliberately called when the top-level prompt returns rather than when the
+/// background registry becomes idle: headless work may use background tools
+/// during the Agent loop, but cannot keep the process alive afterward.
 func cleanupHeadlessAgent(_ agent: Agent) async {
-    agent.retire()
-    await agent.abortAndKillBackgroundTasks()
-    // Retirement makes already-scheduled bridge wakes harmless. Discard any
-    // exit-only queues and wait until an in-flight run observes cancellation
-    // before closing provider resources.
-    agent.abort()
-    agent.clearAllQueues()
-    await agent.waitForIdle()
     await agent.closeSession()
 }
 

--- a/Tests/KWWKAgentTests/AgentBackgroundTests.swift
+++ b/Tests/KWWKAgentTests/AgentBackgroundTests.swift
@@ -115,6 +115,46 @@ struct AgentBackgroundTests {
         }
     }
 
+    @Test("background delivery can remain queued without auto-continuing an idle agent")
+    func idleAutoContinueCanBeDisabled() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+        registration.setResponses([
+            .message(fauxAssistantMessage("initial")),
+            .message(fauxAssistantMessage("must not auto-continue")),
+        ])
+
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwbg-no-auto-continue-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let agent = Agent(initialState: AgentInitialState(model: registration.getModel()))
+        try await agent.prompt("seed")
+        let detach = await agent.attachBackgroundManager(
+            manager,
+            sessionId: "no-auto-continue",
+            autoContinueWhenIdle: false
+        )
+        defer { Task { await detach() } }
+
+        let (taskId, _) = await manager.spawn(
+            runner: FauxRunner(
+                label: "queue without waking",
+                outcome: BackgroundTaskOutcome(success: true, summary: "done")
+            ),
+            sessionId: "no-auto-continue"
+        )
+        let delivered = await awaitUntil(2_000) {
+            let snapshot = await manager.get(taskId)
+            return snapshot?.status == .completed && agent.hasQueuedMessages()
+        }
+        #expect(delivered)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(agent.state.messages.count == 2)
+        #expect(!agent.state.isStreaming)
+        await agent.stop()
+    }
+
     @Test("abortAndKillBackgroundTasks drains the manager")
     func abortAndKill() async {
         let outputDir = FileManager.default.temporaryDirectory
@@ -140,6 +180,41 @@ struct AgentBackgroundTests {
 
         let after = await manager.list(sessionId: "s1").filter(\.status.isActive).count
         #expect(after == 0)
+    }
+
+    @Test("closeSession stops owned background tasks and retires the agent")
+    func closeSessionStopsBackgroundTasks() async {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kwbg-close-agent-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let agent = Agent(
+            initialState: AgentInitialState(model: registration.getModel()),
+            sessionId: "close-agent"
+        )
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let detach = await agent.attachBackgroundManager(manager, sessionId: "close-agent")
+        defer { Task { await detach() } }
+
+        _ = await manager.spawn(
+            runner: ForeverRunner(label: "close with agent"),
+            sessionId: "close-agent"
+        )
+        let started = await awaitUntil(2_000) {
+            await manager.list(sessionId: "close-agent").contains { $0.status.isActive }
+        }
+        #expect(started)
+
+        await agent.closeSession()
+
+        let active = await manager.list(sessionId: "close-agent").filter(\.status.isActive)
+        #expect(active.isEmpty)
+        await #expect(throws: AgentError.alreadyRunning) {
+            try await agent.prompt("must not restart")
+        }
     }
 
     @Test("silent session close does not wake an idle agent")

--- a/Tests/KWWKAgentTests/AgentTests.swift
+++ b/Tests/KWWKAgentTests/AgentTests.swift
@@ -156,6 +156,46 @@ struct AgentInitTests {
         #expect(agent.compactionModel?.provider == compactionModel.provider)
     }
 
+    @Test("coding agent config enables independent background managers by default")
+    func codingAgentEnablesBackgroundByDefault() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+
+        let firstConfig = CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: FileManager.default.temporaryDirectory.path,
+            tools: .standard,
+            bashEnvironment: [:]
+        )
+        let secondConfig = CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: FileManager.default.temporaryDirectory.path,
+            tools: .standard,
+            bashEnvironment: [:]
+        )
+        let firstManager = try #require(firstConfig.backgroundManager)
+        let secondManager = try #require(secondConfig.backgroundManager)
+        #expect(firstManager !== secondManager)
+
+        let coding = await makeCodingAgent(firstConfig)
+        #expect(coding.detachBackground != nil)
+        let toolNames = Set(coding.agent.state.tools.map(\.name))
+        for name in ["task_list", "task_read", "task_poll", "task_cancel"] {
+            #expect(toolNames.contains(name))
+        }
+        await coding.detachBackground?()
+
+        let disabled = await makeCodingAgent(CodingAgentConfig(
+            model: registration.getModel(),
+            cwd: FileManager.default.temporaryDirectory.path,
+            tools: .standard,
+            backgroundManager: nil,
+            bashEnvironment: [:]
+        ))
+        #expect(disabled.detachBackground == nil)
+        #expect(!disabled.agent.state.tools.contains { $0.name.hasPrefix("task_") })
+    }
+
     @Test("coding agent can explicitly disable auto compact")
     func codingAgentCanDisableAutoCompact() async throws {
         let registration = await registerFauxProvider()

--- a/Tests/KWWKAgentTests/SubagentToolTests.swift
+++ b/Tests/KWWKAgentTests/SubagentToolTests.swift
@@ -25,6 +25,7 @@ struct SubagentToolTests {
             model: faux.getModel(),
             cwd: cwd.path,
             tools: .readOnly,
+            backgroundManager: nil,
             subagents: [minimalSubagent()],
             bashEnvironment: [:]
         )).agent

--- a/Tests/KWWKCliTests/HeadlessTests.swift
+++ b/Tests/KWWKCliTests/HeadlessTests.swift
@@ -6,8 +6,8 @@ import Testing
 
 @Suite("Headless background policy", .serialized)
 struct HeadlessTests {
-    @Test("headless forces reusable background-default subagents to foreground")
-    func headlessOverridesDefinitionDefault() async throws {
+    @Test("headless preserves reusable background-default subagents")
+    func headlessPreservesDefinitionDefault() async throws {
         let faux = await registerFauxProvider()
         defer { faux.unregister() }
         faux.setResponses([.message(fauxAssistantMessage(
@@ -28,13 +28,14 @@ struct HeadlessTests {
         defer { try? FileManager.default.removeItem(at: cwd) }
         var definition = SubagentDefinition.general(tools: .readOnly)
         definition.runInBackgroundByDefault = true
+        let manager = BackgroundTaskManager(
+            outputDir: cwd.appendingPathComponent("background", isDirectory: true)
+        )
         let agent = await makeHeadlessCodingAgent(CodingAgentConfig(
             model: faux.getModel(),
             cwd: cwd.path,
             tools: .readOnly,
-            backgroundManager: BackgroundTaskManager(
-                outputDir: cwd.appendingPathComponent("background", isDirectory: true)
-            ),
+            backgroundManager: manager,
             subagents: [definition],
             sessionId: "headless-default",
             autoCompactThreshold: nil,
@@ -46,7 +47,7 @@ struct HeadlessTests {
             return
         }
         let result = try await subagent.execute(
-            "foreground-default",
+            "background-default",
             .object([
                 "description": .string("check default"),
                 "prompt": .string("return a result"),
@@ -55,16 +56,22 @@ struct HeadlessTests {
             nil,
             nil
         )
-        let rendered = result.content.compactMap { block -> String? in
-            if case .text(let text) = block { return text.text }
-            return nil
-        }.joined(separator: "\n")
-        #expect(rendered.contains("foreground child result"))
-        #expect(!rendered.contains("requires a BackgroundTaskManager"))
+        guard case .object(let details) = result.details ?? .null else {
+            Issue.record("expected background result details")
+            return
+        }
+        #expect(details["status"] == .string("background_started"))
+        let startedTasks = await manager.list(sessionId: "headless-default")
+        #expect(!startedTasks.isEmpty)
+        await cleanupHeadlessAgent(agent)
+        let stoppedTasks = await manager.list(sessionId: "headless-default")
+        #expect(stoppedTasks.allSatisfy {
+            !$0.status.isActive
+        })
     }
 
-    @Test("headless builder strips background capabilities even from a reusable config")
-    func headlessBuilderForbidsBackground() async throws {
+    @Test("headless exposes background capabilities but cleanup ends their lifetime")
+    func headlessBuilderAllowsBackground() async throws {
         let cwd = FileManager.default.temporaryDirectory
             .appendingPathComponent("kwwk-headless-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: cwd, withIntermediateDirectories: true)
@@ -86,11 +93,10 @@ struct HeadlessTests {
 
         let agent = await makeHeadlessCodingAgent(config)
         let toolNames = Set(agent.state.tools.map(\.name))
-        #expect(!toolNames.contains("task"))
-        #expect(!toolNames.contains("task_poll"))
-        #expect(!toolNames.contains("task_cancel"))
-        #expect(!toolNames.contains("task_list"))
-        #expect(!toolNames.contains("task_read"))
+        #expect(toolNames.contains("task_poll"))
+        #expect(toolNames.contains("task_cancel"))
+        #expect(toolNames.contains("task_list"))
+        #expect(toolNames.contains("task_read"))
 
         guard let bash = agent.state.tools.first(where: { $0.name == "bash" }),
               case .object(let bashSchema) = bash.parameters,
@@ -98,10 +104,10 @@ struct HeadlessTests {
             Issue.record("expected headless bash schema")
             return
         }
-        #expect(bashProperties["run_in_background"] == nil)
+        #expect(bashProperties["run_in_background"] != nil)
 
         guard let subagent = agent.state.tools.first(where: { $0.name == "agent" }) else {
-            Issue.record("expected foreground subagent tool")
+            Issue.record("expected subagent tool")
             return
         }
         guard case .object(let agentSchema) = subagent.parameters,
@@ -109,25 +115,33 @@ struct HeadlessTests {
             Issue.record("expected headless subagent schema")
             return
         }
-        #expect(agentProperties["run_in_background"] == nil)
-        #expect(!subagent.description.contains("run_in_background"))
-        do {
-            _ = try await subagent.execute(
-                "headless-background-attempt",
-                .object([
-                    "description": .string("background attempt"),
-                    "prompt": .string("do work"),
-                    "subagent_type": .string("general"),
-                    "run_in_background": .bool(true),
-                ]),
-                nil,
-                nil
-            )
-            Issue.record("headless subagent unexpectedly started in background")
-        } catch {
-            #expect("\(error)".contains("requires a BackgroundTaskManager"))
+        #expect(agentProperties["run_in_background"] != nil)
+        #expect(subagent.description.contains("run_in_background"))
+        let result = try await subagent.execute(
+            "headless-background-attempt",
+            .object([
+                "description": .string("background attempt"),
+                "prompt": .string("do work"),
+                "subagent_type": .string("general"),
+                "run_in_background": .bool(true),
+            ]),
+            nil,
+            nil
+        )
+        guard case .object(let details) = result.details ?? .null else {
+            Issue.record("expected background result details")
+            return
         }
-        #expect(await manager.list(sessionId: "headless-policy").isEmpty)
+        #expect(details["status"] == .string("background_started"))
+        let startedTasks = await manager.list(sessionId: "headless-policy")
+        #expect(!startedTasks.isEmpty)
+
+        await cleanupHeadlessAgent(agent)
+
+        let stoppedTasks = await manager.list(sessionId: "headless-policy")
+        #expect(stoppedTasks.allSatisfy {
+            !$0.status.isActive
+        })
     }
 
     @Test("headless teardown kills any agent-owned background work")


### PR DESCRIPTION
## Summary

- create a `BackgroundTaskManager` by default for coding agents while preserving explicit opt-out
- keep background tools available in headless mode without allowing background completion to extend the one-shot loop
- add deterministic Agent stop/close cleanup for active background tasks

## Testing

- `swift test --filter 'HeadlessTests|AgentBackgroundTests|AgentInitTests|SubagentToolTests.agentToolIsConditional'` (23 tests passed)