### PR TITLE
Release v0.1.36

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.35"
+    static let version = "0.1.36"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
## Summary

- release the refreshed bundled model catalogs from #91
- bump the CLI version to 0.1.36

## Validation

- `main` CI passed on all 5 jobs at `e611b0a`
- release PR CI will verify the version bump