### PR TITLE
Release v0.1.35

### DIFF
--- a/Sources/KWWKCli/BuiltinSlashCommands.swift
+++ b/Sources/KWWKCli/BuiltinSlashCommands.swift
@@ -974,7 +974,9 @@ private func handleShakeCommand(_ ctx: SlashContext, _ args: String) async {
             }
 
             shakeAgent.state.messages = rewrittenMessages
-            await shakeAgent.closeSession()
+            // `/shake` keeps the Agent reusable; only invalidate the
+            // provider-side chain so the rewritten history is replayed.
+            await KWWKAI.closeProviderSession(sessionId: ctx.sessionId)
             ctx.refreshTranscript()
 
             switch mode {

--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.34"
+    static let version = "0.1.35"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The

--- a/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
+++ b/Tests/KWWKAgentTests/BackgroundTaskManagerTests.swift
@@ -561,6 +561,8 @@ struct BackgroundTaskManagerTests {
 
         let noneSummary = await manager.runningTasksSummary(sessionId: "other")
         #expect(noneSummary.isEmpty)
+
+        await manager.killAll(sessionId: nil)
     }
 
     @Test("output pagination preserves UTF-8 and exposes invalid bytes losslessly")


### PR DESCRIPTION
## Summary

- bump the CLI version to 0.1.35 for the default background-task release
- clean up the permanent runner in `runningTasksSummary` so the test does not leave a background task alive
- keep `/shake` reusable by closing only the provider-side session chain instead of terminally closing the Agent

## Validation

- `swift test --skip-build` (1315 tests in 194 suites passed)
- `swift build -c release --product kwwk`
- `.build/release/kwwk --self-test`