### PR TITLE
chore(kwwk): bump version to 0.1.39

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.38"
+    static let version = "0.1.39"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.39 — carries #98 (compaction summaries mirror the agent's live reasoning level, unwedging agents on reasoning-mandatory models like Grok 4.5 behind OpenRouter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSLrZkCUcm68WQTZdEPn1R