### PR TITLE
fix: enable OpenRouter session affinity by default

### DIFF
--- a/Sources/KWWKAI/OpenAICompletionsProvider.swift
+++ b/Sources/KWWKAI/OpenAICompletionsProvider.swift
@@ -508,7 +508,11 @@ public final class OpenAICompletionsProvider: APIProvider, @unchecked Sendable {
             zaiToolStream: c?.zaiToolStream ?? false,
             supportsStrictMode: c?.supportsStrictMode ?? (!isMoonshot && !isTogether && !isCfGateway && !isNvidia),
             cacheControlFormat: c?.cacheControlFormat ?? ((provider == "openrouter" && model.id.hasPrefix("anthropic/")) ? "anthropic" : nil),
-            sendSessionAffinityHeaders: c?.sendSessionAffinityHeaders ?? false,
+            // OpenRouter uses the session id to keep provider/model routing
+            // sticky across an agent run. Built-in OpenRouter catalog entries
+            // do not repeat this flag per model, so enable it from provider /
+            // base-URL detection while preserving an explicit opt-out.
+            sendSessionAffinityHeaders: c?.sendSessionAffinityHeaders ?? isOpenRouter,
             sessionAffinityFormat: c?.sessionAffinityFormat ?? (isOpenRouter ? "openrouter" : "openai"),
             supportsLongCacheRetention: c?.supportsLongCacheRetention ?? !(isTogether || isCloudflareWorkers || isCfGateway || isNvidia || isAntLing)
         )

--- a/Tests/KWWKAITests/OpenAICompletionsTests.swift
+++ b/Tests/KWWKAITests/OpenAICompletionsTests.swift
@@ -297,9 +297,6 @@ struct OpenAICompletionsTests {
         var model = Self.model
         model.provider = "openrouter"
         model.baseURL = "https://openrouter.ai/api"
-        var compat = ModelCompat()
-        compat.sendSessionAffinityHeaders = true
-        model.compat = compat
 
         let client = StubSSEClient(body: Self.textSSE)
         let provider = OpenAICompletionsProvider(client: client, defaultAPIKey: "k")
@@ -314,6 +311,22 @@ struct OpenAICompletionsTests {
         #expect(headers["session_id"] == nil)
         #expect(headers["x-client-request-id"] == nil)
         #expect(headers["x-session-affinity"] == nil)
+
+        // Provider defaults remain overridable for proxies or callers that do
+        // not want OpenRouter sticky routing.
+        var optedOut = model
+        var optedOutCompat = ModelCompat()
+        optedOutCompat.sendSessionAffinityHeaders = false
+        optedOut.compat = optedOutCompat
+        let optedOutClient = StubSSEClient(body: Self.textSSE)
+        let optedOutProvider = OpenAICompletionsProvider(client: optedOutClient, defaultAPIKey: "k")
+        _ = optedOutProvider.stream(
+            model: optedOut,
+            context: Context(messages: [.user(UserMessage(text: "hi"))]),
+            options: StreamOptions(cacheRetention: .short, sessionId: "session-or")
+        )
+        await Self.waitForRequest(optedOutClient)
+        #expect(optedOutClient.lastRequest?.headers["x-session-id"] == nil)
 
         // An explicit compat format overrides the URL-based detection.
         var pinned = model


### PR DESCRIPTION
## Summary

- enable session-affinity headers automatically for OpenRouter providers and OpenRouter base URLs
- send the KWWK session id through OpenRouter's `x-session-id` header
- preserve explicit compatibility opt-out and format overrides

## Tests

- `swift test --filter OpenAICompletionsTests`
- `swift test` (1315 tests passed)
- `git diff --check`
