### PR TITLE
chore: refresh bundled model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -4581,7 +4581,7 @@
         "supportsUsageInStreaming" : true,
         "thinkingFormat" : "baseten"
       },
-      "contextWindow" : 524288,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.21,
         "cacheWrite" : 0,
@@ -6264,7 +6264,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 256000,
       "name" : "Glm 5.2",
       "provider" : "cloudflare-workers-ai",
       "reasoning" : true,
@@ -6284,6 +6284,7 @@
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.deepseek.com",
       "compat" : {
+        "maxTokensField" : "max_tokens",
         "requiresReasoningContentOnAssistantMessages" : true,
         "supportsDeveloperRole" : false,
         "supportsStore" : false,
@@ -6316,6 +6317,7 @@
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.deepseek.com",
       "compat" : {
+        "maxTokensField" : "max_tokens",
         "requiresReasoningContentOnAssistantMessages" : true,
         "supportsDeveloperRole" : false,
         "supportsStore" : false,
@@ -7942,46 +7944,6 @@
       "provider" : "google",
       "reasoning" : true
     },
-    "gemini-2.0-flash" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.4
-      },
-      "id" : "gemini-2.0-flash",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemini 2.0 Flash",
-      "provider" : "google",
-      "reasoning" : false
-    },
-    "gemini-2.0-flash-lite" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.3
-      },
-      "id" : "gemini-2.0-flash-lite",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Gemini 2.0 Flash-Lite",
-      "provider" : "google",
-      "reasoning" : false
-    },
     "gemini-2.5-computer-use-preview-10-2025" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -8082,33 +8044,6 @@
       "provider" : "google",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "gemini-3-pro-preview" : {
-      "api" : "google-generative-ai",
-      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 12
-      },
-      "id" : "gemini-3-pro-preview",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Gemini 3 Pro Preview",
-      "provider" : "google",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "HIGH",
-        "low" : "LOW",
-        "medium" : null,
-        "minimal" : null,
         "off" : null
       }
     },
@@ -16341,10 +16276,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.017919999999999998,
+        "cacheRead" : 0.015959999999999998,
         "cacheWrite" : 0,
-        "input" : 0.089599999999999999,
-        "output" : 0.1792
+        "input" : 0.079799999999999996,
+        "output" : 0.1596
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
@@ -16422,7 +16357,7 @@
       "cost" : {
         "cacheRead" : 0.29,
         "cacheWrite" : 0,
-        "input" : 2.5,
+        "input" : 2.8,
         "output" : 14
       },
       "id" : "~moonshotai\/kimi-latest",
@@ -17917,9 +17852,9 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.017999999999999999,
+        "cacheRead" : 0.016,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
+        "input" : 0.080000000000000002,
         "output" : 0.18
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
@@ -17949,16 +17884,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.054364000000000003,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0.64432,
+        "output" : 1.28864
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
         "text"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 393216,
       "name" : "DeepSeek: DeepSeek V4 Pro",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -18580,17 +18515,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.34
+        "input" : 0.12,
+        "output" : 0.4
       },
       "id" : "google\/gemma-4-26b-a4b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 262144,
       "name" : "Google: Gemma 4 26B A4B ",
       "provider" : "openrouter",
       "reasoning" : true
@@ -18999,19 +18934,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.2,
-        "output" : 0.8
+        "output" : 0.696
       },
       "id" : "meta-llama\/llama-4-maverick",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 4096,
       "name" : "Meta: Llama 4 Maverick",
       "provider" : "openrouter",
       "reasoning" : false
@@ -19039,6 +18974,30 @@
       "name" : "Meta: Llama 4 Scout",
       "provider" : "openrouter",
       "reasoning" : false
+    },
+    "meta\/muse-glimmer-30b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.35,
+        "output" : 1.5
+      },
+      "id" : "meta\/muse-glimmer-30b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Meta: Muse Glimmer 30B",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "meta\/muse-spark-1.1" : {
       "api" : "openai-completions",
@@ -19189,10 +19148,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0.053999999999999999,
+        "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.27,
-        "output" : 1.08
+        "input" : 0.3,
+        "output" : 1.2
       },
       "id" : "minimax\/minimax-m2.7",
       "input" : [
@@ -19731,10 +19690,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.097600000000000006,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.5795,
-        "output" : 2.44
+        "input" : 0.95,
+        "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -19875,7 +19834,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
         "output" : 0.2
@@ -19884,7 +19843,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 228000,
       "name" : "NVIDIA: Nemotron 3 Nano 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20964,7 +20923,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 32000,
       "name" : "OpenAI: GPT-5.2 Chat",
       "provider" : "openrouter",
       "reasoning" : false,
@@ -21072,32 +21031,6 @@
       "name" : "OpenAI: GPT-5.2 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
-      "thinkingLevelMap" : {
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.3-chat" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "openai\/gpt-5.3-chat",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "OpenAI: GPT-5.3 Chat",
-      "provider" : "openrouter",
-      "reasoning" : false,
       "thinkingLevelMap" : {
         "xhigh" : "xhigh"
       }
@@ -22572,18 +22505,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.2275,
-        "output" : 0.91
+        "input" : 0.12,
+        "output" : 0.24
       },
       "id" : "qwen\/qwen3-14b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 14B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -22779,18 +22712,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 160000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.070000000000000007,
-        "output" : 0.27
+        "output" : 0.28
       },
       "id" : "qwen\/qwen3-coder-30b-a3b-instruct",
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3 Coder 30B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -23229,17 +23162,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
-        "input" : 0.39,
-        "output" : 2.34
+        "input" : 0.5,
+        "output" : 3.6
       },
       "id" : "qwen\/qwen3.5-397b-a17b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3.5 397B A17B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23835,6 +23768,29 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "upstage\/solar-pro4" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 524288,
+      "cost" : {
+        "cacheRead" : 0.0060000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.029999999999999999,
+        "output" : 0.12
+      },
+      "id" : "upstage\/solar-pro4",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Upstage: Solar Pro 4",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "x-ai\/grok-4.3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -24196,10 +24152,10 @@
       },
       "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.1768,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0.952,
-        "output" : 2.992
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "z-ai\/glm-5.1",
       "input" : [
@@ -24217,18 +24173,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1024000,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.038219999999999997,
+        "cacheRead" : 0.14,
         "cacheWrite" : 0,
-        "input" : 0.2058,
-        "output" : 0.6468
+        "input" : 0.76,
+        "output" : 2.42
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 262144,
       "name" : "Z.ai: GLM 5.2",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -26001,7 +25957,7 @@
         "supportsStrictMode" : false,
         "thinkingFormat" : "together"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 512000,
       "cost" : {
         "cacheRead" : 0.26,
         "cacheWrite" : 0,
@@ -26854,6 +26810,34 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic\/claude-opus-5-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsTemperature" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 1,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-opus-5-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Opus 5 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic\/claude-sonnet-4" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -27411,7 +27395,7 @@
         "image"
       ],
       "maxTokens" : 131072,
-      "name" : "Gemma 4 26B A4B IT",
+      "name" : "Google Gemma 4 26B A4B",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -27705,6 +27689,26 @@
       "name" : "Llama 4 Scout 17B Instruct",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
+    },
+    "meta\/muse-glimmer-30b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.35,
+        "output" : 1.5
+      },
+      "id" : "meta\/muse-glimmer-30b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Glimmer 30B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
     },
     "meta\/muse-spark-1.1" : {
       "api" : "anthropic-messages",
@@ -28750,26 +28754,6 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
-    "openai\/gpt-5.1-instant" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.13,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "openai\/gpt-5.1-instant",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.1 Instant",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
     "openai\/gpt-5.1-thinking" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -28855,29 +28839,6 @@
       "name" : "GPT 5.2 ",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
-      "thinkingLevelMap" : {
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.3-chat" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "openai\/gpt-5.3-chat",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.3 Chat",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false,
       "thinkingLevelMap" : {
         "xhigh" : "xhigh"
       }


### PR DESCRIPTION
## Summary

- regenerate the regular catalog from authoritative `badlogic/pi-mono` main at `cd6852a123f2c0cc646a41a2a52f3711a603b822`
- add 4 entries: OpenRouter Muse Glimmer 30B and Solar Pro 4; Vercel AI Gateway Claude Opus 5 Fast and Muse Glimmer 30B
- remove 6 entries: Google Gemini 2.0 Flash, Gemini 2.0 Flash-Lite, Gemini 3 Pro Preview; OpenRouter GPT-5.3 Chat; Vercel AI Gateway GPT-5.1 Instant and GPT-5.3 Chat
- refresh pricing, context/output limits, compatibility, or display metadata for 21 existing entries
- regenerate Cursor from GetUsableModels: 187 models, unchanged

## Validation

- JSON parse validation for both bundled catalogs
- `git diff --check`
- credential and localhost/private endpoint scans
- targeted catalog/Cursor tests: 44 tests in 7 suites
- full `swift test`: 1,316 tests in 194 suites