### PR TITLE
Credential-source failures end the run at once instead of retrying

### DIFF
--- a/Sources/KWWKAI/OAuth.swift
+++ b/Sources/KWWKAI/OAuth.swift
@@ -108,6 +108,26 @@ public enum OAuthError: Error, LocalizedError {
     }
 }
 
+/// A credential source that failed to answer for `providerId`. The agent
+/// loop never retries this one: the source is an external authority (a
+/// backend minting tokens, a keychain daemon), and its refusal means the
+/// user must act — a deleted login, a parked refresh chain — not that a
+/// second attempt would fare better. The underlying error's own text is
+/// what surfaces, so the authority's copy reaches the user unchanged.
+public struct OAuthCredentialSourceError: Error, LocalizedError {
+    public let providerId: String
+    public let underlying: any Error
+
+    public init(providerId: String, underlying: any Error) {
+        self.providerId = providerId
+        self.underlying = underlying
+    }
+
+    public var errorDescription: String? {
+        (underlying as? LocalizedError)?.errorDescription ?? String(describing: underlying)
+    }
+}
+
 // MARK: - Credential source
 
 /// Where an `OAuthManager` reads credentials from. `OAuthStore` is the
@@ -316,9 +336,20 @@ public actor OAuthManager {
     }
 
     public func credentials(for providerId: String) async throws -> OAuthCredentials? {
+        let served: OAuthCredentials?
+        do {
+            served = try await source.credentials(for: providerId)
+        } catch let error as OAuthCredentialSourceError {
+            throw error
+        } catch {
+            // The source's refusal cannot be retried away (see
+            // `OAuthCredentialSourceError`). Wrapped here so every read
+            // path — apiKey, priming, registration — reports it uniformly.
+            throw OAuthCredentialSourceError(providerId: providerId, underlying: error)
+        }
         // A held rotation stands in for exactly the entry it rotated; any
         // other answer from the source supersedes it (see `reconciled`).
-        reconciled(try await source.credentials(for: providerId), for: providerId)
+        return reconciled(served, for: providerId)
     }
 
     /// Get a valid api-key for `providerId`, refreshing if the stored token

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -937,6 +937,16 @@ public enum AgentLoop {
                         emittedStart: emittedStart
                     )
                 }
+                // A failed credential source is the user's to fix — a
+                // deleted or parked login. Retrying cannot change its
+                // answer, and the copy such errors carry ("connect your …
+                // login") reads like a network failure to the string
+                // classifier below.
+                if error is OAuthCredentialSourceError {
+                    let discarded = cursorResults.drain()
+                    turnToolState.rollbackLeases(for: discarded.map(\.toolCallId))
+                    throw error
+                }
                 if isRetryableError(reason), attemptIndex < maxRetries - 1 {
                     let discarded = cursorResults.drain()
                     turnToolState.rollbackLeases(for: discarded.map(\.toolCallId))

--- a/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
+++ b/Tests/KWWKAITests/OAuthCredentialSourceTests.swift
@@ -51,6 +51,34 @@ struct OAuthCredentialSourceTests {
         )
     }
 
+    /// Stands in for an authority that refuses to answer — a backend whose
+    /// stored login was deleted or parked.
+    struct RefusingSource: OAuthCredentialSource {
+        struct Refusal: LocalizedError {
+            var errorDescription: String? {
+                "This Agent is set to an 'x' model, but the Team has not connected an x login."
+            }
+        }
+
+        func providerIds() async -> [String] { ["x"] }
+        func credentials(for providerId: String) async throws -> OAuthCredentials? {
+            throw Refusal()
+        }
+    }
+
+    @Test("a source that throws surfaces as a credential-source error, message intact")
+    func sourceErrorsAreWrapped() async throws {
+        let provider = RefreshCountingProvider(id: "x")
+        let manager = OAuthManager(source: RefusingSource(), providers: [provider])
+
+        let thrown = await #expect(throws: OAuthCredentialSourceError.self) {
+            _ = try await manager.apiKey(for: "x")
+        }
+        #expect(thrown?.providerId == "x")
+        // The authority's own copy is what the user must see.
+        #expect(thrown?.errorDescription?.contains("has not connected") == true)
+    }
+
     @Test("a fresh token from the source is served without refreshing")
     func servesSourceToken() async throws {
         let source = StubSource(["x": fresh("from-authority")])

--- a/Tests/KWWKAgentTests/AgentRetryTests.swift
+++ b/Tests/KWWKAgentTests/AgentRetryTests.swift
@@ -146,6 +146,46 @@ struct AgentRetryTests {
             Issue.record("expected assistant error after exhausted retries")
         }
     }
+
+    @Test("a failed credential source ends the run at once, not after the retry budget")
+    func credentialSourceErrorFailsFast() async throws {
+        let registration = await registerFauxProvider()
+        defer { registration.unregister() }
+        registration.setResponses([.message(fauxAssistantMessage("never reached"))])
+
+        // The message alone would sniff as retryable ("connected…"), which
+        // is exactly the trap: the error's type must win over its text.
+        struct Refusal: LocalizedError {
+            var errorDescription: String? {
+                "This Agent is set to an 'openai-codex' model, but the Team has not connected an openai-codex login."
+            }
+        }
+
+        let agent = Agent(initialState: AgentInitialState(model: registration.getModel()))
+        agent.retryBaseDelayMs = 10
+        agent.authResolver = { _, _ in
+            throw OAuthCredentialSourceError(providerId: "openai-codex", underlying: Refusal())
+        }
+
+        let recorder = RetryEventRecorder()
+        _ = agent.subscribe { event, _ in
+            if case .streamRetry(let attempt, let delayMs, let reason) = event {
+                await recorder.record(attempt: attempt, delayMs: delayMs, reason: reason)
+            }
+        }
+
+        try await agent.prompt("hi")
+
+        #expect(await recorder.snapshot().isEmpty)
+        // The run ends in the error state with the authority's copy intact —
+        // this is what the host renders as the agent's failure status.
+        if case .assistant(let msg) = agent.state.messages.last {
+            #expect(msg.stopReason == .error)
+            #expect(msg.errorMessage?.contains("openai-codex") == true)
+        } else {
+            Issue.record("expected the credential failure to surface immediately")
+        }
+    }
 }
 
 @Suite("Retry error classification")


### PR DESCRIPTION
## Problem

Deleting a Team's BYOK login while an agent still points at that model left the agent silent for a long stretch before any error showed. The credential source's refusal ("This Agent is set to an 'openai-codex' model, but the Team has not connected…") carries the word *connected*, which the agent loop's string classifier reads as a transient network failure — so the run replayed through the full 5-attempt retry budget with exponential backoff before the error finally surfaced.

## Change

- `OAuthManager` wraps any error thrown by an external `OAuthCredentialSource` in a new `OAuthCredentialSourceError` (provider id + the authority's own message, which is what the user must see).
- The agent loop throws that error through immediately — no string classification, no retries — so the run lands in the normal `agentEnd(.error)` state on the first attempt and the host can show the failure status right away.

No behavior change for any other error: transient transport failures, HTTP 429/5xx, and the existing string classification all retry exactly as before.

## Tests

- `OAuthCredentialSourceTests`: a throwing source surfaces as `OAuthCredentialSourceError` with the message intact.
- `AgentRetryTests`: a credential-source failure ends the run at once with zero `streamRetry` events, using exactly the copy that used to trip the classifier.
- Full suite: 1325 tests, 195 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5by2mAz4cPjxM7LKDYWn8