### PR TITLE
fix(ai): no default WebSocket transport off Darwin

### DIFF
--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -40,7 +40,7 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
     public init(
         api: String = "openai-responses",
         client: HTTPClient = URLSessionHTTPClient(),
-        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient.platformDefault,
         defaultBaseURL: URL = URL(string: "https://api.openai.com")!,
         defaultAPIKey: String? = nil,
         extraHeaders: [String: String] = [:],

--- a/Sources/KWWKAI/ProviderVariants.swift
+++ b/Sources/KWWKAI/ProviderVariants.swift
@@ -23,7 +23,7 @@ public enum ProviderVariants {
         apiVersion: String = "2024-10-01-preview",
         apiKey: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
-        webSocketClient: WebSocketClient? = URLSessionWebSocketClient()
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient.platformDefault
     ) -> OpenAIResponsesProvider {
         let endpointString = endpoint.absoluteString.trimmedSlashes
         return OpenAIResponsesProvider(
@@ -63,7 +63,7 @@ public enum ProviderVariants {
         apiKey: String? = nil,
         api: String = "azure-openai-responses",
         client: HTTPClient = URLSessionHTTPClient(),
-        webSocketClient: WebSocketClient? = URLSessionWebSocketClient()
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient.platformDefault
     ) -> OpenAIResponsesProvider {
         let base = endpoint.absoluteString.trimmedSlashes
         return OpenAIResponsesProvider(
@@ -245,7 +245,7 @@ public enum ProviderVariants {
         accessToken: String? = nil,
         accountId: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
-        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient.platformDefault,
         originator: String = "kw-cli"
     ) -> OpenAIResponsesProvider {
         var extra: [String: String] = [
@@ -341,7 +341,7 @@ public enum ProviderVariants {
     public static func githubCopilotResponses(
         sessionToken: String? = nil,
         client: HTTPClient = URLSessionHTTPClient(),
-        webSocketClient: WebSocketClient? = URLSessionWebSocketClient(),
+        webSocketClient: WebSocketClient? = URLSessionWebSocketClient.platformDefault,
         integrationID: String = "vscode-chat",
         api: String = "openai-responses",
         baseURL: URL = URL(string: "https://api.individual.githubcopilot.com")!

--- a/Sources/KWWKAI/WebSocketClient.swift
+++ b/Sources/KWWKAI/WebSocketClient.swift
@@ -27,6 +27,29 @@ public struct WebSocketKeepaliveError: Error, CustomStringConvertible, Sendable 
 }
 
 public struct URLSessionWebSocketClient: WebSocketClient {
+    /// The WebSocket transport a Responses provider gets when the caller
+    /// names none: URLSession's on Apple platforms, nothing elsewhere.
+    ///
+    /// swift-corelibs-foundation's `URLSessionWebSocketTask` (Linux, on
+    /// libcurl) hands each TCP read out as its own message: any frame over
+    /// a few KB — a `response.completed` carrying reasoning
+    /// `encrypted_content`, say — arrives as several `.string` fragments,
+    /// none of them valid JSON, and the event is lost. The stream then
+    /// waits for a terminal event that never comes until the keepalive
+    /// tears it down, retries, and only reaches HTTP after
+    /// `maxWebSocketFailures` such rounds. Measured with the 6.3.3 static
+    /// musl SDK against an echo server: 1 KB intact, 15 KB in 7 pieces.
+    /// The upstream fix (swift-corelibs-foundation#5255) is unmerged, so
+    /// off Darwin the default is no WebSocket and the SSE path from the
+    /// start. Pass a client explicitly to opt in anyway.
+    public static var platformDefault: WebSocketClient? {
+        #if canImport(Darwin)
+            URLSessionWebSocketClient()
+        #else
+            nil
+        #endif
+    }
+
     public let session: URLSession
     /// Seconds between keepalive pings. `0` disables the heartbeat.
     public var pingIntervalSeconds: TimeInterval

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -84,6 +84,27 @@ struct OpenAIResponsesTests {
 
     """
 
+    /// The default transport follows the platform: URLSession's WebSocket
+    /// on Darwin, none elsewhere — swift-corelibs-foundation splits large
+    /// frames into fragments (see `URLSessionWebSocketClient.platformDefault`),
+    /// so a Linux provider must start on SSE rather than lose three rounds
+    /// to keepalive timeouts first.
+    @Test("the default WebSocket transport is Darwin-only")
+    func defaultWebSocketTransportFollowsPlatform() {
+        let provider = OpenAIResponsesProvider()
+        let codex = ProviderVariants.chatgptCodex()
+        #if canImport(Darwin)
+            #expect(provider.webSocketClient != nil)
+            #expect(codex.webSocketClient != nil)
+        #else
+            #expect(provider.webSocketClient == nil)
+            #expect(codex.webSocketClient == nil)
+        #endif
+        // An explicit client is always honoured.
+        let explicit = OpenAIResponsesProvider(webSocketClient: URLSessionWebSocketClient())
+        #expect(explicit.webSocketClient != nil)
+    }
+
     @Test("streams text + completes with usage")
     func basicText() async throws {
         let client = StubSSEClient(body: Self.textSSE)


### PR DESCRIPTION
## Why

On Linux, `URLSessionWebSocketTask` (swift-corelibs-foundation, libcurl-backed) delivers every TCP read as its own message — `_WebSocketURLProtocol.didReceive(data:)` ignores `curl_ws_meta().bytesleft`. Any frame over a few KB is handed to us as several `.string` fragments; `WebSocketSSESequence` → `parseJSONObject` fails on each and `drive` skips them, so the whole event vanishes.

With Codex, `response.output_item.done` / `response.completed` carrying reasoning `encrypted_content` are exactly that size. The stream never sees its terminal event, the 60 s keepalive kills the socket, the turn retries (“Model stream retrying”), and only after `maxWebSocketFailures` (3) does it fall back to HTTP — ~3.5 min lost per agent session. Seen in the AirBuild sandbox 2026-08-19; the sandbox network itself is fine (a stdlib Python WS client from the same Pod completes the Codex session normally).

Reproduced with the exact 6.3.3 static musl SDK against `wss://echo.websocket.org`:

```
size 1000  : 1 read  → OK one message
size 15000 : 7 reads → SPLIT (2732/4096/1376/1368/4096/8/1324)
size 20000+: 8+ reads, never assembled
```

Upstream fix: swiftlang/swift-corelibs-foundation#5255 (open since 2025-08, unreviewed).

## What

- `URLSessionWebSocketClient.platformDefault`: `URLSessionWebSocketClient()` on Darwin, `nil` elsewhere.
- Every default `webSocketClient:` parameter (`OpenAIResponsesProvider.init`, `azureOpenAIResponses`, `azureOpenAIResponsesV1`, `chatgptCodex`, `githubCopilotResponses`) uses it, so Linux starts on SSE. Passing a client explicitly still enables WS.
- Test asserts the platform default and that an explicit client is honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL8ZdGiGeSfq9GNj45gP5g
