### PR TITLE
Credentials can come from an external authority, consume-only

### DIFF
--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -84,6 +84,7 @@ extension OAuthProvider {
 
 public enum OAuthError: Error, LocalizedError {
     case missing(providerId: String)
+    case expired(providerId: String)
     case unknownProvider(String)
     case transport(String)
     case invalidResponse(String)
@@ -94,6 +95,8 @@ public enum OAuthError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .missing(let id): return "no OAuth credentials stored for '\(id)'"
+        case .expired(let id):
+            return "OAuth credentials for '\(id)' are expired and refresh is disabled in consume-only mode — the credential source must serve fresh ones"
         case .unknownProvider(let id): return "unknown OAuth provider '\(id)'"
         case .transport(let text): return "OAuth transport error: \(text)"
         case .invalidResponse(let text): return "OAuth invalid response: \(text)"
@@ -103,6 +106,30 @@ public enum OAuthError: Error, LocalizedError {
         case .persistFailed(let text): return "OAuth store write failed: \(text)"
         }
     }
+}
+
+// MARK: - Credential source
+
+/// Where an `OAuthManager` reads credentials from. `OAuthStore` is the
+/// file-backed implementation; a host that owns refresh elsewhere (a backend
+/// minting per-tenant tokens, a keychain daemon, …) implements this instead
+/// and hands it to `OAuthManager(source:)`, which then only ever *consumes*
+/// tokens — nothing is refreshed and nothing is written to disk.
+///
+/// An external source is the authority on freshness: `credentials(for:)` must
+/// return a token that is valid *now*, because a consume-only manager will not
+/// refresh an expired one (it throws `OAuthError.expired` instead). Sources
+/// that talk to a network authority should do their own caching so the
+/// per-request read stays cheap.
+public protocol OAuthCredentialSource: Sendable {
+    /// Ids the source currently holds credentials for. Registration walks this
+    /// to decide which providers to wire up and in what priority order, so it
+    /// should be as cheap as a cache read.
+    func providerIds() async -> [String]
+
+    /// Current credentials for `providerId`, or nil when the source holds none
+    /// (the caller reports that as `OAuthError.missing`).
+    func credentials(for providerId: String) async throws -> OAuthCredentials?
 }
 
 // MARK: - Credential store
@@ -195,14 +222,44 @@ public actor OAuthStore {
     }
 }
 
+/// The file store is itself a credential source — reading it can't fail (the
+/// only failure mode, a corrupt file, is caught at `init`), so these witness
+/// the throwing requirements without throwing.
+extension OAuthStore: OAuthCredentialSource {
+    public func providerIds() -> [String] { Array(credentials.keys) }
+    public func credentials(for providerId: String) -> OAuthCredentials? { credentials[providerId] }
+}
+
 // MARK: - Manager
+
+/// Whether a manager may refresh the credentials it reads.
+public enum OAuthRefreshPolicy: Sendable {
+    /// Expired credentials are refreshed through the provider and the fresh
+    /// pair is persisted back to the store. Requires a writable `OAuthStore`.
+    case automatic
+    /// Tokens are only ever read. An expired credential is an error
+    /// (`OAuthError.expired`) rather than a refresh — the source's authority
+    /// owns refresh, and this process writes nothing.
+    case consumeOnly
+}
 
 /// Refresh-on-demand front end. Wrap an `OAuthStore` with a set of
 /// `OAuthProvider`s. Call `apiKey(for:)` (or the `resolver()` closure) to
 /// fetch a fresh api-key — `OAuthManager` checks `.isExpired`, refreshes, and
 /// persists new credentials automatically.
+///
+/// `init(source:)` builds the consume-only variant instead: credentials come
+/// from an external authority that owns refresh, and this manager never calls
+/// `provider.refresh` nor touches the disk.
 public actor OAuthManager {
-    public let store: OAuthStore
+    /// The writable store, and thus non-nil exactly for `.automatic` managers
+    /// — `init(source:)` is always `.consumeOnly`, so there is nothing to
+    /// persist a refresh into.
+    public let store: OAuthStore?
+    /// Where credentials are read from. Same object as `store` for the
+    /// store-backed init.
+    public let source: any OAuthCredentialSource
+    public let policy: OAuthRefreshPolicy
     public let client: HTTPClient
     private var providers: [String: OAuthProvider]
     /// In-flight refresh per provider id. Concurrent `apiKey(for:)` callers
@@ -216,6 +273,23 @@ public actor OAuthManager {
         client: HTTPClient = URLSessionHTTPClient()
     ) {
         self.store = store
+        self.source = store
+        self.policy = .automatic
+        self.providers = Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
+        self.client = client
+    }
+
+    /// Consume-only manager over an external credential source. The source is
+    /// the authority on freshness (see `OAuthCredentialSource`); this manager
+    /// reads tokens, never refreshes them, and never persists anything.
+    public init(
+        source: any OAuthCredentialSource,
+        providers: [OAuthProvider] = OAuthManager.defaultProviders(),
+        client: HTTPClient = URLSessionHTTPClient()
+    ) {
+        self.store = nil
+        self.source = source
+        self.policy = .consumeOnly
         self.providers = Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
         self.client = client
     }
@@ -234,17 +308,37 @@ public actor OAuthManager {
         providers[provider.id] = provider
     }
 
+    /// Ids the backing source holds credentials for, and the credentials
+    /// themselves. Registration code reads through these so it works the same
+    /// over a file store and over an external authority.
+    public func providerIds() async -> [String] {
+        await source.providerIds()
+    }
+
+    public func credentials(for providerId: String) async throws -> OAuthCredentials? {
+        try await source.credentials(for: providerId)
+    }
+
     /// Get a valid api-key for `providerId`, refreshing if the stored token
-    /// is expired. Throws `OAuthError.missing` if no credentials are stored.
+    /// is expired. Throws `OAuthError.missing` if no credentials are stored,
+    /// and — under `.consumeOnly`, where refreshing is not ours to do —
+    /// `OAuthError.expired` if the source served a stale one.
     public func apiKey(for providerId: String) async throws -> String {
         guard let provider = providers[providerId] else {
             throw OAuthError.unknownProvider(providerId)
         }
-        guard var credentials = await store.get(providerId) else {
+        guard var credentials = try await source.credentials(for: providerId) else {
             throw OAuthError.missing(providerId: providerId)
         }
         if credentials.isExpired {
-            credentials = try await refresh(providerId, provider: provider, stale: credentials)
+            // `.automatic` is only reachable through `init(store:)`, so the
+            // store is there; the guard is a type-level formality.
+            guard case .automatic = policy, let store else {
+                throw OAuthError.expired(providerId: providerId)
+            }
+            credentials = try await refresh(
+                providerId, provider: provider, store: store, stale: credentials
+            )
         }
         return try await provider.apiKey(from: credentials, using: client)
     }
@@ -256,12 +350,12 @@ public actor OAuthManager {
     private func refresh(
         _ providerId: String,
         provider: OAuthProvider,
+        store: OAuthStore,
         stale: OAuthCredentials
     ) async throws -> OAuthCredentials {
         if let existing = inFlightRefresh[providerId] {
             return try await existing.value
         }
-        let store = self.store
         let client = self.client
         let task = Task<OAuthCredentials, Error> {
             let current = await store.get(providerId) ?? stale
@@ -288,6 +382,10 @@ public actor OAuthManager {
                 // request is the correct outcome. A refresh/exchange failure
                 // (any other error) propagates so the provider surfaces it
                 // rather than silently sending an unauthenticated request.
+                // `.expired` is one of those propagating errors on purpose: a
+                // logged-in account whose source served a stale token is a
+                // real fault, and reporting it as "not logged in" would hide
+                // it behind a downstream 401.
                 return nil
             }
         }
@@ -295,7 +393,7 @@ public actor OAuthManager {
 
     private func resolvedAuth(for providerId: String) async throws -> ResolvedProviderAuth {
         let token = try await apiKey(for: providerId)
-        let credentials = await store.get(providerId)
+        let credentials = try await source.credentials(for: providerId)
         return ResolvedProviderAuth(
             token: token,
             scheme: .bearer,

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -96,7 +96,7 @@ public enum OAuthError: Error, LocalizedError {
         switch self {
         case .missing(let id): return "no OAuth credentials stored for '\(id)'"
         case .expired(let id):
-            return "OAuth credentials for '\(id)' are expired and refresh is disabled in consume-only mode — the credential source must serve fresh ones"
+            return "OAuth credentials for '\(id)' are expired and carry no refresh token — the credential source must serve fresh ones"
         case .unknownProvider(let id): return "unknown OAuth provider '\(id)'"
         case .transport(let text): return "OAuth transport error: \(text)"
         case .invalidResponse(let text): return "OAuth invalid response: \(text)"
@@ -113,12 +113,14 @@ public enum OAuthError: Error, LocalizedError {
 /// Where an `OAuthManager` reads credentials from. `OAuthStore` is the
 /// file-backed implementation; a host that owns refresh elsewhere (a backend
 /// minting per-tenant tokens, a keychain daemon, …) implements this instead
-/// and hands it to `OAuthManager(source:)`, which then only ever *consumes*
-/// tokens — nothing is refreshed and nothing is written to disk.
+/// and hands it to `OAuthManager(source:)`.
 ///
-/// An external source is the authority on freshness: `credentials(for:)` must
-/// return a token that is valid *now*, because a consume-only manager will not
-/// refresh an expired one (it throws `OAuthError.expired` instead). Sources
+/// There is no mode switch: whether the manager refreshes is decided by the
+/// credentials themselves. An entry with an empty `refresh` cannot be
+/// refreshed, so an authority that wants to keep refresh (and the refresh
+/// token) entirely to itself simply serves access tokens with `refresh: ""` —
+/// then this process never refreshes and never writes anything, and an
+/// expired credential is the source's fault (`OAuthError.expired`). Sources
 /// that talk to a network authority should do their own caching so the
 /// per-request read stays cheap.
 public protocol OAuthCredentialSource: Sendable {
@@ -232,40 +234,38 @@ extension OAuthStore: OAuthCredentialSource {
 
 // MARK: - Manager
 
-/// Whether a manager may refresh the credentials it reads.
-public enum OAuthRefreshPolicy: Sendable {
-    /// Expired credentials are refreshed through the provider and the fresh
-    /// pair is persisted back to the store. Requires a writable `OAuthStore`.
-    case automatic
-    /// Tokens are only ever read. An expired credential is an error
-    /// (`OAuthError.expired`) rather than a refresh — the source's authority
-    /// owns refresh, and this process writes nothing.
-    case consumeOnly
-}
-
-/// Refresh-on-demand front end. Wrap an `OAuthStore` with a set of
+/// Refresh-on-demand front end. Wrap a credential source with a set of
 /// `OAuthProvider`s. Call `apiKey(for:)` (or the `resolver()` closure) to
-/// fetch a fresh api-key — `OAuthManager` checks `.isExpired`, refreshes, and
-/// persists new credentials automatically.
+/// fetch a fresh api-key — `OAuthManager` checks `.isExpired`, refreshes
+/// entries that carry a refresh token, and persists new credentials to the
+/// store when the source is one.
 ///
-/// `init(source:)` builds the consume-only variant instead: credentials come
-/// from an external authority that owns refresh, and this manager never calls
-/// `provider.refresh` nor touches the disk.
+/// There is deliberately no refresh-policy switch: the credentials decide.
+/// An entry whose `refresh` is empty is unrefreshable, so expiry is an error
+/// (`OAuthError.expired`) — which is exactly how an external authority keeps
+/// refresh to itself: serve access tokens with `refresh: ""`.
 public actor OAuthManager {
-    /// The writable store, and thus non-nil exactly for `.automatic` managers
-    /// — `init(source:)` is always `.consumeOnly`, so there is nothing to
-    /// persist a refresh into.
+    /// The writable store when the source is one — the store-backed init sets
+    /// it, and refreshed credentials persist there. A plain `init(source:)`
+    /// has nowhere durable to write; see `refreshedOverlay`.
     public let store: OAuthStore?
     /// Where credentials are read from. Same object as `store` for the
     /// store-backed init.
     public let source: any OAuthCredentialSource
-    public let policy: OAuthRefreshPolicy
     public let client: HTTPClient
     private var providers: [String: OAuthProvider]
     /// In-flight refresh per provider id. Concurrent `apiKey(for:)` callers
     /// await the same task instead of each launching their own refresh with
     /// the same (rotated-on-use) refresh token.
     private var inFlightRefresh: [String: Task<OAuthCredentials, Error>] = [:]
+    /// Rotations with nowhere durable to go. When a store-less source serves
+    /// a refresh-bearing entry and it expires, the provider rotation must not
+    /// be lost — re-running it with the consumed refresh token would kill the
+    /// login on rotating providers. Each overlay entry remembers the exact
+    /// credentials it was refreshed *from*: while the source still serves
+    /// those, reads see the rotation; the moment the source serves anything
+    /// else (a new login, its own newer tokens), the overlay yields.
+    private var refreshedOverlay: [String: (base: OAuthCredentials, result: OAuthCredentials)] = [:]
 
     public init(
         store: OAuthStore = OAuthStore(),
@@ -274,14 +274,15 @@ public actor OAuthManager {
     ) {
         self.store = store
         self.source = store
-        self.policy = .automatic
         self.providers = Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
         self.client = client
     }
 
-    /// Consume-only manager over an external credential source. The source is
-    /// the authority on freshness (see `OAuthCredentialSource`); this manager
-    /// reads tokens, never refreshes them, and never persists anything.
+    /// Manager over an external credential source. Behavior follows the data
+    /// the source serves: refresh-less entries are consumed as-is and expiry
+    /// is the source's fault; refresh-bearing entries refresh normally, with
+    /// the rotation held in this actor's memory (the source stays the
+    /// authority — a changed entry from it drops the held rotation).
     public init(
         source: any OAuthCredentialSource,
         providers: [OAuthProvider] = OAuthManager.defaultProviders(),
@@ -289,7 +290,6 @@ public actor OAuthManager {
     ) {
         self.store = nil
         self.source = source
-        self.policy = .consumeOnly
         self.providers = Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
         self.client = client
     }
@@ -316,57 +316,89 @@ public actor OAuthManager {
     }
 
     public func credentials(for providerId: String) async throws -> OAuthCredentials? {
-        try await source.credentials(for: providerId)
+        // A held rotation stands in for exactly the entry it rotated; any
+        // other answer from the source supersedes it (see `reconciled`).
+        reconciled(try await source.credentials(for: providerId), for: providerId)
     }
 
     /// Get a valid api-key for `providerId`, refreshing if the stored token
-    /// is expired. Throws `OAuthError.missing` if no credentials are stored,
-    /// and — under `.consumeOnly`, where refreshing is not ours to do —
-    /// `OAuthError.expired` if the source served a stale one.
+    /// is expired and refreshable. Throws `OAuthError.missing` if no
+    /// credentials are stored, and `OAuthError.expired` for a stale entry
+    /// with no refresh token — that entry's authority failed to serve a
+    /// fresh one.
     public func apiKey(for providerId: String) async throws -> String {
         guard let provider = providers[providerId] else {
             throw OAuthError.unknownProvider(providerId)
         }
-        guard var credentials = try await source.credentials(for: providerId) else {
+        guard var credentials = try await credentials(for: providerId) else {
             throw OAuthError.missing(providerId: providerId)
         }
         if credentials.isExpired {
-            // `.automatic` is only reachable through `init(store:)`, so the
-            // store is there; the guard is a type-level formality.
-            guard case .automatic = policy, let store else {
+            guard !credentials.refresh.isEmpty else {
                 throw OAuthError.expired(providerId: providerId)
             }
-            credentials = try await refresh(
-                providerId, provider: provider, store: store, stale: credentials
-            )
+            credentials = try await refresh(providerId, provider: provider, stale: credentials)
         }
         return try await provider.apiKey(from: credentials, using: client)
     }
 
     /// Refresh (or join an in-flight refresh for) `providerId`. The first
     /// caller starts the task and records it; concurrent callers await the
-    /// same task. The task re-reads the store on entry so a refresh that
-    /// landed while we were suspended is reused instead of re-run.
+    /// same task. The task re-reads the credentials on entry so a refresh
+    /// that landed while we were suspended is reused instead of re-run.
     private func refresh(
         _ providerId: String,
         provider: OAuthProvider,
-        store: OAuthStore,
         stale: OAuthCredentials
     ) async throws -> OAuthCredentials {
         if let existing = inFlightRefresh[providerId] {
             return try await existing.value
         }
         let client = self.client
-        let task = Task<OAuthCredentials, Error> {
-            let current = await store.get(providerId) ?? stale
+        let task = Task<OAuthCredentials, Error> { [store] in
+            // Re-read the raw source answer: the overlay key must be what the
+            // source serves, or the next read would mistake the source's
+            // unchanged entry for a new login and drop the held rotation —
+            // then re-refresh with a consumed refresh token.
+            let served = try await self.source.credentials(for: providerId)
+            let current = await self.reconciled(served, for: providerId) ?? stale
             if !current.isExpired { return current }
             let refreshed = try await provider.refresh(current, using: client)
-            try await store.set(refreshed, for: providerId)
+            if let store {
+                try await store.set(refreshed, for: providerId)
+            } else {
+                await self.holdRotation(refreshed, from: served ?? stale, for: providerId)
+            }
             return refreshed
         }
         inFlightRefresh[providerId] = task
         defer { inFlightRefresh[providerId] = nil }
         return try await task.value
+    }
+
+    /// The credentials in effect for a raw source answer: the held rotation
+    /// while the source still serves the entry it rotated, the source's
+    /// answer otherwise (dropping any superseded rotation).
+    private func reconciled(
+        _ served: OAuthCredentials?, for providerId: String
+    ) -> OAuthCredentials? {
+        guard let served else {
+            refreshedOverlay[providerId] = nil
+            return nil
+        }
+        if let overlay = refreshedOverlay[providerId] {
+            if overlay.base == served { return overlay.result }
+            refreshedOverlay[providerId] = nil
+        }
+        return served
+    }
+
+    private func holdRotation(
+        _ refreshed: OAuthCredentials,
+        from base: OAuthCredentials,
+        for providerId: String
+    ) {
+        refreshedOverlay[providerId] = (base: base, result: refreshed)
     }
 
     /// Build an auth resolver closure. The resolver receives the active model;

--- a/Sources/KWWKAI/ProviderDirectory.swift
+++ b/Sources/KWWKAI/ProviderDirectory.swift
@@ -146,9 +146,17 @@ public func providerDescriptor(forStoreId storeId: String) -> ProviderDescriptor
 /// order, with unknown ids appended (sorted) so they still surface in
 /// `/logout` listings and the "not wired up" launch notice.
 public func storedProviderOrder(_ all: [String: OAuthCredentials]) -> [String] {
-    var order = providerDirectory.map(\.storeId).filter { all[$0] != nil }
+    storedProviderOrder(ids: Array(all.keys))
+}
+
+/// Same ordering over a bare id list, for credential sources that can name
+/// their providers without materializing every credential
+/// (`OAuthCredentialSource.providerIds()`).
+public func storedProviderOrder(ids: [String]) -> [String] {
+    let present = Set(ids)
+    var order = providerDirectory.map(\.storeId).filter { present.contains($0) }
     let known = Set(providerDirectory.map(\.storeId))
-    order.append(contentsOf: all.keys.filter { !known.contains($0) }.sorted())
+    order.append(contentsOf: present.filter { !known.contains($0) }.sorted())
     return order
 }
 

--- a/Sources/KWWKAI/StoredProviders.swift
+++ b/Sources/KWWKAI/StoredProviders.swift
@@ -9,9 +9,8 @@ import Foundation
 // terminal output — diagnostics go through the `notice` callbacks.
 //
 // Every entry point comes in two shapes: one taking an `OAuthManager` (the
-// general form — works over any source, with that manager's refresh policy)
-// and one taking a bare `OAuthStore`, which is the file-backed convenience
-// wrapper the CLI uses.
+// general form — works over any credential source) and one taking a bare
+// `OAuthStore`, which is the file-backed convenience wrapper the CLI uses.
 
 /// Result of resolving which LLM + credentials to use for this session.
 /// The provider has already been registered on `APIRegistry.shared`.
@@ -845,7 +844,7 @@ private func stringExtra(_ creds: OAuthCredentials, _ key: String) -> String? {
 /// Re-read `id` after priming, so the caller sees whatever claims the token
 /// exchange just persisted (Copilot's proxy `endpoint`, Codex's `accountId`).
 /// Falls back to the pre-prime credentials when the source has nothing to add
-/// — priming is best-effort, and a consume-only source never changes here.
+/// — priming is best-effort, and an access-only source never changes here.
 private func primed(
     _ manager: OAuthManager,
     _ id: String,
@@ -866,8 +865,8 @@ private func oauthResolver(
             return ResolvedProviderAuth(token: token, scheme: scheme, baseURL: baseURL)
         } catch OAuthError.missing, OAuthError.unknownProvider {
             // Not logged in for this provider ⇒ anonymous. Any other failure
-            // (refresh/exchange error, or a consume-only source serving an
-            // expired token) propagates so the request surfaces it instead of
+            // (refresh/exchange error, or an unrefreshable entry served
+            // expired) propagates so the request surfaces it instead of
             // silently going out unauthenticated.
             return nil
         }

--- a/Sources/KWWKAI/StoredProviders.swift
+++ b/Sources/KWWKAI/StoredProviders.swift
@@ -1,11 +1,17 @@
 import Foundation
 
-// Store-backed provider registration: turn the credentials persisted in an
-// `OAuthStore` (the `~/.kwwk/oauth.json` shape) into live, request-ready
-// providers on `APIRegistry.shared`. Shared by the kwwk CLI's launch/login
-// paths and by library consumers that sync a store from elsewhere (e.g. a
-// backend materializing per-tenant BYOK credentials). Pure library code: no
+// Stored-credential provider registration: turn the credentials an
+// `OAuthManager` can read (the `~/.kwwk/oauth.json` shape, whether they come
+// from that file or from an external `OAuthCredentialSource`) into live,
+// request-ready providers on `APIRegistry.shared`. Shared by the kwwk CLI's
+// launch/login paths and by library consumers that hold credentials elsewhere
+// (e.g. a backend serving per-tenant BYOK tokens). Pure library code: no
 // terminal output — diagnostics go through the `notice` callbacks.
+//
+// Every entry point comes in two shapes: one taking an `OAuthManager` (the
+// general form — works over any source, with that manager's refresh policy)
+// and one taking a bare `OAuthStore`, which is the file-backed convenience
+// wrapper the CLI uses.
 
 /// Result of resolving which LLM + credentials to use for this session.
 /// The provider has already been registered on `APIRegistry.shared`.
@@ -129,13 +135,13 @@ public actor SessionAuthResolvers {
     }
 }
 
-/// Register **every** provider stored in `store` on `APIRegistry.shared`
-/// (each scoped by its `model.provider` so same-wire providers don't clobber
-/// each other), and return a `ResolvedAuth` whose model is the *active*
-/// provider's default and whose `authResolver` is a **unified** closure that
-/// dispatches by `model.provider` across all logged-in accounts. The CLI's
-/// `/model` can then switch to any registered provider's models mid-session
-/// and requests route to the right credentials.
+/// Register **every** provider `manager` holds credentials for on
+/// `APIRegistry.shared` (each scoped by its `model.provider` so same-wire
+/// providers don't clobber each other), and return a `ResolvedAuth` whose
+/// model is the *active* provider's default and whose `authResolver` is a
+/// **unified** closure that dispatches by `model.provider` across all
+/// logged-in accounts. The CLI's `/model` can then switch to any registered
+/// provider's models mid-session and requests route to the right credentials.
 ///
 /// Active-provider selection:
 ///   - `modelOverride` of the form `provider/id` activates that provider (if
@@ -143,17 +149,16 @@ public actor SessionAuthResolvers {
 ///   - Otherwise the highest-priority logged-in provider is active, and a bare
 ///     `modelOverride` names its model.
 ///
-/// Throws `AuthResolveError.noCredentials` when the store is empty (or no
-/// stored entry could be registered). Skipped entries — same-scope dual
-/// logins, unwired ids — are reported through `notice`.
+/// Throws `AuthResolveError.noCredentials` when the manager's source holds
+/// nothing (or no entry could be registered). Skipped entries — same-scope
+/// dual logins, unwired ids — are reported through `notice`.
 public func registerAllStored(
-    store: OAuthStore,
+    manager: OAuthManager,
     modelOverride: String? = nil,
     context1m: Bool = false,
     notice: @escaping @Sendable (String) -> Void = { _ in }
 ) async throws -> ResolvedAuth {
-    let all = await store.all()
-    let order = storedProviderOrder(all)
+    let order = await storedProviderOrder(ids: manager.providerIds())
 
     // Split an explicit `provider/model` override and resolve which logged-in
     // store id it targets (prefer the priority order on ambiguity, e.g.
@@ -179,7 +184,6 @@ public func registerAllStored(
     var active: ResolvedAuth?
 
     for storeId in order {
-        guard all[storeId] != nil else { continue }
         let scope = modelProviderScope(forStoreId: storeId)
         if seenScopes.contains(scope) {
             notice("'\(storeId)' shares the '\(scope)' provider slot with an already-registered login; skipping.")
@@ -192,7 +196,7 @@ public func registerAllStored(
         // fired an OAuth refresh/exchange network round-trip per account on
         // every launch, for accounts the session may never touch.
         guard let resolved = try await registerStored(
-            storeId: storeId, store: store, modelOverride: mo, context1m: context1m,
+            storeId: storeId, manager: manager, modelOverride: mo, context1m: context1m,
             primeToken: storeId == activeStoreId,
             notice: notice
         ) else { continue }
@@ -223,6 +227,20 @@ public func registerAllStored(
     )
 }
 
+/// File-store convenience wrapper: register everything in `store` through a
+/// refresh-on-demand `OAuthManager`. What the CLI calls at launch.
+public func registerAllStored(
+    store: OAuthStore,
+    modelOverride: String? = nil,
+    context1m: Bool = false,
+    notice: @escaping @Sendable (String) -> Void = { _ in }
+) async throws -> ResolvedAuth {
+    try await registerAllStored(
+        manager: OAuthManager(store: store),
+        modelOverride: modelOverride, context1m: context1m, notice: notice
+    )
+}
+
 /// Register one stored provider on `APIRegistry.shared` (scoped by its
 /// `model.provider`) and return its `ResolvedAuth` (default model + optional
 /// per-provider resolver). Shared by launch-time `registerAllStored` and the
@@ -230,7 +248,7 @@ public func registerAllStored(
 /// missing credentials (reporting a `notice` for the former).
 public func registerStored(
     storeId: String,
-    store: OAuthStore,
+    manager: OAuthManager,
     modelOverride: String? = nil,
     context1m: Bool = false,
     // When false, skip the eager OAuth token refresh/exchange network call at
@@ -240,13 +258,13 @@ public func registerStored(
     primeToken: Bool = true,
     notice: @escaping @Sendable (String) -> Void = { _ in }
 ) async throws -> ResolvedAuth? {
-    guard let creds = await store.get(storeId) else { return nil }
+    guard let creds = try await manager.credentials(for: storeId) else { return nil }
     switch storeId {
     case "openai-codex":
-        return await registerCodex(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+        return await registerCodex(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "anthropic":
         return await registerAnthropicOAuth(
-            store: store, creds: creds, modelOverride: modelOverride, context1m: context1m, primeToken: primeToken
+            manager: manager, creds: creds, modelOverride: modelOverride, context1m: context1m, primeToken: primeToken
         )
     case "anthropic-api-key":
         return await registerAnthropicAPIKey(creds: creds, modelOverride: modelOverride)
@@ -259,11 +277,11 @@ public func registerStored(
     case "openrouter":
         return await registerOpenRouter(creds: creds, modelOverride: modelOverride)
     case "github-copilot":
-        return await registerGitHubCopilot(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+        return await registerGitHubCopilot(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "cursor":
-        return await registerCursor(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+        return await registerCursor(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "kimi-coding":
-        return await registerKimiCoding(store: store, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+        return await registerKimiCoding(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "zai", "zai-coding-cn":
         return await registerZai(storeId: storeId, creds: creds, modelOverride: modelOverride)
     default:
@@ -272,15 +290,30 @@ public func registerStored(
     }
 }
 
+/// File-store convenience wrapper for `registerStored(storeId:manager:…)`.
+public func registerStored(
+    storeId: String,
+    store: OAuthStore,
+    modelOverride: String? = nil,
+    context1m: Bool = false,
+    primeToken: Bool = true,
+    notice: @escaping @Sendable (String) -> Void = { _ in }
+) async throws -> ResolvedAuth? {
+    try await registerStored(
+        storeId: storeId, manager: OAuthManager(store: store),
+        modelOverride: modelOverride, context1m: context1m,
+        primeToken: primeToken, notice: notice
+    )
+}
+
 // MARK: - Codex (OAuth)
 
 private func registerCodex(
-    store: OAuthStore,
+    manager: OAuthManager,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
     primeToken: Bool = true
 ) async -> ResolvedAuth {
-    let manager = OAuthManager(store: store)
     // Grab a fresh token if expired. If the refresh fails we still register
     // the provider — the authResolver below will retry on the next request
     // and surface the error to the user there. When not priming, read the
@@ -290,7 +323,7 @@ private func registerCodex(
         _ = try? await manager.apiKey(for: "openai-codex")
     }
 
-    let refreshed = primeToken ? (await store.get("openai-codex") ?? creds) : creds
+    let refreshed = primeToken ? await primed(manager, "openai-codex", fallback: creds) : creds
     let accountId: String? = {
         if case .string(let s) = refreshed.extras["accountId"] ?? .null { return s }
         return nil
@@ -329,13 +362,12 @@ private func registerCodex(
 // MARK: - Anthropic OAuth
 
 private func registerAnthropicOAuth(
-    store: OAuthStore,
+    manager: OAuthManager,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
     context1m: Bool = false,
     primeToken: Bool = true
 ) async -> ResolvedAuth {
-    let manager = OAuthManager(store: store)
     // Prime the token only for the active provider; otherwise the resolver
     // refreshes lazily on the first request.
     if primeToken {
@@ -391,12 +423,11 @@ private func registerAnthropicOAuth(
 // MARK: - GitHub Copilot (OAuth)
 
 private func registerGitHubCopilot(
-    store: OAuthStore,
+    manager: OAuthManager,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
     primeToken: Bool = true
 ) async -> ResolvedAuth {
-    let manager = OAuthManager(store: store)
     // Prime the session token — Copilot's `refresh` is actually a PAT →
     // session-token exchange that must happen before the proxy will route.
     // We ignore the returned token; the resolver below re-fetches on demand
@@ -408,7 +439,7 @@ private func registerGitHubCopilot(
     if primeToken {
         _ = try? await manager.apiKey(for: "github-copilot")
     }
-    let refreshed = primeToken ? (await store.get("github-copilot") ?? creds) : creds
+    let refreshed = primeToken ? await primed(manager, "github-copilot", fallback: creds) : creds
 
     // Copilot Business / Enterprise get a proxy-endpoint claim (e.g.
     // `https://api.business.githubcopilot.com`) that the session-token
@@ -500,12 +531,11 @@ private func registerGitHubCopilot(
 // MARK: - Cursor (OAuth subscription)
 
 private func registerCursor(
-    store: OAuthStore,
+    manager: OAuthManager,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
     primeToken: Bool = true
 ) async -> ResolvedAuth {
-    let manager = OAuthManager(store: store)
     // Prime the token only for the active provider; the resolver refreshes
     // lazily on the first request for the others. Cursor's `refresh` exchanges
     // the stored refresh token for a fresh short-lived JWT access token.
@@ -538,12 +568,11 @@ private func registerCursor(
 // MARK: - Kimi For Coding (OAuth device flow)
 
 private func registerKimiCoding(
-    store: OAuthStore,
+    manager: OAuthManager,
     creds: OAuthCredentials,
     modelOverride: String? = nil,
     primeToken: Bool = true
 ) async -> ResolvedAuth {
-    let manager = OAuthManager(store: store)
     // Prime the token only for the active provider; the resolver refreshes
     // lazily on the first request for the others.
     if primeToken {
@@ -813,6 +842,18 @@ private func stringExtra(_ creds: OAuthCredentials, _ key: String) -> String? {
     return nil
 }
 
+/// Re-read `id` after priming, so the caller sees whatever claims the token
+/// exchange just persisted (Copilot's proxy `endpoint`, Codex's `accountId`).
+/// Falls back to the pre-prime credentials when the source has nothing to add
+/// — priming is best-effort, and a consume-only source never changes here.
+private func primed(
+    _ manager: OAuthManager,
+    _ id: String,
+    fallback: OAuthCredentials
+) async -> OAuthCredentials {
+    (try? await manager.credentials(for: id)) ?? fallback
+}
+
 private func oauthResolver(
     manager: OAuthManager,
     providerId: String,
@@ -825,8 +866,9 @@ private func oauthResolver(
             return ResolvedProviderAuth(token: token, scheme: scheme, baseURL: baseURL)
         } catch OAuthError.missing, OAuthError.unknownProvider {
             // Not logged in for this provider ⇒ anonymous. Any other failure
-            // (refresh/exchange error) propagates so the request surfaces it
-            // instead of silently going out unauthenticated.
+            // (refresh/exchange error, or a consume-only source serving an
+            // expired token) propagates so the request surfaces it instead of
+            // silently going out unauthenticated.
             return nil
         }
     }

--- a/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
+++ b/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import KWWKAI
+
+/// Covers the consume-only path: an `OAuthManager` reading through an external
+/// `OAuthCredentialSource` must never refresh and never persist — a stale
+/// token is the authority's problem, and surfaces as `OAuthError.expired`.
+@Suite("OAuth credential source")
+struct OAuthCredentialSourceTests {
+
+    /// Stands in for an external authority (a backend that owns refresh):
+    /// serves a fixed table, writes nothing.
+    final class StubSource: OAuthCredentialSource, @unchecked Sendable {
+        private let lock = NSLock()
+        private let table: [String: OAuthCredentials]
+        init(_ table: [String: OAuthCredentials]) { self.table = table }
+        func providerIds() async -> [String] { lock.withLock { Array(table.keys) } }
+        func credentials(for providerId: String) async throws -> OAuthCredentials? {
+            lock.withLock { table[providerId] }
+        }
+    }
+
+    /// Provider whose `refresh` must never run under `.consumeOnly`. It counts
+    /// the call rather than refusing it, so a regression fails on the count
+    /// assertion instead of on some unrelated error.
+    final class RefreshCountingProvider: OAuthProvider, @unchecked Sendable {
+        let id: String
+        let name = "consume-only probe"
+        private let lock = NSLock()
+        private var count = 0
+        var refreshCount: Int { lock.withLock { count } }
+        init(id: String) { self.id = id }
+        func refresh(_ c: OAuthCredentials, using client: HTTPClient) async throws -> OAuthCredentials {
+            lock.withLock { count += 1 }
+            return OAuthCredentials(access: "refreshed", refresh: c.refresh, expires: .max)
+        }
+    }
+
+    private func fresh(_ access: String) -> OAuthCredentials {
+        OAuthCredentials(
+            access: access, refresh: "r",
+            expires: Int64(Date().timeIntervalSince1970 * 1000) + 600_000
+        )
+    }
+
+    @Test("consume-only serves the source's token without refreshing")
+    func consumeOnlyServesSourceToken() async throws {
+        let source = StubSource(["x": fresh("from-authority")])
+        let provider = RefreshCountingProvider(id: "x")
+        let manager = OAuthManager(source: source, providers: [provider])
+
+        #expect(await manager.policy == .consumeOnly)
+        #expect(await manager.store == nil)
+        #expect(try await manager.apiKey(for: "x") == "from-authority")
+        #expect(provider.refreshCount == 0)
+    }
+
+    @Test("consume-only reports an expired credential instead of refreshing it")
+    func consumeOnlyRefusesToRefresh() async throws {
+        let stale = OAuthCredentials(access: "stale", refresh: "r", expires: 0)
+        let source = StubSource(["x": stale])
+        let provider = RefreshCountingProvider(id: "x")
+        let manager = OAuthManager(source: source, providers: [provider])
+
+        let thrown = await #expect(throws: OAuthError.self) {
+            _ = try await manager.apiKey(for: "x")
+        }
+        if case .expired(let id)? = thrown {
+            #expect(id == "x")
+        } else {
+            Issue.record("expected .expired, got \(String(describing: thrown))")
+        }
+        // The whole point: the authority refreshes, we don't.
+        #expect(provider.refreshCount == 0)
+    }
+
+    @Test("consume-only reports a credential the source doesn't hold as missing")
+    func consumeOnlyMissing() async throws {
+        let manager = OAuthManager(
+            source: StubSource([:]), providers: [RefreshCountingProvider(id: "x")]
+        )
+        let thrown = await #expect(throws: OAuthError.self) {
+            _ = try await manager.apiKey(for: "x")
+        }
+        if case .missing(let id)? = thrown {
+            #expect(id == "x")
+        } else {
+            Issue.record("expected .missing, got \(String(describing: thrown))")
+        }
+    }
+
+    @Test("the file store is itself a credential source")
+    func storeIsASource() async throws {
+        let store = OAuthStore()
+        try await store.set(fresh("a"), for: "anthropic")
+        try await store.set(fresh("c"), for: "cursor")
+
+        #expect(await store.providerIds().sorted() == ["anthropic", "cursor"])
+        #expect(await store.credentials(for: "anthropic")?.access == "a")
+        #expect(await store.credentials(for: "nobody") == nil)
+
+        // And it works through the existential, which is how a manager holds it.
+        let source: any OAuthCredentialSource = store
+        #expect(try await source.credentials(for: "cursor")?.access == "c")
+    }
+
+    @Test("a store-backed manager keeps refreshing and persisting")
+    func storeBackedManagerStillRefreshes() async throws {
+        let store = OAuthStore()
+        try await store.set(
+            OAuthCredentials(access: "stale", refresh: "r", expires: 0), for: "x"
+        )
+        let provider = RefreshCountingProvider(id: "x")
+        let manager = OAuthManager(store: store, providers: [provider])
+
+        #expect(await manager.policy == .automatic)
+        #expect(try await manager.apiKey(for: "x") == "refreshed")
+        #expect(provider.refreshCount == 1)
+        #expect(await store.get("x")?.access == "refreshed")
+    }
+
+    @Test("registerAllStored wires a provider read from an external source")
+    func registerAllStoredOverSource() async throws {
+        let source = StubSource(["anthropic": fresh("from-authority")])
+        let provider = RefreshCountingProvider(id: "anthropic")
+        let manager = OAuthManager(source: source, providers: [provider])
+
+        let resolved = try await registerAllStored(manager: manager)
+        #expect(resolved.model.provider == "anthropic")
+        #expect(resolved.model.api == "anthropic-messages")
+        #expect(resolved.providerSlots.map(\.storeId) == ["anthropic"])
+
+        // The session resolver reads back through the source, so requests
+        // carry the authority's token — and priming never refreshed it.
+        let auth = try await resolved.authResolver?(resolved.model, nil)
+        #expect(auth?.token == "from-authority")
+        #expect(auth?.scheme == .bearer)
+        #expect(provider.refreshCount == 0)
+
+        await APIRegistry.shared.unregisterScope("anthropic")
+    }
+}

--- a/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
+++ b/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
@@ -5,62 +5,66 @@ import FoundationNetworking
 import Testing
 @testable import KWWKAI
 
-/// Covers the consume-only path: an `OAuthManager` reading through an external
-/// `OAuthCredentialSource` must never refresh and never persist — a stale
-/// token is the authority's problem, and surfaces as `OAuthError.expired`.
+/// Covers `OAuthManager` over an external `OAuthCredentialSource`. There is
+/// no refresh-policy switch — the credentials decide: an entry with an empty
+/// `refresh` is consumed as-is and its expiry is the authority's fault
+/// (`OAuthError.expired`); a refresh-bearing entry refreshes normally, with
+/// the rotation held in the manager while the source keeps serving the entry
+/// it rotated.
 @Suite("OAuth credential source")
 struct OAuthCredentialSourceTests {
 
     /// Stands in for an external authority (a backend that owns refresh):
-    /// serves a fixed table, writes nothing.
+    /// serves a mutable table, writes nothing.
     final class StubSource: OAuthCredentialSource, @unchecked Sendable {
         private let lock = NSLock()
-        private let table: [String: OAuthCredentials]
+        private var table: [String: OAuthCredentials]
         init(_ table: [String: OAuthCredentials]) { self.table = table }
         func providerIds() async -> [String] { lock.withLock { Array(table.keys) } }
         func credentials(for providerId: String) async throws -> OAuthCredentials? {
             lock.withLock { table[providerId] }
         }
+        func serve(_ credentials: OAuthCredentials?, for providerId: String) {
+            lock.withLock { table[providerId] = credentials }
+        }
     }
 
-    /// Provider whose `refresh` must never run under `.consumeOnly`. It counts
-    /// the call rather than refusing it, so a regression fails on the count
-    /// assertion instead of on some unrelated error.
+    /// Counts `refresh` calls rather than refusing them, so a regression
+    /// fails on the count assertion instead of on some unrelated error.
     final class RefreshCountingProvider: OAuthProvider, @unchecked Sendable {
         let id: String
-        let name = "consume-only probe"
+        let name = "refresh probe"
         private let lock = NSLock()
         private var count = 0
         var refreshCount: Int { lock.withLock { count } }
         init(id: String) { self.id = id }
         func refresh(_ c: OAuthCredentials, using client: HTTPClient) async throws -> OAuthCredentials {
             lock.withLock { count += 1 }
-            return OAuthCredentials(access: "refreshed", refresh: c.refresh, expires: .max)
+            return OAuthCredentials(access: "refreshed", refresh: "rotated", expires: .max)
         }
     }
 
-    private func fresh(_ access: String) -> OAuthCredentials {
+    private func fresh(_ access: String, refresh: String = "") -> OAuthCredentials {
         OAuthCredentials(
-            access: access, refresh: "r",
+            access: access, refresh: refresh,
             expires: Int64(Date().timeIntervalSince1970 * 1000) + 600_000
         )
     }
 
-    @Test("consume-only serves the source's token without refreshing")
-    func consumeOnlyServesSourceToken() async throws {
+    @Test("a fresh token from the source is served without refreshing")
+    func servesSourceToken() async throws {
         let source = StubSource(["x": fresh("from-authority")])
         let provider = RefreshCountingProvider(id: "x")
         let manager = OAuthManager(source: source, providers: [provider])
 
-        #expect(await manager.policy == .consumeOnly)
         #expect(await manager.store == nil)
         #expect(try await manager.apiKey(for: "x") == "from-authority")
         #expect(provider.refreshCount == 0)
     }
 
-    @Test("consume-only reports an expired credential instead of refreshing it")
-    func consumeOnlyRefusesToRefresh() async throws {
-        let stale = OAuthCredentials(access: "stale", refresh: "r", expires: 0)
+    @Test("an expired entry with no refresh token is the authority's fault")
+    func expiredWithoutRefreshTokenThrows() async throws {
+        let stale = OAuthCredentials(access: "stale", refresh: "", expires: 0)
         let source = StubSource(["x": stale])
         let provider = RefreshCountingProvider(id: "x")
         let manager = OAuthManager(source: source, providers: [provider])
@@ -73,12 +77,13 @@ struct OAuthCredentialSourceTests {
         } else {
             Issue.record("expected .expired, got \(String(describing: thrown))")
         }
-        // The whole point: the authority refreshes, we don't.
+        // No refresh token means nothing to refresh with — the authority
+        // serving access-only entries has kept refresh to itself.
         #expect(provider.refreshCount == 0)
     }
 
-    @Test("consume-only reports a credential the source doesn't hold as missing")
-    func consumeOnlyMissing() async throws {
+    @Test("a credential the source doesn't hold is missing")
+    func missing() async throws {
         let manager = OAuthManager(
             source: StubSource([:]), providers: [RefreshCountingProvider(id: "x")]
         )
@@ -92,11 +97,37 @@ struct OAuthCredentialSourceTests {
         }
     }
 
+    @Test("a refresh-bearing entry from a store-less source refreshes once and the rotation is held")
+    func refreshBearingEntryRotatesOnceAndHolds() async throws {
+        let stale = OAuthCredentials(access: "stale", refresh: "r1", expires: 0)
+        let source = StubSource(["x": stale])
+        let provider = RefreshCountingProvider(id: "x")
+        let manager = OAuthManager(source: source, providers: [provider])
+
+        #expect(try await manager.apiKey(for: "x") == "refreshed")
+        #expect(provider.refreshCount == 1)
+
+        // The source still serves the stale entry, but re-running the
+        // rotation with its consumed refresh token would kill the login on
+        // rotating providers — the held rotation answers instead.
+        #expect(try await manager.apiKey(for: "x") == "refreshed")
+        #expect(provider.refreshCount == 1)
+        #expect(try await manager.credentials(for: "x")?.refresh == "rotated")
+
+        // The moment the source serves something else — a new login — the
+        // source wins and the held rotation is dropped.
+        let relogin = fresh("relogged", refresh: "r2")
+        source.serve(relogin, for: "x")
+        #expect(try await manager.credentials(for: "x") == relogin)
+        #expect(try await manager.apiKey(for: "x") == "relogged")
+        #expect(provider.refreshCount == 1)
+    }
+
     @Test("the file store is itself a credential source")
     func storeIsASource() async throws {
         let store = OAuthStore()
-        try await store.set(fresh("a"), for: "anthropic")
-        try await store.set(fresh("c"), for: "cursor")
+        try await store.set(fresh("a", refresh: "r"), for: "anthropic")
+        try await store.set(fresh("c", refresh: "r"), for: "cursor")
 
         #expect(await store.providerIds().sorted() == ["anthropic", "cursor"])
         #expect(await store.credentials(for: "anthropic")?.access == "a")
@@ -116,7 +147,6 @@ struct OAuthCredentialSourceTests {
         let provider = RefreshCountingProvider(id: "x")
         let manager = OAuthManager(store: store, providers: [provider])
 
-        #expect(await manager.policy == .automatic)
         #expect(try await manager.apiKey(for: "x") == "refreshed")
         #expect(provider.refreshCount == 1)
         #expect(await store.get("x")?.access == "refreshed")


### PR DESCRIPTION
## Summary

- New `OAuthCredentialSource` protocol: the read side of the credential store. `OAuthStore` (file-backed) is now one implementation; hosts that own refresh elsewhere (e.g. a backend serving per-tenant BYOK tokens) implement it to inject tokens without materializing `oauth.json` on disk.
- **No refresh-policy switch — the credentials decide.** An entry with an empty `refresh` cannot be refreshed: expiry surfaces as the new `OAuthError.expired` and nothing is written, so an authority that wants refresh kept entirely to itself simply serves access-only entries. A refresh-bearing entry refreshes exactly as before. `resolver()` deliberately propagates `.expired` instead of downgrading to an anonymous request.
- Rotation safety for store-less sources: when a plain `init(source:)` manager refreshes a rotating entry, the rotation is held in the manager's memory keyed on the exact entry the source served — re-running a rotation with a consumed refresh token would kill the login. The source stays the authority: the moment it serves anything else (a re-login), the held rotation is dropped.
- `registerAllStored(manager:)` / `registerStored(manager:)` variants register providers over any manager/source; the existing `store:` signatures remain as thin wrappers, so the CLI paths are unchanged. `storedProviderOrder(ids:)` orders a bare id list for sources that can name providers without decrypting credentials.
- `swift test` — 1323 tests, all green.

Consumer: AirBuildEnvironment's BYOK credential source (backend-refreshed tokens served with `refresh: ""`, in-memory cache), designed in backend `docs/byok.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZ2zHUCip2cGnXHcrSKShK