### PR TITLE
chore: refresh bundled model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -1860,6 +1860,158 @@
   {
     "api" : "cursor-agent",
     "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-high",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-high-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-low",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-low-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Low Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-medium",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Medium",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-medium-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Medium Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-xhigh",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Extra High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "cursor-grok-4.6-xhigh-fast",
+    "input" : [
+      "text"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Cursor Grok 4.6 Extra High Fast",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
     "contextWindow" : 1048576,
     "cost" : {
       "cacheRead" : 0,

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -1805,7 +1805,7 @@
       "compat" : {
         "supportsStrictMode" : true
       },
-      "contextWindow" : 272000,
+      "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0.275,
@@ -1831,10 +1831,10 @@
       "compat" : {
         "supportsStrictMode" : true
       },
-      "contextWindow" : 272000,
+      "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.55,
-        "cacheWrite" : 6.88,
+        "cacheWrite" : 6.875,
         "input" : 5.5,
         "output" : 33
       },
@@ -1857,7 +1857,7 @@
       "compat" : {
         "supportsStrictMode" : true
       },
-      "contextWindow" : 272000,
+      "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.22,
         "cacheWrite" : 2.75,
@@ -5184,6 +5184,9 @@
     "gpt-4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 8192,
       "cost" : {
         "cacheRead" : 0,
@@ -5203,6 +5206,9 @@
     "gpt-4-turbo" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
@@ -5223,6 +5229,9 @@
     "gpt-4o" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 1.25,
@@ -5243,6 +5252,9 @@
     "gpt-4o-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.080000000000000002,
@@ -5264,7 +5276,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -5296,7 +5309,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -5328,7 +5342,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -5360,7 +5375,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -5392,7 +5408,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 400000,
       "cost" : {
@@ -5424,7 +5441,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -5456,7 +5474,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -5488,7 +5507,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -5529,7 +5549,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -5561,7 +5582,8 @@
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
-        "supportsOpenAIGrammarTools" : true
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
       },
       "contextWindow" : 1050000,
       "cost" : {
@@ -5601,6 +5623,9 @@
     "o1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 7.5,
@@ -5630,6 +5655,9 @@
     "o3" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -5659,6 +5687,9 @@
     "o3-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.55,
@@ -5687,6 +5718,9 @@
     "o3-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0,
@@ -5716,6 +5750,9 @@
     "o4-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
       "contextWindow" : 200000,
       "cost" : {
         "cacheRead" : 0.28,
@@ -6307,7 +6344,7 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : null,
+        "low" : "low",
         "max" : "max",
         "medium" : null,
         "minimal" : null
@@ -7890,6 +7927,41 @@
       ],
       "maxTokens" : 128000,
       "name" : "MAI-Code-1-Flash",
+      "provider" : "github-copilot",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "mai-code-1.1-flash" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 1.2
+      },
+      "headers" : {
+        "Copilot-Integration-Id" : "vscode-chat",
+        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
+        "Editor-Version" : "vscode\/1.107.0",
+        "User-Agent" : "GitHubCopilotChat\/0.35.0"
+      },
+      "id" : "mai-code-1.1-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "MAI-Code-1.1-Flash",
       "provider" : "github-copilot",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -12286,6 +12358,36 @@
       "provider" : "nvidia",
       "reasoning" : true
     },
+    "nvidia\/nemotron-3.5-lightning-30b-a3b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "NVCF-POLL-SECONDS" : "3600"
+      },
+      "id" : "nvidia\/nemotron-3.5-lightning-30b-a3b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Nemotron 3.5 Lightning 30B A3B",
+      "provider" : "nvidia",
+      "reasoning" : true
+    },
     "nvidia\/nemotron-nano-12b-v2-vl" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -15252,6 +15354,38 @@
         "xhigh" : null
       }
     },
+    "grok-4.6" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "sessionAffinityFormat" : "openai-nosession"
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.6",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "grok-build-0.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -15280,6 +15414,39 @@
         "medium" : null,
         "minimal" : null,
         "off" : null
+      }
+    },
+    "hy3-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 190000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "hy3-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Hy3 Free",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
       }
     },
     "kimi-k2.5" : {
@@ -15452,30 +15619,6 @@
       "provider" : "opencode",
       "reasoning" : true
     },
-    "longcat-2.0-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "longcat-2.0-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "LongCat-2.0 Free",
-      "provider" : "opencode",
-      "reasoning" : true
-    },
     "mimo-v2.5-free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -15599,7 +15742,7 @@
       "provider" : "opencode",
       "reasoning" : true
     },
-    "north-mini-code-free" : {
+    "nemotron-3.5-lightning-free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
       "compat" : {
@@ -15607,30 +15750,21 @@
         "supportsDeveloperRole" : false,
         "supportsStore" : false
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0,
         "output" : 0
       },
-      "id" : "north-mini-code-free",
+      "id" : "nemotron-3.5-lightning-free",
       "input" : [
         "text"
       ],
-      "maxTokens" : 64000,
-      "name" : "North Mini Code Free",
+      "maxTokens" : 262144,
+      "name" : "Nemotron 3.5 Lightning Free",
       "provider" : "opencode",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : null
-      }
+      "reasoning" : true
     },
     "qwen3.5-plus" : {
       "api" : "anthropic-messages",
@@ -15729,7 +15863,7 @@
         "text"
       ],
       "maxTokens" : 384000,
-      "name" : "DeepSeek V4 Pro",
+      "name" : "DeepSeek V4 Pro (New)",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -16276,16 +16410,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.015959999999999998,
+        "cacheRead" : 0.0252,
         "cacheWrite" : 0,
-        "input" : 0.079799999999999996,
-        "output" : 0.1596
+        "input" : 0.079995999999999998,
+        "output" : 0.252
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 4096,
       "name" : "DeepSeek V4 Flash Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -16427,7 +16561,7 @@
       },
       "contextWindow" : 500000,
       "cost" : {
-        "cacheRead" : 0.3,
+        "cacheRead" : 0.5,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -17509,6 +17643,54 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "bytedance-seed\/seed-2-1-turbo" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 2.5
+      },
+      "id" : "bytedance-seed\/seed-2-1-turbo",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "ByteDance Seed: Seed 2.1 Turbo",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "bytedance-seed\/seed-2.0-code" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 3
+      },
+      "id" : "bytedance-seed\/seed-2.0-code",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "ByteDance Seed: Seed-2.0-Code",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "bytedance-seed\/seed-2.0-lite" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -17748,12 +17930,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.135,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
         "input" : 0.27,
-        "output" : 1
+        "output" : 0.95
       },
       "id" : "deepseek\/deepseek-v3.1-terminus",
       "input" : [
@@ -17884,10 +18066,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.054364000000000003,
+        "cacheRead" : 0.098549999999999999,
         "cacheWrite" : 0,
-        "input" : 0.64432,
-        "output" : 1.28864
+        "input" : 1.168,
+        "output" : 2.336
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
@@ -17895,6 +18077,38 @@
       ],
       "maxTokens" : 393216,
       "name" : "DeepSeek: DeepSeek V4 Pro",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek\/deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.0036250000000000002,
+        "cacheWrite" : 0,
+        "input" : 0.435,
+        "output" : 0.87
+      },
+      "id" : "deepseek\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek: DeepSeek V4 Pro 0813",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -18835,6 +19049,29 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "liquid\/lfm-2.5-2.6b:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "liquid\/lfm-2.5-2.6b:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "LiquidAI: LFM2.5-2.6B (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "meituan\/longcat-2.0" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -19716,8 +19953,8 @@
       "cost" : {
         "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.7,
-        "output" : 3.5
+        "input" : 0.67,
+        "output" : 3.4
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -20007,6 +20244,52 @@
       ],
       "maxTokens" : 65536,
       "name" : "NVIDIA: Nemotron 3 Ultra (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "nvidia\/nemotron-3.5-lightning" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.1,
+        "output" : 0.25
+      },
+      "id" : "nvidia\/nemotron-3.5-lightning",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "NVIDIA: Nemotron 3.5 Lightning",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "nvidia\/nemotron-3.5-lightning:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "nvidia\/nemotron-3.5-lightning:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 65536,
+      "name" : "NVIDIA: Nemotron 3.5 Lightning (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -21819,9 +22102,9 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.029999999999999999,
         "cacheWrite" : 0,
-        "input" : 0.036999999999999998,
+        "input" : 0.029999999999999999,
         "output" : 0.17
       },
       "id" : "openai\/gpt-oss-120b",
@@ -23018,10 +23301,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.21,
-        "output" : 1.9
+        "input" : 0.26,
+        "output" : 1.04
       },
       "id" : "qwen\/qwen3-vl-235b-a22b-instruct",
       "input" : [
@@ -23114,10 +23397,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 1
+        "input" : 0.25,
+        "output" : 1.25
       },
       "id" : "qwen\/qwen3.5-35b-a3b",
       "input" : [
@@ -23162,17 +23445,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.3,
+        "cacheRead" : 0.044999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 3.6
+        "input" : 0.45,
+        "output" : 3
       },
       "id" : "qwen\/qwen3.5-397b-a17b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 65536,
       "name" : "Qwen: Qwen3.5 397B A17B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23439,6 +23722,29 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "qwen\/qwen3.8-2.4t-a95b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "qwen\/qwen3.8-2.4t-a95b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 52429,
+      "name" : "Qwen: Qwen3.8 2.4T A95B",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "qwen\/qwen3.8-max" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -23531,6 +23837,30 @@
       ],
       "maxTokens" : 128000,
       "name" : "Sakana: Fugu Ultra",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "sakana\/sakana-namazu" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0,
+        "input" : 0.95,
+        "output" : 4
+      },
+      "id" : "sakana\/sakana-namazu",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Sakana: Sakana Namazu",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -23836,6 +24166,30 @@
       ],
       "maxTokens" : 4096,
       "name" : "SpaceXAI: Grok 4.5",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "x-ai\/grok-4.6" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "x-ai\/grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 4096,
+      "name" : "SpaceXAI: Grok 4.6",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -24173,18 +24527,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.14,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.76,
-        "output" : 2.42
+        "input" : 0.5,
+        "output" : 3.15
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "Z.ai: GLM 5.2",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -27199,6 +27553,25 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "deepseek\/deepseek-v4-pro-0813" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.0035999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.435,
+        "output" : 0.87
+      },
+      "id" : "deepseek\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "google\/gemini-2.5-flash" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29310,6 +29683,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "sakana\/namazu" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0,
+        "input" : 0.95,
+        "output" : 4
+      },
+      "id" : "sakana\/namazu",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 256000,
+      "name" : "Sakana Namazu",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "stepfun\/step-3.5-flash" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29486,6 +29879,25 @@
       ],
       "maxTokens" : 500000,
       "name" : "Grok 4.5",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "xai\/grok-4.6" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "xai\/grok-4.6",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.6",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -30015,6 +30427,31 @@
         "off" : null,
         "xhigh" : null
       }
+    },
+    "grok-4.6" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.x.ai\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.6",
+      "provider" : "xai",
+      "reasoning" : true
     },
     "grok-build-0.1" : {
       "api" : "openai-completions",


### PR DESCRIPTION
## Summary

- refresh `models.json` from authoritative badlogic/pi-mono main commit `581d75a89cea21e50d6a26df840352f94427f633`
- update the regular catalog from 1,217 to 1,233 models across 39 providers: 18 additions, 2 removals, and metadata changes for 34 models
- additions include Grok 4.6 across xAI/OpenRouter/OpenCode/Vercel, DeepSeek V4 Pro 0813, Nemotron 3.5 Lightning, MAI-Code 1.1 Flash, Qwen 3.8, and other upstream entries
- remove the retired OpenCode `longcat-2.0-free` and `north-mini-code-free` entries
- metadata changes cover context and output limits, pricing, strict-mode compatibility, one reasoning-level mapping, and one display name
- update `cursor-models.json` from 187 to 195 models by adding eight Cursor Grok 4.6 reasoning/fast variants; no Cursor removals or metadata-only changes

## Validation

- `jq empty Sources/KWWKAI/Resources/models.json Sources/KWWKAI/Resources/cursor-models.json`
- `git diff --check`
- endpoint and credential-pattern scans
- targeted catalog, generator, and Cursor tests: 44 tests in 7 suites
- full `swift test`: 1,323 tests in 195 suites
