### PR TITLE
chore: refresh bundled model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -35,7 +35,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 4",
+    "name" : "Claude Sonnet 4",
     "provider" : "cursor",
     "reasoning" : true,
     "thinkingLevelMap" : {
@@ -142,7 +142,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.6 1M Max",
+    "name" : "Claude Opus 4.6 1M Max",
     "provider" : "cursor",
     "reasoning" : true,
     "thinkingLevelMap" : {
@@ -195,7 +195,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M (NO ZDR)",
+    "name" : "Claude Fable 5 1M (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -215,7 +215,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Low (NO ZDR)",
+    "name" : "Claude Fable 5 1M Low (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -235,7 +235,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Max (NO ZDR)",
+    "name" : "Claude Fable 5 1M Max (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -255,7 +255,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Medium (NO ZDR)",
+    "name" : "Claude Fable 5 1M Medium (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -275,7 +275,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Thinking (NO ZDR)",
+    "name" : "Claude Fable 5 1M Thinking (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -295,7 +295,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Low Thinking (NO ZDR)",
+    "name" : "Claude Fable 5 1M Low Thinking (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -315,7 +315,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Max Thinking (NO ZDR)",
+    "name" : "Claude Fable 5 1M Max Thinking (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -335,7 +335,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Medium Thinking (NO ZDR)",
+    "name" : "Claude Fable 5 1M Medium Thinking (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -355,7 +355,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Extra High Thinking (NO ZDR)",
+    "name" : "Claude Fable 5 1M Extra High Thinking (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -375,7 +375,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Fable 5 1M Extra High (NO ZDR)",
+    "name" : "Claude Fable 5 1M Extra High (NO ZDR)",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -395,7 +395,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M High",
+    "name" : "Claude Opus 4.7 1M High",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -415,7 +415,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M High Fast",
+    "name" : "Claude Opus 4.7 1M High Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -435,7 +435,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Low",
+    "name" : "Claude Opus 4.7 1M Low",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -455,7 +455,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Low Fast",
+    "name" : "Claude Opus 4.7 1M Low Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -475,7 +475,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Max",
+    "name" : "Claude Opus 4.7 1M Max",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -495,7 +495,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Max Fast",
+    "name" : "Claude Opus 4.7 1M Max Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -515,7 +515,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Medium",
+    "name" : "Claude Opus 4.7 1M Medium",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -535,7 +535,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Medium Fast",
+    "name" : "Claude Opus 4.7 1M Medium Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -555,7 +555,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M High Thinking",
+    "name" : "Claude Opus 4.7 1M High Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -575,7 +575,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M High Thinking Fast",
+    "name" : "Claude Opus 4.7 1M High Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -595,7 +595,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Low Thinking",
+    "name" : "Claude Opus 4.7 1M Low Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -615,7 +615,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Low Thinking Fast",
+    "name" : "Claude Opus 4.7 1M Low Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -635,7 +635,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Max Thinking",
+    "name" : "Claude Opus 4.7 1M Max Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -655,7 +655,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Max Thinking Fast",
+    "name" : "Claude Opus 4.7 1M Max Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -675,7 +675,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Medium Thinking",
+    "name" : "Claude Opus 4.7 1M Medium Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -695,7 +695,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Medium Thinking Fast",
+    "name" : "Claude Opus 4.7 1M Medium Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -715,7 +715,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Thinking",
+    "name" : "Claude Opus 4.7 1M Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -735,7 +735,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Thinking Fast",
+    "name" : "Claude Opus 4.7 1M Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -755,7 +755,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M",
+    "name" : "Claude Opus 4.7 1M",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -775,7 +775,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.7 1M Fast",
+    "name" : "Claude Opus 4.7 1M Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -795,7 +795,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M",
+    "name" : "Claude Opus 4.8 1M",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -815,7 +815,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Fast",
+    "name" : "Claude Opus 4.8 1M Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -835,7 +835,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Low",
+    "name" : "Claude Opus 4.8 1M Low",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -855,7 +855,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Low Fast",
+    "name" : "Claude Opus 4.8 1M Low Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -875,7 +875,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Max",
+    "name" : "Claude Opus 4.8 1M Max",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -895,7 +895,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Max Fast",
+    "name" : "Claude Opus 4.8 1M Max Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -915,7 +915,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Medium",
+    "name" : "Claude Opus 4.8 1M Medium",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -935,7 +935,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Medium Fast",
+    "name" : "Claude Opus 4.8 1M Medium Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -955,7 +955,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Thinking",
+    "name" : "Claude Opus 4.8 1M Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -975,7 +975,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Thinking Fast",
+    "name" : "Claude Opus 4.8 1M Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -995,7 +995,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Low Thinking",
+    "name" : "Claude Opus 4.8 1M Low Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1015,7 +1015,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Low Thinking Fast",
+    "name" : "Claude Opus 4.8 1M Low Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1035,7 +1035,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Max Thinking",
+    "name" : "Claude Opus 4.8 1M Max Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1055,7 +1055,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Max Thinking Fast",
+    "name" : "Claude Opus 4.8 1M Max Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1075,7 +1075,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Medium Thinking",
+    "name" : "Claude Opus 4.8 1M Medium Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1095,7 +1095,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Medium Thinking Fast",
+    "name" : "Claude Opus 4.8 1M Medium Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1115,7 +1115,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Extra High Thinking",
+    "name" : "Claude Opus 4.8 1M Extra High Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1135,7 +1135,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Extra High Thinking Fast",
+    "name" : "Claude Opus 4.8 1M Extra High Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1155,7 +1155,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Extra High",
+    "name" : "Claude Opus 4.8 1M Extra High",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1175,7 +1175,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 4.8 1M Extra High Fast",
+    "name" : "Claude Opus 4.8 1M Extra High Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1195,7 +1195,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M",
+    "name" : "Claude Opus 5 1M",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1215,7 +1215,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Fast",
+    "name" : "Claude Opus 5 1M Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1235,7 +1235,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Low",
+    "name" : "Claude Opus 5 1M Low",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1255,7 +1255,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Low Fast",
+    "name" : "Claude Opus 5 1M Low Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1275,7 +1275,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Medium",
+    "name" : "Claude Opus 5 1M Medium",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1295,7 +1295,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Medium Fast",
+    "name" : "Claude Opus 5 1M Medium Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1315,7 +1315,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Thinking",
+    "name" : "Claude Opus 5 1M Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1335,7 +1335,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Thinking Fast",
+    "name" : "Claude Opus 5 1M Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1355,7 +1355,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Low Thinking",
+    "name" : "Claude Opus 5 1M Low Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1375,7 +1375,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Low Thinking Fast",
+    "name" : "Claude Opus 5 1M Low Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1395,7 +1395,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Max Thinking",
+    "name" : "Claude Opus 5 1M Max Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1415,7 +1415,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Max Thinking Fast",
+    "name" : "Claude Opus 5 1M Max Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1435,7 +1435,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Medium Thinking",
+    "name" : "Claude Opus 5 1M Medium Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1455,7 +1455,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Medium Thinking Fast",
+    "name" : "Claude Opus 5 1M Medium Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1475,7 +1475,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Extra High Thinking",
+    "name" : "Claude Opus 5 1M Extra High Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1495,7 +1495,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Opus 5 1M Extra High Thinking Fast",
+    "name" : "Claude Opus 5 1M Extra High Thinking Fast",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1515,7 +1515,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M",
+    "name" : "Claude Sonnet 5 1M",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1535,7 +1535,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Low",
+    "name" : "Claude Sonnet 5 1M Low",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1555,7 +1555,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Max",
+    "name" : "Claude Sonnet 5 1M Max",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1575,7 +1575,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Medium",
+    "name" : "Claude Sonnet 5 1M Medium",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1595,7 +1595,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Thinking",
+    "name" : "Claude Sonnet 5 1M Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1615,7 +1615,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Low Thinking",
+    "name" : "Claude Sonnet 5 1M Low Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1635,7 +1635,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Max Thinking",
+    "name" : "Claude Sonnet 5 1M Max Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1655,7 +1655,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Medium Thinking",
+    "name" : "Claude Sonnet 5 1M Medium Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1675,7 +1675,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Extra High Thinking",
+    "name" : "Claude Sonnet 5 1M Extra High Thinking",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -1695,7 +1695,7 @@
       "image"
     ],
     "maxTokens" : 64000,
-    "name" : "Sonnet 5 1M Extra High",
+    "name" : "Claude Sonnet 5 1M Extra High",
     "provider" : "cursor",
     "reasoning" : false
   },
@@ -2146,6 +2146,66 @@
     ],
     "maxTokens" : 64000,
     "name" : "Gemini 3.6 Flash Minimal",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gemini-3.7-flash-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.7 Flash",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gemini-3.7-flash-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.7 Flash Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gemini-3.7-flash-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.7 Flash Medium",
     "provider" : "cursor",
     "reasoning" : false
   },

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -1046,6 +1046,84 @@
         "xhigh" : "xhigh"
       }
     },
+    "global.openai.gpt-5.6-luna" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.021999999999999999,
+        "cacheWrite" : 0.275,
+        "input" : 0.22,
+        "output" : 1.32
+      },
+      "id" : "global.openai.gpt-5.6-luna",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Luna (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "global.openai.gpt-5.6-sol" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.55,
+        "cacheWrite" : 6.875,
+        "input" : 5.5,
+        "output" : 33
+      },
+      "id" : "global.openai.gpt-5.6-sol",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Sol (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "global.openai.gpt-5.6-terra" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.22,
+        "cacheWrite" : 2.75,
+        "input" : 2.2,
+        "output" : 13.2
+      },
+      "id" : "global.openai.gpt-5.6-terra",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6 Terra (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "google.gemma-3-4b-it" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -2712,6 +2790,10 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
+        "allowedFallbackModels" : [
+          "claude-opus-4-8",
+          "claude-opus-5"
+        ],
         "forceAdaptiveThinking" : true,
         "supportsStrictTools" : true
       },
@@ -2918,6 +3000,9 @@
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
+        "allowedFallbackModels" : [
+          "claude-opus-4-8"
+        ],
         "forceAdaptiveThinking" : true,
         "supportsStrictTools" : true,
         "supportsTemperature" : false
@@ -3975,7 +4060,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 1048576,
+      "maxTokens" : 384000,
       "name" : "Deepseek V4 Flash 0731",
       "provider" : "baseten",
       "reasoning" : true
@@ -3993,7 +4078,7 @@
         "supportsUsageInStreaming" : true,
         "thinkingFormat" : "openai"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.145,
         "cacheWrite" : 0,
@@ -4006,6 +4091,44 @@
       ],
       "maxTokens" : 262144,
       "name" : "Deepseek V4 Pro",
+      "provider" : "baseten",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek-ai\/DeepSeek-V4-Pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/inference.baseten.co\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "supportsStrictMode" : true,
+        "supportsUsageInStreaming" : true,
+        "thinkingFormat" : "openai"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "deepseek-ai\/DeepSeek-V4-Pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Deepseek V4 Pro 0813",
       "provider" : "baseten",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -4547,7 +4670,8 @@
       },
       "id" : "zai-org\/GLM-5.2",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 262144,
       "name" : "GLM 5.2",
@@ -4590,7 +4714,8 @@
       },
       "id" : "zai-org\/GLM-5.2-Fast",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 262144,
       "name" : "GLM 5.2 Fast",
@@ -4672,179 +4797,9 @@
         "off" : null,
         "xhigh" : null
       }
-    },
-    "zai-glm-4.7" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.cerebras.ai\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 2.25,
-        "cacheWrite" : 0,
-        "input" : 2.25,
-        "output" : 2.75
-      },
-      "id" : "zai-glm-4.7",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 40960,
-      "name" : "Z.AI GLM-4.7",
-      "provider" : "cerebras",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : null,
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : null
-      }
     }
   },
   "cloudflare-ai-gateway" : {
-    "claude-3-5-haiku" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.080000000000000002,
-        "cacheWrite" : 1,
-        "input" : 0.8,
-        "output" : 4
-      },
-      "id" : "claude-3-5-haiku",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Haiku 3.5 (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "claude-3-haiku" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0.3,
-        "input" : 0.25,
-        "output" : 1.25
-      },
-      "id" : "claude-3-haiku",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Claude Haiku 3",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "claude-3-opus" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 1.5,
-        "cacheWrite" : 18.75,
-        "input" : 15,
-        "output" : 75
-      },
-      "id" : "claude-3-opus",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Claude Opus 3",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "claude-3-sonnet" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 0.3,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "claude-3-sonnet",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Claude Sonnet 3",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "claude-3.5-haiku" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.080000000000000002,
-        "cacheWrite" : 1,
-        "input" : 0.8,
-        "output" : 4
-      },
-      "id" : "claude-3.5-haiku",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Haiku 3.5 (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "claude-3.5-sonnet" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "claude-3.5-sonnet",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 8192,
-      "name" : "Claude Sonnet 3.5 v2",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
     "claude-fable-5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
@@ -4874,7 +4829,7 @@
         "xhigh" : "xhigh"
       }
     },
-    "claude-haiku-4-5" : {
+    "claude-haiku-4.5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -4887,7 +4842,7 @@
         "input" : 1,
         "output" : 5
       },
-      "id" : "claude-haiku-4-5",
+      "id" : "claude-haiku-4.5",
       "input" : [
         "text",
         "image"
@@ -4897,53 +4852,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
-    "claude-opus-4" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 1.5,
-        "cacheWrite" : 18.75,
-        "input" : 15,
-        "output" : 75
-      },
-      "id" : "claude-opus-4",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32000,
-      "name" : "Claude Opus 4 (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true
-    },
-    "claude-opus-4-1" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 1.5,
-        "cacheWrite" : 18.75,
-        "input" : 15,
-        "output" : 75
-      },
-      "id" : "claude-opus-4-1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32000,
-      "name" : "Claude Opus 4.1 (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true
-    },
-    "claude-opus-4-5" : {
+    "claude-opus-4.5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -4956,7 +4865,7 @@
         "input" : 5,
         "output" : 25
       },
-      "id" : "claude-opus-4-5",
+      "id" : "claude-opus-4.5",
       "input" : [
         "text",
         "image"
@@ -4966,7 +4875,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
-    "claude-opus-4-6" : {
+    "claude-opus-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -4980,20 +4889,20 @@
         "input" : 5,
         "output" : 25
       },
-      "id" : "claude-opus-4-6",
+      "id" : "claude-opus-4.6",
       "input" : [
         "text",
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "Claude Opus 4.6 (latest)",
+      "name" : "Claude Opus 4.6",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "max" : "max"
       }
     },
-    "claude-opus-4-7" : {
+    "claude-opus-4.7" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -5008,7 +4917,7 @@
         "input" : 5,
         "output" : 25
       },
-      "id" : "claude-opus-4-7",
+      "id" : "claude-opus-4.7",
       "input" : [
         "text",
         "image"
@@ -5022,7 +4931,7 @@
         "xhigh" : "xhigh"
       }
     },
-    "claude-opus-4-8" : {
+    "claude-opus-4.8" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -5037,7 +4946,7 @@
         "input" : 5,
         "output" : 25
       },
-      "id" : "claude-opus-4-8",
+      "id" : "claude-opus-4.8",
       "input" : [
         "text",
         "image"
@@ -5080,43 +4989,20 @@
         "xhigh" : "xhigh"
       }
     },
-    "claude-sonnet-4" : {
+    "claude-sonnet-4.5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
         "sendSessionAffinityHeaders" : true
       },
-      "contextWindow" : 200000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.3,
         "cacheWrite" : 3.75,
         "input" : 3,
         "output" : 15
       },
-      "id" : "claude-sonnet-4",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Claude Sonnet 4 (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true
-    },
-    "claude-sonnet-4-5" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 3.75,
-        "input" : 3,
-        "output" : 15
-      },
-      "id" : "claude-sonnet-4-5",
+      "id" : "claude-sonnet-4.5",
       "input" : [
         "text",
         "image"
@@ -5126,7 +5012,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
-    "claude-sonnet-4-6" : {
+    "claude-sonnet-4.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/anthropic",
       "compat" : {
@@ -5140,12 +5026,12 @@
         "input" : 3,
         "output" : 15
       },
-      "id" : "claude-sonnet-4-6",
+      "id" : "claude-sonnet-4.6",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 64000,
+      "maxTokens" : 128000,
       "name" : "Claude Sonnet 4.6",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
@@ -5226,6 +5112,75 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : false
     },
+    "gpt-4.1" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 8
+      },
+      "id" : "gpt-4.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
+    "gpt-4.1-mini" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.1,
+        "cacheWrite" : 0,
+        "input" : 0.4,
+        "output" : 1.6
+      },
+      "id" : "gpt-4.1-mini",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1 mini",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
+    "gpt-4.1-nano" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.025000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.1,
+        "output" : 0.4
+      },
+      "id" : "gpt-4.1-nano",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1 nano",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
     "gpt-4o" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -5234,10 +5189,10 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 1.25,
+        "cacheRead" : 0.625,
         "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 10
+        "input" : 1.25,
+        "output" : 5
       },
       "id" : "gpt-4o",
       "input" : [
@@ -5257,10 +5212,10 @@
       },
       "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.080000000000000002,
+        "cacheRead" : 0.037499999999999999,
         "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 0.6
+        "input" : 0.074999999999999997,
+        "output" : 0.3
       },
       "id" : "gpt-4o-mini",
       "input" : [
@@ -5272,40 +5227,7 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : false
     },
-    "gpt-5.1" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.13,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 10
-      },
-      "id" : "gpt-5.1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.1",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "gpt-5.1-codex" : {
+    "gpt-5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
@@ -5319,13 +5241,145 @@
         "input" : 1.25,
         "output" : 10
       },
-      "id" : "gpt-5.1-codex",
+      "id" : "gpt-5",
       "input" : [
         "text",
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "GPT-5.1 Codex",
+      "name" : "GPT-5",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "gpt-5-mini" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.025000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 2
+      },
+      "id" : "gpt-5-mini",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5 Mini",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "gpt-5-nano" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.0050000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.050000000000000003,
+        "output" : 0.4
+      },
+      "id" : "gpt-5-nano",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5 Nano",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "gpt-5-pro" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 15,
+        "output" : 120
+      },
+      "id" : "gpt-5-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 272000,
+      "name" : "GPT-5 Pro",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "gpt-5.1" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.125,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 10
+      },
+      "id" : "gpt-5.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.1",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -5371,7 +5425,40 @@
         "xhigh" : "xhigh"
       }
     },
-    "gpt-5.2-codex" : {
+    "gpt-5.2-chat-latest" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0.175,
+        "cacheWrite" : 0,
+        "input" : 1.75,
+        "output" : 14
+      },
+      "id" : "gpt-5.2-chat-latest",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT-5.2 Chat",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.2-pro" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
       "compat" : {
@@ -5380,26 +5467,54 @@
       },
       "contextWindow" : 400000,
       "cost" : {
-        "cacheRead" : 0.175,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
+        "input" : 21,
+        "output" : 168
       },
-      "id" : "gpt-5.2-codex",
+      "id" : "gpt-5.2-pro",
       "input" : [
         "text",
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "GPT-5.2 Codex",
+      "name" : "GPT-5.2 Pro",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : "low",
+        "low" : null,
         "max" : null,
         "medium" : "medium",
         "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.3-chat-latest" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0.175,
+        "cacheWrite" : 0,
+        "input" : 1.75,
+        "output" : 14
+      },
+      "id" : "gpt-5.3-chat-latest",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT-5.3 Chat (latest)",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false,
+      "thinkingLevelMap" : {
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -5425,6 +5540,39 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT-5.3 Codex",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.3-codex-spark" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0.175,
+        "cacheWrite" : 0,
+        "input" : 1.75,
+        "output" : 14
+      },
+      "id" : "gpt-5.3-codex-spark",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32000,
+      "name" : "GPT-5.3 Codex Spark",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -5470,6 +5618,105 @@
         "xhigh" : "xhigh"
       }
     },
+    "gpt-5.4-mini" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 4.5
+      },
+      "id" : "gpt-5.4-mini",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.4 mini",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.4-nano" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 1.25
+      },
+      "id" : "gpt-5.4-nano",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.4 nano",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.4-pro" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 30,
+        "output" : 180
+      },
+      "id" : "gpt-5.4-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.4 Pro",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "gpt-5.5" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -5497,6 +5744,72 @@
         "high" : "high",
         "low" : "low",
         "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.5-pro" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 30,
+        "output" : 180
+      },
+      "id" : "gpt-5.5-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.5 Pro",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "gpt-5.6" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsOpenAIGrammarTools" : true,
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "gpt-5.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5.6",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
         "medium" : "medium",
         "minimal" : null,
         "off" : null,
@@ -5555,7 +5868,7 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.5,
-        "cacheWrite" : 0,
+        "cacheWrite" : 6.25,
         "input" : 5,
         "output" : 30
       },
@@ -5640,6 +5953,38 @@
       ],
       "maxTokens" : 100000,
       "name" : "o1",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "o1-pro" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 150,
+        "output" : 600
+      },
+      "id" : "o1-pro",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 100000,
+      "name" : "o1-pro",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -5755,7 +6100,7 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.28,
+        "cacheRead" : 0.275,
         "cacheWrite" : 0,
         "input" : 1.1,
         "output" : 4.4
@@ -5779,7 +6124,7 @@
         "xhigh" : null
       }
     },
-    "workers-ai\/@cf\/moonshotai\/kimi-k2.5" : {
+    "workers-ai\/@cf\/google\/gemma-4-26b-a4b-it" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
       "compat" : {
@@ -5793,20 +6138,133 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.6,
-        "output" : 3
+        "input" : 0.1,
+        "output" : 0.3
       },
-      "id" : "workers-ai\/@cf\/moonshotai\/kimi-k2.5",
+      "id" : "workers-ai\/@cf\/google\/gemma-4-26b-a4b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 256000,
-      "name" : "Kimi K2.5",
+      "maxTokens" : 16384,
+      "name" : "Gemma 4 26B A4B IT",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
+    },
+    "workers-ai\/@cf\/ibm-granite\/granite-4.0-h-micro" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 131000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.017000000000000001,
+        "output" : 0.112
+      },
+      "id" : "workers-ai\/@cf\/ibm-granite\/granite-4.0-h-micro",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131000,
+      "name" : "Granite 4.0 H Micro",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
+    "workers-ai\/@cf\/meta\/llama-3.3-70b-instruct-fp8-fast" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 24000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.293,
+        "output" : 2.253
+      },
+      "id" : "workers-ai\/@cf\/meta\/llama-3.3-70b-instruct-fp8-fast",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 24000,
+      "name" : "Llama 3.3 70B Instruct fp8 Fast",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
+    "workers-ai\/@cf\/meta\/llama-4-scout-17b-16e-instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 131000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.27,
+        "output" : 0.85
+      },
+      "id" : "workers-ai\/@cf\/meta\/llama-4-scout-17b-16e-instruct",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "Llama 4 Scout 17B 16E Instruct",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
+    },
+    "workers-ai\/@cf\/mistralai\/mistral-small-3.1-24b-instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.351,
+        "output" : 0.555
+      },
+      "id" : "workers-ai\/@cf\/mistralai\/mistral-small-3.1-24b-instruct",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Mistral Small 3.1 24B Instruct",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : false
     },
     "workers-ai\/@cf\/moonshotai\/kimi-k2.6" : {
       "api" : "openai-completions",
@@ -5820,7 +6278,7 @@
         "supportsStore" : false,
         "supportsStrictMode" : false
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0.16,
         "cacheWrite" : 0,
@@ -5834,6 +6292,35 @@
       ],
       "maxTokens" : 256000,
       "name" : "Kimi K2.6",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
+    "workers-ai\/@cf\/moonshotai\/kimi-k2.7-code" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.19,
+        "cacheWrite" : 0,
+        "input" : 0.95,
+        "output" : 4
+      },
+      "id" : "workers-ai\/@cf\/moonshotai\/kimi-k2.7-code",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Kimi K2.7 Code",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
@@ -5865,6 +6352,90 @@
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
+    "workers-ai\/@cf\/openai\/gpt-oss-20b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 0.3
+      },
+      "id" : "workers-ai\/@cf\/openai\/gpt-oss-20b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT OSS 20B",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
+    "workers-ai\/@cf\/openai\/gpt-oss-120b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.35,
+        "output" : 0.75
+      },
+      "id" : "workers-ai\/@cf\/openai\/gpt-oss-120b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT OSS 120B",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
+    "workers-ai\/@cf\/qwen\/qwen3-30b-a3b-fp8" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 32768,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.050900000000000001,
+        "output" : 0.335
+      },
+      "id" : "workers-ai\/@cf\/qwen\/qwen3-30b-a3b-fp8",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Qwen3 30B A3b fp8",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
     "workers-ai\/@cf\/zai-org\/glm-4.7-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
@@ -5881,7 +6452,7 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.060499999999999998,
         "output" : 0.4
       },
       "id" : "workers-ai\/@cf\/zai-org\/glm-4.7-flash",
@@ -5916,13 +6487,81 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 256000,
       "name" : "Glm 5.2",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     }
   },
   "cloudflare-workers-ai" : {
+    "@cf\/deepseek-ai\/deepseek-v4-flash-0731" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.014,
+        "cacheWrite" : 0,
+        "input" : 0.44,
+        "output" : 1.32
+      },
+      "id" : "@cf\/deepseek-ai\/deepseek-v4-flash-0731",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "DeepSeek V4 Flash 0731",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "@cf\/deepseek-ai\/deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.043999999999999997,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "@cf\/deepseek-ai\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
     "@cf\/google\/gemma-4-26b-a4b-it" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
@@ -6247,6 +6886,41 @@
       "provider" : "cloudflare-workers-ai",
       "reasoning" : true
     },
+    "@cf\/qwen\/qwen3.8-27b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.45,
+        "output" : 3.2
+      },
+      "id" : "@cf\/qwen\/qwen3.8-27b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Qwen3.8 27B",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "@cf\/zai-org\/glm-4.7-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
@@ -6460,6 +7134,31 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
+    "accounts\/fireworks\/models\/deepseek-v4-pro-0813" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.043999999999999997,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "accounts\/fireworks\/models\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
     "accounts\/fireworks\/models\/glm-5p2" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference\/v1",
@@ -6541,6 +7240,32 @@
       ],
       "maxTokens" : 32768,
       "name" : "GPT OSS 120B",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/models\/inkling" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.17,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 4.05
+      },
+      "id" : "accounts\/fireworks\/models\/inkling",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "Inkling",
       "provider" : "fireworks",
       "reasoning" : true
     },
@@ -6685,6 +7410,82 @@
       "provider" : "fireworks",
       "reasoning" : true
     },
+    "accounts\/fireworks\/models\/muse-glimmer-30b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.35,
+        "output" : 1.5
+      },
+      "id" : "accounts\/fireworks\/models\/muse-glimmer-30b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Glimmer 30B",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/models\/nemotron-3-ultra-nvfp4" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.119,
+        "cacheWrite" : 0,
+        "input" : 0.6,
+        "output" : 2.4
+      },
+      "id" : "accounts\/fireworks\/models\/nemotron-3-ultra-nvfp4",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Nemotron 3 Ultra 550B A55B",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/models\/nemotron-lightning-3p5-30b-a3b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.01,
+        "cacheWrite" : 0,
+        "input" : 0.050000000000000003,
+        "output" : 0.2
+      },
+      "id" : "accounts\/fireworks\/models\/nemotron-lightning-3p5-30b-a3b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Nemotron 3.5 Lightning 30B A3B",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
     "accounts\/fireworks\/models\/qwen3p7-plus" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
@@ -6708,6 +7509,31 @@
       ],
       "maxTokens" : 65536,
       "name" : "Qwen 3.7 Plus",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/models\/qwen3p8-max" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "accounts\/fireworks\/models\/qwen3p8-max",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 Max",
       "provider" : "fireworks",
       "reasoning" : true
     },
@@ -7317,6 +8143,37 @@
       "provider" : "github-copilot",
       "reasoning" : true
     },
+    "gemini-3.7-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "headers" : {
+        "Copilot-Integration-Id" : "vscode-chat",
+        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
+        "Editor-Version" : "vscode\/1.107.0",
+        "User-Agent" : "GitHubCopilotChat\/0.35.0"
+      },
+      "id" : "gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Gemini 3.7 Flash",
+      "provider" : "github-copilot",
+      "reasoning" : true
+    },
     "gpt-4.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
@@ -7843,6 +8700,50 @@
         "xhigh" : null
       }
     },
+    "grok-4.6" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6,
+        "tiers" : [
+          {
+            "cacheRead" : 1,
+            "cacheWrite" : 0,
+            "input" : 4,
+            "inputTokensAbove" : 200000,
+            "output" : 12
+          }
+        ]
+      },
+      "headers" : {
+        "Copilot-Integration-Id" : "vscode-chat",
+        "Editor-Plugin-Version" : "copilot-chat\/0.35.0",
+        "Editor-Version" : "vscode\/1.107.0",
+        "User-Agent" : "GitHubCopilotChat\/0.35.0"
+      },
+      "id" : "grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Grok 4.6",
+      "provider" : "github-copilot",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "kimi-k2.7-code" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
@@ -8334,6 +9235,29 @@
         "off" : null
       }
     },
+    "gemini-3.7-flash" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.7 Flash",
+      "provider" : "google",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
     "gemini-flash-latest" : {
       "api" : "google-generative-ai",
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
@@ -8685,6 +9609,29 @@
         "off" : null
       }
     },
+    "gemini-3.7-flash" : {
+      "api" : "google-vertex",
+      "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.7 Flash",
+      "provider" : "google-vertex",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
     "gemini-flash-latest" : {
       "api" : "google-vertex",
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
@@ -8952,6 +9899,28 @@
       "provider" : "huggingface",
       "reasoning" : false
     },
+    "deepseek-ai\/DeepSeek-V3-0324" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 163840,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.27,
+        "output" : 1.12
+      },
+      "id" : "deepseek-ai\/DeepSeek-V3-0324",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 163840,
+      "name" : "DeepSeek V3 0324",
+      "provider" : "huggingface",
+      "reasoning" : false
+    },
     "deepseek-ai\/DeepSeek-V3.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -9080,6 +10049,37 @@
         "xhigh" : null
       }
     },
+    "deepseek-ai\/DeepSeek-V4-Pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "deepseek-ai\/DeepSeek-V4-Pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "google\/gemma-4-26B-A4B-it" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -9125,6 +10125,28 @@
       "name" : "Gemma 4 31B IT",
       "provider" : "huggingface",
       "reasoning" : true
+    },
+    "meta-llama\/Llama-3.1-8B-Instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.059999999999999998,
+        "output" : 0.059999999999999998
+      },
+      "id" : "meta-llama\/Llama-3.1-8B-Instruct",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 4096,
+      "name" : "Llama-3.1-8B-Instruct",
+      "provider" : "huggingface",
+      "reasoning" : false
     },
     "meta-llama\/Llama-3.3-70B-Instruct" : {
       "api" : "openai-completions",
@@ -9488,6 +10510,50 @@
         "xhigh" : null
       }
     },
+    "Qwen\/Qwen2.5-Coder-32B-Instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.059999999999999998,
+        "output" : 0.2
+      },
+      "id" : "Qwen\/Qwen2.5-Coder-32B-Instruct",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 8192,
+      "name" : "Qwen2.5-Coder-32B-Instruct",
+      "provider" : "huggingface",
+      "reasoning" : false
+    },
+    "Qwen\/Qwen3-30B-A3B" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 40960,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.12,
+        "output" : 0.5
+      },
+      "id" : "Qwen\/Qwen3-30B-A3B",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 16384,
+      "name" : "Qwen3 30B A3B",
+      "provider" : "huggingface",
+      "reasoning" : true
+    },
     "Qwen\/Qwen3-32B" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -9686,6 +10752,61 @@
       "provider" : "huggingface",
       "reasoning" : false
     },
+    "Qwen\/Qwen3-VL-235B-A22B-Instruct" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.3,
+        "output" : 1.5
+      },
+      "id" : "Qwen\/Qwen3-VL-235B-A22B-Instruct",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Qwen3 VL 235B A22B Instruct",
+      "provider" : "huggingface",
+      "reasoning" : false
+    },
+    "Qwen\/Qwen3-VL-235B-A22B-Thinking" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.98,
+        "output" : 3.95
+      },
+      "id" : "Qwen\/Qwen3-VL-235B-A22B-Thinking",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Qwen3 VL 235B A22B Thinking",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "Qwen\/Qwen3.5-9B" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -9855,6 +10976,37 @@
       "name" : "Qwen3.6 35B-A3B",
       "provider" : "huggingface",
       "reasoning" : true
+    },
+    "Qwen\/Qwen3.8-2.4T-A95B" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 2.5,
+        "output" : 6.25
+      },
+      "id" : "Qwen\/Qwen3.8-2.4T-A95B",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 2.4T A95B",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "stepfun-ai\/Step-3.5-Flash" : {
       "api" : "openai-completions",
@@ -10295,9 +11447,6 @@
         "input" : 3,
         "output" : 15
       },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
-      },
       "id" : "k3",
       "input" : [
         "text",
@@ -10329,9 +11478,6 @@
         "cacheWrite" : 0,
         "input" : 0,
         "output" : 0
-      },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
       },
       "id" : "k3-256k",
       "input" : [
@@ -10366,9 +11512,6 @@
         "input" : 0.95,
         "output" : 4
       },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
-      },
       "id" : "kimi-for-coding",
       "input" : [
         "text",
@@ -10391,9 +11534,6 @@
         "cacheWrite" : 0,
         "input" : 1.9,
         "output" : 8
-      },
-      "headers" : {
-        "User-Agent" : "KimiCLI\/1.5"
       },
       "id" : "kimi-for-coding-highspeed",
       "input" : [
@@ -11932,6 +13072,37 @@
       "name" : "Llama 3.3 70b Instruct",
       "provider" : "nvidia",
       "reasoning" : false
+    },
+    "meta\/muse-glimmer-30b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "NVCF-POLL-SECONDS" : "3600"
+      },
+      "id" : "meta\/muse-glimmer-30b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Glimmer 30B",
+      "provider" : "nvidia",
+      "reasoning" : true
     },
     "minimaxai\/minimax-m3" : {
       "api" : "openai-completions",
@@ -14418,7 +15589,7 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : null,
+        "low" : "low",
         "max" : "max",
         "medium" : null,
         "minimal" : null,
@@ -14452,7 +15623,7 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : null,
+        "low" : "low",
         "max" : "max",
         "medium" : null,
         "minimal" : null,
@@ -14608,6 +15779,29 @@
       ],
       "maxTokens" : 65536,
       "name" : "Gemini 3.6 Flash",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
+    "gemini-3.7-flash" : {
+      "api" : "google-generative-ai",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 7.5
+      },
+      "id" : "gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.7 Flash",
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -15595,30 +16789,6 @@
         "xhigh" : null
       }
     },
-    "ling-3.0-tiny-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "ling-3.0-tiny-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Ling-3.0-tiny Free",
-      "provider" : "opencode",
-      "reasoning" : true
-    },
     "mimo-v2.5-free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -15717,6 +16887,38 @@
       "name" : "MiniMax-M3",
       "provider" : "opencode",
       "reasoning" : true
+    },
+    "muse-spark-1.2" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "sessionAffinityFormat" : "openai-nosession"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 4.25
+      },
+      "id" : "muse-spark-1.2",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Spark 1.2",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "nemotron-3-ultra-free" : {
       "api" : "openai-completions",
@@ -15820,22 +17022,22 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0014,
+        "cacheRead" : 0.0070000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.14
+        "input" : 0.22,
+        "output" : 0.66
       },
       "id" : "deepseek-v4-flash",
       "input" : [
         "text"
       ],
       "maxTokens" : 384000,
-      "name" : "DeepSeek V4 Flash (2x usage)",
+      "name" : "DeepSeek V4 Flash",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : null,
+        "low" : "low",
         "max" : "max",
         "medium" : null,
         "minimal" : null
@@ -15853,10 +17055,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek-v4-pro",
       "input" : [
@@ -15924,6 +17126,39 @@
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
         "medium" : null,
         "minimal" : null,
@@ -16240,8 +17475,13 @@
       "reasoning" : true
     },
     "qwen3.7-max" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.5,
@@ -16259,8 +17499,13 @@
       "reasoning" : true
     },
     "qwen3.7-plus" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.040000000000000001,
@@ -16279,8 +17524,13 @@
       "reasoning" : true
     },
     "qwen3.8-max" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.25,
@@ -16408,18 +17658,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.0252,
+        "cacheRead" : 0.015719,
         "cacheWrite" : 0,
-        "input" : 0.079995999999999998,
-        "output" : 0.252
+        "input" : 0.078595999999999999,
+        "output" : 0.157192
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 384000,
       "name" : "DeepSeek V4 Flash Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -16441,10 +17691,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.15,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 1.5,
-        "output" : 7.5
+        "cacheRead" : 0.037499999999999999,
+        "cacheWrite" : 0.020833000000000001,
+        "input" : 0.375,
+        "output" : 1.875
       },
       "id" : "~google\/gemini-flash-latest",
       "input" : [
@@ -16487,12 +17737,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 974842,
       "cost" : {
         "cacheRead" : 0.29,
         "cacheWrite" : 0,
-        "input" : 2.8,
-        "output" : 14
+        "input" : 2.6,
+        "output" : 13
       },
       "id" : "~moonshotai\/kimi-latest",
       "input" : [
@@ -16513,10 +17763,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "~openai\/gpt-latest",
       "input" : [
@@ -17932,16 +19182,16 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.27,
-        "output" : 0.95
+        "output" : 1
       },
       "id" : "deepseek\/deepseek-v3.1-terminus",
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 163840,
       "name" : "DeepSeek: DeepSeek V3.1 Terminus",
       "provider" : "openrouter",
       "reasoning" : true
@@ -18000,18 +19250,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.01652,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
+        "input" : 0.082600000000000007,
+        "output" : 0.1652
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
         "text"
       ],
-      "maxTokens" : 393216,
+      "maxTokens" : 384000,
       "name" : "DeepSeek: DeepSeek V4 Flash 0423",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -18034,16 +19284,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.016,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.080000000000000002,
-        "output" : 0.18
+        "input" : 0.14,
+        "output" : 0.28
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
       "input" : [
         "text"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 393216,
       "name" : "DeepSeek: DeepSeek V4 Flash 0731",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -18066,17 +19316,17 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.098549999999999999,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 1.168,
-        "output" : 2.336
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
         "text"
       ],
-      "maxTokens" : 393216,
-      "name" : "DeepSeek: DeepSeek V4 Pro",
+      "maxTokens" : 384000,
+      "name" : "DeepSeek: DeepSeek V4 Pro 0423",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -18098,10 +19348,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0036250000000000002,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
@@ -18119,6 +19369,30 @@
         "minimal" : null,
         "xhigh" : "xhigh"
       }
+    },
+    "dots-studio\/dots-3-note-preview:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 512000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "dots-studio\/dots-3-note-preview:free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 512000,
+      "name" : "Dots Studio: Dots3-Note Preview (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "google\/gemini-2.5-flash" : {
       "api" : "openai-completions",
@@ -18633,10 +19907,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.15,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 1.5,
-        "output" : 7.5
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "google\/gemini-3.6-flash",
       "input" : [
@@ -18657,10 +19931,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.074999999999999997,
-        "cacheWrite" : 0.083333000000000004,
-        "input" : 0.75,
-        "output" : 3.75
+        "cacheRead" : 0.037499999999999999,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.375,
+        "output" : 1.875
       },
       "id" : "google\/gemini-3.6-flash:batch",
       "input" : [
@@ -18669,6 +19943,54 @@
       ],
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.6 Flash (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "google\/gemini-3.7-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.037499999999999999,
+        "cacheWrite" : 0.020833000000000001,
+        "input" : 0.375,
+        "output" : 1.875
+      },
+      "id" : "google\/gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.7 Flash",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "google\/gemini-3.7-flash:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.018749999999999999,
+        "cacheWrite" : 0.020833000000000001,
+        "input" : 0.1875,
+        "output" : 0.9375
+      },
+      "id" : "google\/gemini-3.7-flash:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.7 Flash (batch)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -18729,17 +20051,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.4
+        "input" : 0.070000000000000007,
+        "output" : 0.34
       },
       "id" : "google\/gemma-4-26b-a4b-it",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 16384,
       "name" : "Google: Gemma 4 26B A4B ",
       "provider" : "openrouter",
       "reasoning" : true
@@ -18751,7 +20073,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -18934,29 +20256,6 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
-    "inclusionai\/ling-3.0-tiny:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "inclusionai\/ling-3.0-tiny:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "inclusionAI: Ling 3.0 Tiny (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
     "inclusionai\/ring-2.6-1t" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -19048,29 +20347,6 @@
       "name" : "Kwaipilot: KAT-Coder-Pro V2.5",
       "provider" : "openrouter",
       "reasoning" : false
-    },
-    "liquid\/lfm-2.5-2.6b:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "liquid\/lfm-2.5-2.6b:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "LiquidAI: LFM2.5-2.6B (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
     },
     "meituan\/longcat-2.0" : {
       "api" : "openai-completions",
@@ -19171,19 +20447,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 128000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 0.2,
-        "output" : 0.696
+        "output" : 0.8
       },
       "id" : "meta-llama\/llama-4-maverick",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 16384,
       "name" : "Meta: Llama 4 Maverick",
       "provider" : "openrouter",
       "reasoning" : false
@@ -19927,10 +21203,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.16,
+        "cacheRead" : 0.094399999999999998,
         "cacheWrite" : 0,
-        "input" : 0.95,
-        "output" : 4
+        "input" : 0.5605,
+        "output" : 2.36
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -19953,8 +21229,8 @@
       "cost" : {
         "cacheRead" : 0.15,
         "cacheWrite" : 0,
-        "input" : 0.67,
-        "output" : 3.4
+        "input" : 0.71,
+        "output" : 3.5
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
@@ -20071,7 +21347,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.025000000000000001,
+        "cacheRead" : 0.029999999999999999,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
         "output" : 0.2
@@ -20080,7 +21356,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 228000,
+      "maxTokens" : 262144,
       "name" : "NVIDIA: Nemotron 3 Nano 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20256,16 +21532,16 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.040000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.25
+        "input" : 0.080000000000000002,
+        "output" : 0.2
       },
       "id" : "nvidia\/nemotron-3.5-lightning",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "NVIDIA: Nemotron 3.5 Lightning",
       "provider" : "openrouter",
       "reasoning" : true
@@ -21667,10 +22943,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0.125,
-        "input" : 0.1,
-        "output" : 0.6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "openai\/gpt-5.6-luna",
       "input" : [
@@ -21694,10 +22970,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0.125,
-        "input" : 0.1,
-        "output" : 0.6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "openai\/gpt-5.6-luna-pro",
       "input" : [
@@ -21775,10 +23051,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "openai\/gpt-5.6-sol",
       "input" : [
@@ -21802,10 +23078,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "openai\/gpt-5.6-sol-pro",
       "input" : [
@@ -21829,10 +23105,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
+        "cacheRead" : 0.125,
         "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 15
+        "input" : 1.25,
+        "output" : 7.5
       },
       "id" : "openai\/gpt-5.6-sol-pro:batch",
       "input" : [
@@ -21856,10 +23132,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
+        "cacheRead" : 0.125,
         "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 15
+        "input" : 1.25,
+        "output" : 7.5
       },
       "id" : "openai\/gpt-5.6-sol:batch",
       "input" : [
@@ -21883,10 +23159,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12
       },
       "id" : "openai\/gpt-5.6-terra",
       "input" : [
@@ -21910,10 +23186,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 6
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12
       },
       "id" : "openai\/gpt-5.6-terra-pro",
       "input" : [
@@ -22745,9 +24021,9 @@
       "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
-        "cacheWrite" : 0.5,
-        "input" : 0.4,
-        "output" : 1.2
+        "cacheWrite" : 0,
+        "input" : 0.26,
+        "output" : 0.78
       },
       "id" : "qwen\/qwen-plus-2025-07-28:thinking",
       "input" : [
@@ -22811,18 +24087,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 40960,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.12,
-        "output" : 0.5
+        "input" : 0.13,
+        "output" : 0.52
       },
       "id" : "qwen\/qwen3-30b-a3b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 8192,
       "name" : "Qwen: Qwen3 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23135,16 +24411,16 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.070000000000000007,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
+        "input" : 0.1,
         "output" : 1.1
       },
       "id" : "qwen\/qwen3-next-80b-a3b-instruct",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3 Next 80B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -23156,7 +24432,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -23167,7 +24443,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 Next 80B A3B Thinking",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23227,19 +24503,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 0.6
+        "input" : 0.13,
+        "output" : 0.52
       },
       "id" : "qwen\/qwen3-vl-30b-a3b-instruct",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 VL 30B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -23301,10 +24577,10 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.26,
-        "output" : 1.04
+        "input" : 0.21,
+        "output" : 1.9
       },
       "id" : "qwen\/qwen3-vl-235b-a22b-instruct",
       "input" : [
@@ -23397,17 +24673,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.25,
+        "cacheRead" : 0.225,
         "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 1.25
+        "input" : 0.225,
+        "output" : 1.8
       },
       "id" : "qwen\/qwen3.5-35b-a3b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 65536,
       "name" : "Qwen: Qwen3.5-35B-A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23445,10 +24721,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.044999999999999998,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.45,
-        "output" : 3
+        "input" : 0.39,
+        "output" : 2.34
       },
       "id" : "qwen\/qwen3.5-397b-a17b",
       "input" : [
@@ -23539,19 +24815,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.12,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.6,
-        "output" : 3.6
+        "input" : 0.289,
+        "output" : 2.4
       },
       "id" : "qwen\/qwen3.6-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "Qwen: Qwen3.6 27B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -23567,7 +24843,7 @@
       "cost" : {
         "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.15,
+        "input" : 0.14,
         "output" : 1
       },
       "id" : "qwen\/qwen3.6-35b-a3b",
@@ -23729,9 +25005,9 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.2,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -23740,8 +25016,32 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 52429,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3.8 2.4T A95B",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "qwen\/qwen3.8-27b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.45,
+        "output" : 3.2
+      },
+      "id" : "qwen\/qwen3.8-27b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen: Qwen3.8 27B",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -23966,10 +25266,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.021000000000000001,
+        "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.063,
-        "output" : 0.21
+        "input" : 0.18,
+        "output" : 0.6
       },
       "id" : "tencent\/hy3-preview",
       "input" : [
@@ -24458,7 +25758,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 204800,
+      "contextWindow" : 198000,
       "cost" : {
         "cacheRead" : 0.119,
         "cacheWrite" : 0,
@@ -24469,7 +25769,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 128000,
       "name" : "Z.ai: GLM 5",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24504,18 +25804,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 202752,
+      "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.26,
+        "cacheRead" : 0.1794,
         "cacheWrite" : 0,
-        "input" : 1.4,
-        "output" : 4.4
+        "input" : 0.966,
+        "output" : 3.036
       },
       "id" : "z-ai\/glm-5.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 128000,
       "name" : "Z.ai: GLM 5.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24529,10 +25829,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.090999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 3.15
+        "input" : 0.49,
+        "output" : 1.54
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
@@ -24708,6 +26008,39 @@
       ],
       "maxTokens" : 384000,
       "name" : "DeepSeek V4 Pro",
+      "provider" : "qwen-token-plan",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
+    },
+    "deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan.ap-southeast-1.maas.aliyuncs.com\/compatible-mode\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "qwen"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
       "provider" : "qwen-token-plan",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -25184,6 +26517,39 @@
         "xhigh" : null
       }
     },
+    "deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan.cn-beijing.maas.aliyuncs.com\/compatible-mode\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "qwen"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "qwen-token-plan-cn",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
+    },
     "glm-5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan.cn-beijing.maas.aliyuncs.com\/compatible-mode\/v1",
@@ -25591,6 +26957,39 @@
         "xhigh" : null
       }
     },
+    "deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan.ap-southeast-1.maas.aliyuncs.com\/compatible-mode\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "qwen"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "qwen-token-plan-individual",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
+    },
     "glm-5.2" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan.ap-southeast-1.maas.aliyuncs.com\/compatible-mode\/v1",
@@ -25803,6 +27202,39 @@
         "medium" : null,
         "minimal" : null,
         "xhigh" : null
+      }
+    },
+    "deepseek-ai\/DeepSeek-V4-Pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.13,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "deepseek-ai\/DeepSeek-V4-Pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
       }
     },
     "google\/gemma-4-31B-it" : {
@@ -26819,6 +28251,45 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "alibaba\/qwen3.8-2.4t-a95b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "alibaba\/qwen3.8-2.4t-a95b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 2.4T A95B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "alibaba\/qwen3.8-27b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.01,
+        "cacheWrite" : 0,
+        "input" : 0.1,
+        "output" : 0.4
+      },
+      "id" : "alibaba\/qwen3.8-27b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262133,
+      "name" : "Qwen3.8 27B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "alibaba\/qwen3.8-max" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -27501,10 +28972,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.2,
-        "output" : 0.4
+        "input" : 0.13,
+        "output" : 0.26
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -27520,10 +28991,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.040000000000000001,
+        "cacheRead" : 0.028000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.2,
-        "output" : 0.4
+        "input" : 0.13,
+        "output" : 0.26
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
       "input" : [
@@ -27558,10 +29029,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.0035999999999999999,
+        "cacheRead" : 0.132,
         "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
+        "input" : 1.32,
+        "output" : 3.96
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
@@ -27737,10 +29208,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.15,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
-        "input" : 1.5,
-        "output" : 7.5
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "google\/gemini-3.6-flash",
       "input" : [
@@ -27749,6 +29220,26 @@
       ],
       "maxTokens" : 64000,
       "name" : "Gemini 3.6 Flash",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "google\/gemini-3.7-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "google\/gemini-3.7-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.7 Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -27775,7 +29266,7 @@
     "google\/gemma-4-31b-it" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -27846,25 +29337,6 @@
       ],
       "maxTokens" : 32000,
       "name" : "Ling 3.0 Flash",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "inclusionai\/ling-3.0-tiny-free" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "inclusionai\/ling-3.0-tiny-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32000,
-      "name" : "Ling 3.0 Tiny (Free)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -28789,6 +30261,25 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "nvidia\/nemotron-3.5-lightning" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "nvidia\/nemotron-3.5-lightning",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Nemotron 3.5 Lightning 30B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "nvidia\/nemotron-nano-9b-v2" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -28887,6 +30378,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
+    "openai\/gpt-4.1-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.875,
+        "cacheWrite" : 0,
+        "input" : 3.5,
+        "output" : 14
+      },
+      "id" : "openai\/gpt-4.1-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
     "openai\/gpt-4.1-mini" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -28904,6 +30415,26 @@
       ],
       "maxTokens" : 32768,
       "name" : "GPT-4.1 mini",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
+    "openai\/gpt-4.1-mini-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.175,
+        "cacheWrite" : 0,
+        "input" : 0.7,
+        "output" : 2.8
+      },
+      "id" : "openai\/gpt-4.1-mini-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1 mini (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
@@ -28927,6 +30458,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
+    "openai\/gpt-4.1-nano-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1047576,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 0.8
+      },
+      "id" : "openai\/gpt-4.1-nano-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GPT-4.1 nano (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
     "openai\/gpt-4o" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -28947,6 +30498,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
+    "openai\/gpt-4o-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 2.125,
+        "cacheWrite" : 0,
+        "input" : 4.25,
+        "output" : 17
+      },
+      "id" : "openai\/gpt-4o-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT-4o (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
     "openai\/gpt-4o-mini" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -28964,6 +30535,26 @@
       ],
       "maxTokens" : 16384,
       "name" : "GPT-4o mini",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
+    "openai\/gpt-4o-mini-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0.125,
+        "cacheWrite" : 0,
+        "input" : 0.25,
+        "output" : 1
+      },
+      "id" : "openai\/gpt-4o-mini-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 16384,
+      "name" : "GPT-4o mini (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
     },
@@ -29007,6 +30598,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "openai\/gpt-5-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 0,
+        "input" : 2.5,
+        "output" : 20
+      },
+      "id" : "openai\/gpt-5-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "openai\/gpt-5-mini" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29024,6 +30635,26 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT-5 mini",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "openai\/gpt-5-mini-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.044999999999999998,
+        "cacheWrite" : 0,
+        "input" : 0.45,
+        "output" : 3.6
+      },
+      "id" : "openai\/gpt-5-mini-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT-5 mini (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -29147,6 +30778,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "openai\/gpt-5.1-thinking-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 0,
+        "input" : 2.5,
+        "output" : 20
+      },
+      "id" : "openai\/gpt-5.1-thinking-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.1 Thinking (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "openai\/gpt-5.2" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29187,6 +30838,29 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT 5.2 Codex",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.2-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.35,
+        "cacheWrite" : 0,
+        "input" : 3.5,
+        "output" : 28
+      },
+      "id" : "openai\/gpt-5.2-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.2 (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -29239,6 +30913,29 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.3-codex-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.35,
+        "cacheWrite" : 0,
+        "input" : 3.5,
+        "output" : 28
+      },
+      "id" : "openai\/gpt-5.3-codex-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.3 Codex (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-5.4" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29262,6 +30959,29 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.4-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-5.4-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.4 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-5.4-mini" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29279,6 +30999,29 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT 5.4 Mini",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.4-mini-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 400000,
+      "cost" : {
+        "cacheRead" : 0.15,
+        "cacheWrite" : 0,
+        "input" : 1.5,
+        "output" : 9
+      },
+      "id" : "openai\/gpt-5.4-mini-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.4 Mini (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -29354,6 +31097,29 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.5-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 1.25,
+        "cacheWrite" : 0,
+        "input" : 12.5,
+        "output" : 75
+      },
+      "id" : "openai\/gpt-5.5-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.5 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-5.5-pro" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29403,15 +31169,38 @@
         "xhigh" : "xhigh"
       }
     },
+    "openai\/gpt-5.6-luna-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0.25,
+        "input" : 0.4,
+        "output" : 2.4
+      },
+      "id" : "openai\/gpt-5.6-luna-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Luna (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
     "openai\/gpt-5.6-sol" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15
       },
       "id" : "openai\/gpt-5.6-sol",
       "input" : [
@@ -29420,6 +31209,29 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT 5.6 Sol",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-sol-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 3.125,
+        "input" : 5,
+        "output" : 30
+      },
+      "id" : "openai\/gpt-5.6-sol-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Sol (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -29443,6 +31255,29 @@
       ],
       "maxTokens" : 128000,
       "name" : "GPT 5.6 Terra",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "xhigh" : "xhigh"
+      }
+    },
+    "openai\/gpt-5.6-terra-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1050000,
+      "cost" : {
+        "cacheRead" : 0.4,
+        "cacheWrite" : 2.5,
+        "input" : 4,
+        "output" : 24
+      },
+      "id" : "openai\/gpt-5.6-terra-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "GPT 5.6 Terra (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -29566,6 +31401,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "openai\/o3-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.875,
+        "cacheWrite" : 0,
+        "input" : 3.5,
+        "output" : 14
+      },
+      "id" : "openai\/o3-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 100000,
+      "name" : "o3 (Fast)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "openai\/o3-mini" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29622,6 +31477,26 @@
       ],
       "maxTokens" : 100000,
       "name" : "o4-mini",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "openai\/o4-mini-fast" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 8
+      },
+      "id" : "openai\/o4-mini-fast",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 100000,
+      "name" : "o4-mini (Fast)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -29894,7 +31769,8 @@
       },
       "id" : "xai\/grok-4.6",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 500000,
       "name" : "Grok 4.6",
@@ -30372,12 +32248,10 @@
   },
   "xai" : {
     "grok-4.3" : {
-      "api" : "openai-completions",
+      "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
       "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
+        "supportsLongCacheRetention" : false
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -30394,7 +32268,16 @@
       "maxTokens" : 30000,
       "name" : "Grok 4.3",
       "provider" : "xai",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "grok-4.5" : {
       "api" : "openai-responses",
@@ -30429,12 +32312,10 @@
       }
     },
     "grok-4.6" : {
-      "api" : "openai-completions",
+      "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
       "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
+        "supportsLongCacheRetention" : false
       },
       "contextWindow" : 500000,
       "cost" : {
@@ -30451,15 +32332,22 @@
       "maxTokens" : 500000,
       "name" : "Grok 4.6",
       "provider" : "xai",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "grok-build-0.1" : {
-      "api" : "openai-completions",
+      "api" : "openai-responses",
       "baseUrl" : "https:\/\/api.x.ai\/v1",
       "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
+        "supportsLongCacheRetention" : false
       },
       "contextWindow" : 256000,
       "cost" : {
@@ -30476,80 +32364,14 @@
       "maxTokens" : 256000,
       "name" : "Grok Build 0.1",
       "provider" : "xai",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "minimal" : null,
+        "off" : null
+      }
     }
   },
   "xiaomi" : {
-    "mimo-v2-flash" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.0028,
-        "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
-      },
-      "id" : "mimo-v2-flash",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 65536,
-      "name" : "MiMo-V2-Flash",
-      "provider" : "xiaomi",
-      "reasoning" : true
-    },
-    "mimo-v2-omni" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.0028,
-        "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
-      },
-      "id" : "mimo-v2-omni",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Omni",
-      "provider" : "xiaomi",
-      "reasoning" : true
-    },
-    "mimo-v2-pro" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0.0035999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.435,
-        "output" : 0.87
-      },
-      "id" : "mimo-v2-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Pro",
-      "provider" : "xiaomi",
-      "reasoning" : true
-    },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/api.xiaomimimo.com\/v1",
@@ -30622,29 +32444,6 @@
     }
   },
   "xiaomi-token-plan-ams" : {
-    "mimo-v2-pro" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "mimo-v2-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Pro",
-      "provider" : "xiaomi-token-plan-ams",
-      "reasoning" : true
-    },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-ams.xiaomimimo.com\/v1",
@@ -30694,29 +32493,6 @@
     }
   },
   "xiaomi-token-plan-cn" : {
-    "mimo-v2-pro" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "mimo-v2-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Pro",
-      "provider" : "xiaomi-token-plan-cn",
-      "reasoning" : true
-    },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-cn.xiaomimimo.com\/v1",
@@ -30766,29 +32542,6 @@
     }
   },
   "xiaomi-token-plan-sgp" : {
-    "mimo-v2-pro" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
-      "compat" : {
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "thinkingFormat" : "deepseek"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "mimo-v2-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "MiMo-V2-Pro",
-      "provider" : "xiaomi-token-plan-sgp",
-      "reasoning" : true
-    },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan-sgp.xiaomimimo.com\/v1",
@@ -30851,10 +32604,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "glm-4.7",
       "input" : [
@@ -30878,10 +32631,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.2,
+        "output" : 4
       },
       "id" : "glm-5-turbo",
       "input" : [
@@ -30905,10 +32658,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.2",
       "input" : [
@@ -30952,9 +32705,64 @@
       "name" : "GLM-5.2 Highspeed",
       "provider" : "zai",
       "reasoning" : true
+    },
+    "glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.z.ai\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3",
+      "provider" : "zai",
+      "reasoning" : true
     }
   },
   "zai-coding-cn" : {
+    "glm-4.6v" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.3,
+        "output" : 0.9
+      },
+      "id" : "glm-4.6v",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GLM-4.6V",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true
+    },
     "glm-4.7" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
@@ -30968,10 +32776,10 @@
       },
       "contextWindow" : 204800,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.6,
+        "output" : 2.2
       },
       "id" : "glm-4.7",
       "input" : [
@@ -30995,10 +32803,10 @@
       },
       "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.24,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.2,
+        "output" : 4
       },
       "id" : "glm-5-turbo",
       "input" : [
@@ -31006,6 +32814,33 @@
       ],
       "maxTokens" : 131072,
       "name" : "GLM-5-Turbo",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true
+    },
+    "glm-5.1" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "glm-5.1",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.1",
       "provider" : "zai-coding-cn",
       "reasoning" : true
     },
@@ -31022,10 +32857,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.2",
       "input" : [
@@ -31067,6 +32902,61 @@
       ],
       "maxTokens" : 131072,
       "name" : "GLM-5.2 Highspeed",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true
+    },
+    "glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true
+    },
+    "glm-5v-turbo" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 200000,
+      "cost" : {
+        "cacheRead" : 0.24,
+        "cacheWrite" : 0,
+        "input" : 1.2,
+        "output" : 4
+      },
+      "id" : "glm-5v-turbo",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5V-Turbo",
       "provider" : "zai-coding-cn",
       "reasoning" : true
     }

--- a/Tests/KWWKCliTests/MultiProviderAuthTests.swift
+++ b/Tests/KWWKCliTests/MultiProviderAuthTests.swift
@@ -233,9 +233,10 @@ struct MultiProviderAuthTests {
             #expect(resolved?.model.api == "openai-completions")
             #expect(resolved?.model.baseURL == "https://api.x.ai/v1")
             let resolvedModel = try #require(resolved?.model)
-            #expect(resolvedModel.compat?.supportsDeveloperRole == false)
-            #expect(resolvedModel.compat?.supportsReasoningEffort == false)
-            #expect(resolvedModel.compat?.supportsStore == false)
+            // pi-mono now catalogs Grok on the Responses wire. The stored
+            // subscription still uses completions, whose provider detects the
+            // Grok request-shape defaults when these fields are omitted.
+            #expect(resolvedModel.compat?.supportsLongCacheRetention == false)
             #expect(resolved?.modelLabel == "grok-4.3 · xAI Grok")
             // The OAuth resolver supplies a bearer token per request.
             let auth = try await resolved?.authResolver?(resolvedModel, nil)


### PR DESCRIPTION
## Summary

- refresh `models.json` from authoritative `badlogic/pi-mono` main commit `a6c6f801802a7083609541dbd49eec203804d8fc`
- refresh `cursor-models.json` from Cursor `GetUsableModels`
- update the xAI stored-provider regression expectation for pi-mono's new Responses compatibility metadata; kwwk's subscription path remains on the completions wire with Grok defaults auto-detected

## Catalog changes

- regular catalog: 39 providers, 1,300 models
  - 97 additions
  - 30 removals
  - 82 metadata changes, primarily pricing, token/context limits, compatibility flags, and xAI API metadata
- Cursor catalog: 198 models
  - 3 additions (`gemini-3.7-flash-high`, `gemini-3.7-flash-low`, `gemini-3.7-flash-medium`)
  - no removals
  - 78 name-only metadata changes

## Validation

- parsed both catalogs with `jq`
- `git diff --check`
- private/localhost endpoint and credential-pattern scans
- `swift test --filter GenerateModelsCoreTests` (5 tests)
- `swift test --filter CursorProtoTests` (31 tests)
- `swift test --filter registerStoredXaiGrok` (1 test)
- full `swift test` (1,342 tests across 196 suites)
