### PR TITLE
chore(kwwk): bump version to 0.1.42

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.41"
+    static let version = "0.1.42"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.42 — credential-source failures end the run at once instead of retrying (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZYCCdaJGhzm28NvKU3Ybd