### PR TITLE
registerCursor: carry compat + thinkingLevelMap from the catalog

### DIFF
--- a/Sources/KWWKAI/StoredProviders.swift
+++ b/Sources/KWWKAI/StoredProviders.swift
@@ -557,7 +557,11 @@ private func registerCursor(
         reasoning: catalog?.reasoning ?? true,
         input: catalog?.input ?? [.text],
         contextWindow: catalog?.contextWindow ?? 200_000,
-        maxTokens: catalog?.maxTokens ?? 64_000
+        maxTokens: catalog?.maxTokens ?? 64_000,
+        compat: catalog?.compat,
+        // Without the catalog's map the agent wire never routes a thinking
+        // level to its `…-thinking` variant — the level silently no-ops.
+        thinkingLevelMap: catalog?.thinkingLevelMap
     )
     return ResolvedAuth(
         model: model,

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -129,6 +129,37 @@ struct MultiProviderAuthTests {
         }
     }
 
+    // MARK: - Cursor
+
+    @Test("registerStored carries Cursor catalog metadata, including the thinking routing map")
+    func registerStoredCursorThinkingMap() async throws {
+        try await withSharedAPIRegistry {
+            await APIRegistry.shared.unregisterScope("cursor")
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kwwk-cursor-\(UUID().uuidString.prefix(8))")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let store = try OAuthStore(url: dir.appendingPathComponent("oauth.json"))
+            // Never-expiring credentials so registration skips the token refresh.
+            try await store.set(OAuthCredentials(
+                access: "cursor-token", refresh: "cursor-key", expires: .max
+            ), for: "cursor")
+
+            let resolved = try await registerStored(
+                storeId: "cursor", store: store,
+                modelOverride: "claude-4.6-opus-high", context1m: false
+            )
+            let model = try #require(resolved?.model)
+            #expect(model.id == "claude-4.6-opus-high")
+            #expect(model.api == "cursor-agent")
+            #expect(model.provider == "cursor")
+            // The catalog's thinking map must survive registration — it is
+            // the only thing that routes a thinking level to the
+            // `…-thinking` wire variant.
+            #expect(model.thinkingLevelMap?["high"] == "claude-4.6-opus-high-thinking")
+            #expect(model.thinkingLevelMap?["off"] == "claude-4.6-opus-high")
+        }
+    }
+
     // MARK: - Kimi For Coding + Z.AI Coding Plan (first-class providers)
 
     @Test("registerStored wires a Kimi For Coding login onto the bearer anthropic wire")


### PR DESCRIPTION
## What

`registerCursor` rebuilt its `Model` without the catalog's `compat`/`thinkingLevelMap`, unlike every other stored registration (xai, kimi, copilot all carry them). Since `CursorAgentProvider.wireModelId` routes thinking levels through `model.thinkingLevelMap`, a thinking level on the `registerStored` path (what AirBuildEnvironment uses) silently no-oped — e.g. `claude-4.6-opus-high` never reached `claude-4.6-opus-high-thinking`.

One call-site fix plus a `MultiProviderAuthTests` case asserting the map survives registration.

## Tests

`swift test --filter MultiProviderAuthTests` — 15/15 passed.

## Why now

AirBuild's model catalog is gaining `byok:cursor/claude-4.6-*` entries with effort levels; without this the levels are accepted but inert. Needs a kwwk release + env repin to reach production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5by2mAz4cPjxM7LKDYWn8