### PR TITLE
chore(kwwk): bump version to 0.1.40

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.39"
+    static let version = "0.1.40"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.40 from the latest `main`.

This release includes the credential-source improvements merged in #103 and the refreshed pi-mono/Cursor model catalogs merged in #104.

Validation:
- `swift build -c release --product kwwk`
- `.build/release/kwwk --self-test`
- `swift test` (1,323 tests in 195 suites)
