### PR TITLE
feat(kwwk): xAI Grok subscription OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 A Swift-native coding agent with two faces:
 
 - **`kwwk`** — an interactive coding CLI (TUI) that drives your existing
-  Anthropic, ChatGPT (Codex), GitHub Copilot, Cursor, or Kimi For Coding
-  subscription — or an API key for Anthropic, OpenAI, Google (Gemini),
-  OpenRouter, the Z.AI GLM Coding Plan, or any OpenAI-compatible endpoint.
+  Anthropic, ChatGPT (Codex), GitHub Copilot, Cursor, Kimi For Coding, or
+  xAI Grok subscription — or an API key for Anthropic, OpenAI, Google
+  (Gemini), OpenRouter, the Z.AI GLM Coding Plan, or any OpenAI-compatible
+  endpoint.
 - **`KWWKAgent` / `KWWKAI`** — the agent runtime underneath, exposed as
   SwiftPM libraries so you can embed it in your own app, build custom
   tools, or swap the LLM provider.
@@ -58,9 +59,9 @@ Credentials come from the OAuth store at `~/.kwwk/oauth.json`; if no login
 exists, the CLI checks supported API-key environment variables. With
 neither configured, kwwk starts logged out — launch it and run `/login`
 to sign in to a provider (OAuth subscription like ChatGPT Codex, Copilot,
-Claude Code, Cursor, or Kimi For Coding; or an API key for Anthropic,
-OpenAI, Google (Gemini), OpenRouter, the Z.AI GLM Coding Plan, or any
-OpenAI-compatible endpoint).
+Claude Code, Cursor, Kimi For Coding, or xAI Grok; or an API key for
+Anthropic, OpenAI, Google (Gemini), OpenRouter, the Z.AI GLM Coding Plan,
+or any OpenAI-compatible endpoint).
 
 Inside the TUI, `/help` lists slash commands (`/model`, `/thinking`,
 `/clear`, …). The agent ships with Bash, Read, Write, Edit, Grep, Find,

--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -301,6 +301,7 @@ public actor OAuthManager {
             GitHubCopilotOAuthProvider(),
             CursorOAuthProvider(),
             KimiCodingOAuthProvider(),
+            XaiOAuthProvider(),
         ]
     }
 

--- a/Sources/KWWKAI/OAuthLogin.swift
+++ b/Sources/KWWKAI/OAuthLogin.swift
@@ -427,6 +427,123 @@ public enum OAuthLogin {
         throw OAuthError.transport("kimi device flow timed out")
     }
 
+    // MARK: - xAI Grok (device flow)
+    //
+    // xAI's subscription auth is an RFC 8628 device-authorization grant
+    // against `auth.x.ai`: POST `/oauth2/device/code` for a one-time user
+    // code, hand the verification URL to the browser, and poll
+    // `/oauth2/token` until the user approves. Same client id + scope as the
+    // official Grok CLI (and pi / oh-my-pi). The resulting Bearer token
+    // authenticates `api.x.ai` requests directly.
+
+    public static func loginXai(
+        clientID: String = XaiOAuth.clientID,
+        callbacks: Callbacks,
+        client: HTTPClient = URLSessionHTTPClient()
+    ) async throws -> OAuthCredentials {
+        let headers = [
+            "accept": "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+        ]
+
+        callbacks.onProgress("requesting xAI device code…")
+        let (deviceResponse, deviceBody) = try await client.request(
+            url: XaiOAuth.deviceCodeURL,
+            method: "POST",
+            headers: headers,
+            body: Data(OAuth.urlEncodedForm([
+                "client_id": clientID,
+                "scope": XaiOAuth.scope,
+            ]).utf8)
+        )
+        if deviceResponse.statusCode >= 400 {
+            throw OAuthError.refreshFailed("xai device code \(deviceResponse.statusCode): \(String(data: deviceBody, encoding: .utf8) ?? "")")
+        }
+        guard let obj = try JSONSerialization.jsonObject(with: deviceBody) as? [String: Any],
+              let userCode = obj["user_code"] as? String,
+              let deviceCode = obj["device_code"] as? String,
+              let verifyURLString = (obj["verification_uri_complete"] as? String)
+                ?? (obj["verification_uri"] as? String),
+              let verifyURL = URL(string: verifyURLString),
+              // The verification URI is handed to the browser; refuse anything
+              // a malicious response could use to make `open` launch a
+              // non-https handler.
+              verifyURL.scheme == "https" else {
+            throw OAuthError.invalidResponse("xai device code response")
+        }
+        // RFC 8628 allows interval 0 (no minimum wait); reject only negative
+        // or malformed values.
+        var intervalSec = (obj["interval"] as? Int).flatMap { $0 >= 0 ? $0 : nil } ?? 5
+        let expiresInSec = (obj["expires_in"] as? Int) ?? 15 * 60
+
+        callbacks.onAuthURL(verifyURL)
+        callbacks.onProgress("enter code in your browser: \(userCode)")
+
+        // Poll for the token until the user approves (or the code expires).
+        // Transient HTTP failures with non-JSON bodies (gateway errors, …)
+        // are retried; only 3 consecutive ones abort the flow.
+        let deadline = Date().addingTimeInterval(TimeInterval(expiresInSec))
+        var consecutiveErrors = 0
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: UInt64(intervalSec) * 1_000_000_000)
+            let (pollResponse, pollBody) = try await client.request(
+                url: XaiOAuth.tokenURL,
+                method: "POST",
+                headers: headers,
+                body: Data(OAuth.urlEncodedForm([
+                    "client_id": clientID,
+                    "device_code": deviceCode,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                ]).utf8)
+            )
+            guard let polled = try? JSONSerialization.jsonObject(with: pollBody) as? [String: Any] else {
+                if pollResponse.statusCode >= 400 {
+                    consecutiveErrors += 1
+                    if consecutiveErrors >= 3 {
+                        throw OAuthError.refreshFailed("xai device flow: HTTP \(pollResponse.statusCode)")
+                    }
+                }
+                continue
+            }
+            consecutiveErrors = 0
+            if let err = polled["error"] as? String {
+                switch err {
+                case "authorization_pending":
+                    continue
+                case "slow_down":
+                    intervalSec += 5
+                    if let serverInterval = polled["interval"] as? Int, serverInterval > intervalSec {
+                        intervalSec = serverInterval
+                    }
+                    continue
+                case "expired_token":
+                    throw OAuthError.refreshFailed("xai device authorization expired")
+                case "access_denied", "authorization_denied":
+                    throw OAuthError.refreshFailed("xai device authorization denied")
+                default:
+                    let description = (polled["error_description"] as? String).map { ": \($0)" } ?? ""
+                    throw OAuthError.refreshFailed("xai device flow: \(err)\(description)")
+                }
+            }
+            if pollResponse.statusCode < 400, let access = polled["access_token"] as? String {
+                // `offline_access` is in the requested scope, so the initial
+                // grant must carry a refresh token — without one the login
+                // would silently die at first expiry.
+                guard let refresh = polled["refresh_token"] as? String, !refresh.isEmpty else {
+                    throw OAuthError.invalidResponse("xai token response missing refresh token")
+                }
+                let expiresIn = (polled["expires_in"] as? Int) ?? 3600
+                let now = Int64(Date().timeIntervalSince1970 * 1000)
+                return OAuthCredentials(
+                    access: access,
+                    refresh: refresh,
+                    expires: now + Int64(expiresIn) * 1000 - 5 * 60 * 1000
+                )
+            }
+        }
+        throw OAuthError.transport("xai device flow timed out")
+    }
+
     // MARK: - JSON helpers
 
     private static func postJSON(

--- a/Sources/KWWKAI/OAuthProviders.swift
+++ b/Sources/KWWKAI/OAuthProviders.swift
@@ -383,6 +383,71 @@ public enum KimiOAuth {
     }
 }
 
+// MARK: - xAI Grok (SuperGrok / X Premium subscription)
+//
+// xAI's subscription auth is an OAuth device-authorization grant against
+// `auth.x.ai` (see `OAuthLogin.loginXai`), the same flow the official Grok
+// CLI uses. Refresh is a standard `grant_type=refresh_token` form POST to the
+// token endpoint; the resulting access token authenticates `api.x.ai`
+// requests as a Bearer key.
+
+public struct XaiOAuthProvider: OAuthProvider {
+    public let id = "xai"
+    public let name = "xAI (Grok subscription)"
+    public let tokenURL: URL
+    public let clientID: String
+
+    public init(
+        tokenURL: URL = XaiOAuth.tokenURL,
+        clientID: String = XaiOAuth.clientID
+    ) {
+        self.tokenURL = tokenURL
+        self.clientID = clientID
+    }
+
+    public func refresh(
+        _ credentials: OAuthCredentials, using client: HTTPClient
+    ) async throws -> OAuthCredentials {
+        let form = OAuth.urlEncodedForm([
+            "grant_type": "refresh_token",
+            "refresh_token": credentials.refresh,
+            "client_id": clientID,
+        ])
+        let (response, body) = try await client.request(
+            url: tokenURL, method: "POST",
+            headers: [
+                "content-type": "application/x-www-form-urlencoded",
+                "accept": "application/json",
+            ],
+            body: Data(form.utf8)
+        )
+        if response.statusCode >= 400 {
+            let text = String(data: body, encoding: .utf8) ?? ""
+            throw OAuthError.refreshFailed("xai \(response.statusCode): \(text)")
+        }
+        let json = try OAuth.decodeTokenResponse(body)
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        return OAuthCredentials(
+            access: json.accessToken,
+            // xAI may omit refresh_token when the token isn't rotated.
+            refresh: json.refreshToken ?? credentials.refresh,
+            expires: now + Int64(json.expiresIn * 1000) - 5 * 60 * 1000,
+            extras: credentials.extras
+        )
+    }
+}
+
+/// Constants shared by the xAI device-flow login and the refresh provider.
+/// Client id and scope mirror the official Grok CLI (same values pi and
+/// oh-my-pi ship); the `grok-cli:access` scope is what unlocks subscription
+/// inference.
+public enum XaiOAuth {
+    public static let clientID = "b1a00492-073a-47ea-816f-4c329264a828"
+    public static let scope = "openid profile email offline_access grok-cli:access api:access"
+    public static let deviceCodeURL = URL(string: "https://auth.x.ai/oauth2/device/code")!
+    public static let tokenURL = URL(string: "https://auth.x.ai/oauth2/token")!
+}
+
 // MARK: - Helpers
 
 enum OAuth {
@@ -419,6 +484,17 @@ enum OAuth {
             case refreshToken = "refresh_token"
             case expiresIn = "expires_in"
             case scope
+        }
+
+        /// `expires_in` is optional per RFC 6749 §4.2.2 and xAI omits it when
+        /// the lifetime is the default; fall back to one hour rather than
+        /// failing the whole token decode.
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            accessToken = try c.decode(String.self, forKey: .accessToken)
+            refreshToken = try c.decodeIfPresent(String.self, forKey: .refreshToken)
+            expiresIn = try c.decodeIfPresent(Int.self, forKey: .expiresIn) ?? 3600
+            scope = try c.decodeIfPresent(String.self, forKey: .scope)
         }
     }
 

--- a/Sources/KWWKAI/ProviderDirectory.swift
+++ b/Sources/KWWKAI/ProviderDirectory.swift
@@ -121,6 +121,13 @@ public let providerDirectory: [ProviderDescriptor] = [
         formTitle: nil
     ),
     ProviderDescriptor(
+        storeId: "xai",
+        scope: "xai",
+        catalogKey: "xai",
+        displayName: "xAI Grok",
+        formTitle: nil
+    ),
+    ProviderDescriptor(
         storeId: "zai",
         scope: "zai",
         catalogKey: "zai",

--- a/Sources/KWWKAI/StoredProviders.swift
+++ b/Sources/KWWKAI/StoredProviders.swift
@@ -281,6 +281,8 @@ public func registerStored(
         return await registerCursor(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "kimi-coding":
         return await registerKimiCoding(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
+    case "xai":
+        return await registerXaiGrok(manager: manager, creds: creds, modelOverride: modelOverride, primeToken: primeToken)
     case "zai", "zai-coding-cn":
         return await registerZai(storeId: storeId, creds: creds, modelOverride: modelOverride)
     default:
@@ -616,6 +618,57 @@ private func registerKimiCoding(
         model: model,
         modelLabel: "\(modelId) · Kimi For Coding",
         authResolver: oauthResolver(manager: manager, providerId: "kimi-coding", scheme: .bearer)
+    )
+}
+
+// MARK: - xAI Grok (OAuth device flow)
+
+private func registerXaiGrok(
+    manager: OAuthManager,
+    creds: OAuthCredentials,
+    modelOverride: String? = nil,
+    primeToken: Bool = true
+) async -> ResolvedAuth {
+    // Prime the token only for the active provider; the resolver refreshes
+    // lazily on the first request for the others.
+    if primeToken {
+        _ = try? await manager.apiKey(for: "xai")
+    }
+
+    // The subscription token authenticates the regular `api.x.ai` completions
+    // endpoint as a Bearer key; the resolver below supplies it per request.
+    await APIRegistry.shared.register(OpenAICompletionsProvider(), scope: "xai")
+
+    let modelId = modelOverride ?? "grok-4.3"
+    let catalog = ModelsCatalog.model(provider: "xai", id: modelId)
+    // Uncatalogued ids still need the request-shape quirks every bundled xai
+    // model pins (no developer role / reasoning_effort / store fields).
+    let fallbackCompat: ModelCompat = {
+        var c = ModelCompat()
+        c.supportsDeveloperRole = false
+        c.supportsReasoningEffort = false
+        c.supportsStore = false
+        return c
+    }()
+    let model = Model(
+        id: modelId,
+        name: catalog?.name ?? modelId,
+        api: "openai-completions",
+        provider: "xai",
+        baseURL: catalog?.baseURL ?? "https://api.x.ai/v1",
+        reasoning: catalog?.reasoning ?? true,
+        input: catalog?.input ?? [.text, .image],
+        cost: catalog?.cost ?? ModelCost(),
+        contextWindow: catalog?.contextWindow ?? 1_000_000,
+        maxTokens: catalog?.maxTokens ?? 30_000,
+        headers: catalog?.headers,
+        compat: catalog?.compat ?? fallbackCompat,
+        thinkingLevelMap: catalog?.thinkingLevelMap
+    )
+    return ResolvedAuth(
+        model: model,
+        modelLabel: "\(modelId) · xAI Grok",
+        authResolver: oauthResolver(manager: manager, providerId: "xai", scheme: .bearer)
     )
 }
 

--- a/Sources/KWWKCli/Login.swift
+++ b/Sources/KWWKCli/Login.swift
@@ -45,6 +45,11 @@ let loginProviders: [LoginEntry] = [
         flow: .oauth
     ),
     LoginEntry(
+        id: "xai",
+        display: "xAI Grok (SuperGrok / X Premium subscription)",
+        flow: .oauth
+    ),
+    LoginEntry(
         id: "anthropic-api-key",
         display: "Anthropic API key (api.anthropic.com)",
         flow: .apiKey(
@@ -288,6 +293,8 @@ func runOAuthFlow(providerId: String) async throws {
             return try await OAuthLogin.loginCursor(callbacks: callbacks)
         case "kimi-coding":
             return try await OAuthLogin.loginKimiCoding(callbacks: callbacks)
+        case "xai":
+            return try await OAuthLogin.loginXai(callbacks: callbacks)
         default:
             throw LoginError.unknownProvider(providerId)
         }

--- a/Tests/KWWKAITests/OAuthLoginTests.swift
+++ b/Tests/KWWKAITests/OAuthLoginTests.swift
@@ -253,6 +253,111 @@ struct OAuthLoginShapeTests {
             )
         }
     }
+
+    @Test("xai device flow rides authorization_pending and returns both tokens")
+    func xaiDeviceFlowShape() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC-1234","verification_uri":"https://auth.x.ai/activate","verification_uri_complete":"https://auth.x.ai/activate?code=UC-1234","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 400,
+            body: #"{"error":"authorization_pending"}"#
+        ))
+        client.queue.append((
+            status: 200,
+            body: #"{"access_token":"xai-access","refresh_token":"xai-refresh","expires_in":3600}"#
+        ))
+
+        let authURL = CapturedURL()
+        let creds = try await OAuthLogin.loginXai(
+            clientID: "test-client",
+            callbacks: OAuthLogin.Callbacks(
+                onAuthURL: { authURL.set($0) },
+                onProgress: { _ in }
+            ),
+            client: client
+        )
+        #expect(creds.access == "xai-access")
+        #expect(creds.refresh == "xai-refresh")
+        // The complete verification URL (with the embedded code) is preferred.
+        #expect(authURL.get()?.absoluteString == "https://auth.x.ai/activate?code=UC-1234")
+
+        // First call: device authorization request with client id + scope.
+        let device = client.recorded[0]
+        #expect(device.url.absoluteString == "https://auth.x.ai/oauth2/device/code")
+        let deviceBody = String(data: device.body ?? Data(), encoding: .utf8) ?? ""
+        #expect(deviceBody.contains("client_id=test-client"))
+        #expect(deviceBody.contains("scope="))
+        #expect(deviceBody.contains("grok-cli%3Aaccess"))
+
+        // Polls carry device_code + the device-code grant; the pending
+        // response is retried rather than surfaced.
+        #expect(client.recorded.count == 3)
+        for poll in client.recorded[1...] {
+            #expect(poll.url.absoluteString == "https://auth.x.ai/oauth2/token")
+            let body = String(data: poll.body ?? Data(), encoding: .utf8) ?? ""
+            #expect(body.contains("device_code=DC"))
+            #expect(body.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"))
+        }
+    }
+
+    @Test("xai device flow surfaces authorization_denied instead of polling forever")
+    func xaiDeviceFlowDenied() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.x.ai/activate","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 400,
+            body: #"{"error":"authorization_denied"}"#
+        ))
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginXai(
+                clientID: "test-client",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+    }
+
+    @Test("xai token response without a refresh token is rejected")
+    func xaiDeviceFlowMissingRefresh() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"https://auth.x.ai/activate","interval":0,"expires_in":900}"#
+        ))
+        client.queue.append((
+            status: 200,
+            body: #"{"access_token":"xai-access","expires_in":3600}"#
+        ))
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginXai(
+                clientID: "test-client",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+    }
+
+    @Test("xai device flow rejects a non-https verification URI")
+    func xaiDeviceFlowInsecureVerifyURI() async throws {
+        let client = SequentialStubClient()
+        client.queue.append((
+            status: 200,
+            body: #"{"device_code":"DC","user_code":"UC","verification_uri":"javascript:alert(1)","interval":0,"expires_in":900}"#
+        ))
+        await #expect(throws: OAuthError.self) {
+            _ = try await OAuthLogin.loginXai(
+                clientID: "test-client",
+                callbacks: OAuthLogin.Callbacks(onAuthURL: { _ in }, onProgress: { _ in }),
+                client: client
+            )
+        }
+    }
 }
 
 /// Thread-safe URL capture for @Sendable callback assertions.

--- a/Tests/KWWKAITests/OAuthTests.swift
+++ b/Tests/KWWKAITests/OAuthTests.swift
@@ -279,6 +279,64 @@ struct KimiCodingOAuthTests {
     }
 }
 
+@Suite("OAuth refresh — xAI Grok")
+struct XaiOAuthTests {
+    @Test("form POST with grant_type=refresh_token to auth.x.ai")
+    func xaiRefresh() async throws {
+        let body = #"""
+        {"access_token":"xai-new","refresh_token":"xai-refresh-2","expires_in":3600}
+        """#
+        let client = StubResponseClient(body: Data(body.utf8))
+        let updated = try await XaiOAuthProvider().refresh(
+            OAuthCredentials(access: "old", refresh: "xai-refresh-1", expires: 0),
+            using: client
+        )
+        #expect(updated.access == "xai-new")
+        #expect(updated.refresh == "xai-refresh-2")
+        // Refreshed ~5 minutes before the hour-long expiry.
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        #expect(updated.expires > now + 50 * 60 * 1000)
+        #expect(updated.expires <= now + 60 * 60 * 1000)
+
+        let req = client.lastRequest!
+        #expect(req.method == "POST")
+        #expect(req.url.absoluteString == "https://auth.x.ai/oauth2/token")
+        let form = String(data: req.body ?? Data(), encoding: .utf8) ?? ""
+        #expect(form.contains("grant_type=refresh_token"))
+        #expect(form.contains("refresh_token=xai-refresh-1"))
+        #expect(form.contains("client_id=\(XaiOAuth.clientID)"))
+    }
+
+    @Test("keeps the old refresh token when the server omits a new one")
+    func xaiRefreshKeepsOldToken() async throws {
+        let body = #"{"access_token":"xai-new","expires_in":3600}"#
+        let client = StubResponseClient(body: Data(body.utf8))
+        let updated = try await XaiOAuthProvider().refresh(
+            OAuthCredentials(access: "old", refresh: "keep-me", expires: 0),
+            using: client
+        )
+        #expect(updated.refresh == "keep-me")
+    }
+
+    @Test("tolerates a token response without expires_in (defaults to 1h)")
+    func xaiRefreshDefaultsExpiry() async throws {
+        let body = #"{"access_token":"xai-new","refresh_token":"r2"}"#
+        let client = StubResponseClient(body: Data(body.utf8))
+        let updated = try await XaiOAuthProvider().refresh(
+            OAuthCredentials(access: "old", refresh: "r1", expires: 0),
+            using: client
+        )
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        #expect(updated.expires > now + 50 * 60 * 1000)
+        #expect(updated.expires <= now + 60 * 60 * 1000)
+    }
+
+    @Test("xai is a default OAuthManager provider")
+    func xaiInDefaultProviders() {
+        #expect(OAuthManager.defaultProviders().contains { $0.id == "xai" })
+    }
+}
+
 @Suite("OAuthManager integration")
 struct OAuthManagerTests {
     /// Provider that counts refresh calls so we can verify caching.

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -181,6 +181,50 @@ struct MultiProviderAuthTests {
         }
     }
 
+    @Test("registerStored wires an xAI Grok login onto the bearer completions wire")
+    func registerStoredXaiGrok() async throws {
+        try await withSharedAPIRegistry {
+            await APIRegistry.shared.unregisterScope("xai")
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kwwk-xai-\(UUID().uuidString.prefix(8))")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+            // Never-expiring credentials so registration skips the token refresh.
+            try await store.set(OAuthCredentials(
+                access: "xai-token", refresh: "xai-refresh", expires: .max
+            ), for: "xai")
+
+            let resolved = try await registerStored(
+                storeId: "xai", store: store, modelOverride: nil, context1m: false
+            )
+            #expect(resolved?.model.id == "grok-4.3")
+            #expect(resolved?.model.provider == "xai")
+            #expect(resolved?.model.api == "openai-completions")
+            #expect(resolved?.model.baseURL == "https://api.x.ai/v1")
+            let resolvedModel = try #require(resolved?.model)
+            #expect(resolvedModel.compat?.supportsDeveloperRole == false)
+            #expect(resolvedModel.compat?.supportsReasoningEffort == false)
+            #expect(resolvedModel.compat?.supportsStore == false)
+            #expect(resolved?.modelLabel == "grok-4.3 · xAI Grok")
+            // The OAuth resolver supplies a bearer token per request.
+            let auth = try await resolved?.authResolver?(resolvedModel, nil)
+            #expect(auth?.token == "xai-token")
+            let scoped = await APIRegistry.shared.provider(scope: "xai", api: "openai-completions")
+            #expect(scoped is OpenAICompletionsProvider)
+
+            // An uncatalogued override still routes through api.x.ai with the
+            // Grok request-shape quirks.
+            let custom = try await registerStored(
+                storeId: "xai", store: store,
+                modelOverride: "grok-9-experimental", context1m: false
+            )
+            #expect(custom?.model.id == "grok-9-experimental")
+            #expect(custom?.model.baseURL == "https://api.x.ai/v1")
+            #expect(custom?.model.compat?.supportsDeveloperRole == false)
+            await APIRegistry.shared.unregisterScope("xai")
+        }
+    }
+
     @Test("registerStored wires Z.AI global + China logins with catalog metadata")
     func registerStoredZai() async throws {
         try await withSharedAPIRegistry {

--- a/Tests/KWWKCliTests/ProviderDirectoryTests.swift
+++ b/Tests/KWWKCliTests/ProviderDirectoryTests.swift
@@ -23,6 +23,7 @@ struct ProviderDirectoryTests {
         ("github-copilot", "github-copilot", "github-copilot", "GitHub Copilot", nil),
         ("cursor", "cursor", "cursor", "Cursor", nil),
         ("kimi-coding", "kimi-coding", "kimi-coding", "Kimi For Coding", nil),
+        ("xai", "xai", "xai", "xAI Grok", nil),
         ("zai", "zai", "zai", "Z.AI Coding Plan", "Z.AI API key"),
         ("zai-coding-cn", "zai-coding-cn", "zai-coding-cn", "Z.AI Coding Plan (China)", "Z.AI API key (China)"),
     ]


### PR DESCRIPTION
## Summary

Ports the xAI Grok OAuth device-authorization flow from upstream pi (earendil-works/pi) / oh-my-pi. `/login` gains an **xAI Grok (SuperGrok / X Premium subscription)** entry that runs the RFC 8628 device-code grant against `auth.x.ai` using the official Grok CLI client id and scope (`grok-cli:access api:access` …); the resulting Bearer token drives the regular `api.x.ai/v1` completions endpoint with the bundled `xai` catalog (default model `grok-4.3`).

- **`OAuthLogin.loginXai`** — device-code request + token poll: rides `authorization_pending`/`slow_down`, surfaces denial/expiry as errors, tolerates up to 3 consecutive transient gateway errors, and refuses non-https verification URIs before handing them to the browser (hardening adopted from pi).
- **`XaiOAuthProvider`** — standard `grant_type=refresh_token` form POST to `auth.x.ai/oauth2/token`; keeps the old refresh token when xAI doesn't rotate it. Registered in `OAuthManager.defaultProviders()`.
- **`OAuth.TokenResponse`** — tolerates a missing `expires_in` (optional per RFC 6749 §4.2.2; xAI omits it) by defaulting to one hour.
- **Wiring** — provider directory entry (`xai` store id / scope / catalog key), `registerStored` case registering `OpenAICompletionsProvider` on the `xai` scope with a Bearer OAuth resolver, Grok request-shape compat fallbacks (`supportsDeveloperRole/supportsReasoningEffort/supportsStore = false`) for uncatalogued ids, CLI `/login` picker entry, README provider lists.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1332 tests / 196 suites pass
- [x] New coverage mirroring the Kimi suites: device-flow shape (pending retry, complete-verification-URL preference), denial, missing refresh token, insecure verification URI, refresh form shape, refresh-token retention, `expires_in` default, `defaultProviders` membership, provider-directory pins, `registerStored` integration incl. uncatalogued-model fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZYCCdaJGhzm28NvKU3Ybd