### PR TITLE
maxTaskTimeoutSeconds caps how long bash and agent keep the model waiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ try await coding.agent.prompt("Use the reviewer subagent to review Sources/KWWKA
 // `backgroundManager: nil` to disable background execution entirely.
 ```
 
-`CodingAgentConfig.maxTaskTimeoutSeconds` (also on `BashToolOptions`,
-`createAgentTool`, `createSubagentToolset`, and `SubagentRunner`) caps how long
-any single `bash` or `agent` call may keep the model waiting. It overrides the
+`CodingAgentConfig.maxTaskTimeoutSeconds` (also on `createAgentTool`,
+`createSubagentToolset`, and `SubagentRunner`) caps how long any single
+`bash` or `agent` call may keep the model waiting; for bash it folds into
+`bashDefaultTimeoutSeconds`/`bashMaxTimeoutSeconds`. It overrides the
 model's own `timeout` and its `run_in_background: false`: a command or
 subagent still running at the cap is moved to the background — the work
 continues, the tool returns `auto_backgrounded` with a task id, and the

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ try await coding.agent.prompt("Use the reviewer subagent to review Sources/KWWKA
 // `backgroundManager: nil` to disable background execution entirely.
 ```
 
+`CodingAgentConfig.maxTaskTimeoutSeconds` (also on `BashToolOptions`,
+`createAgentTool`, `createSubagentToolset`, and `SubagentRunner`) caps how long
+any single `bash` or `agent` call may keep the model waiting. It overrides the
+model's own `timeout` and its `run_in_background: false`: a command or
+subagent still running at the cap is moved to the background — the work
+continues, the tool returns `auto_backgrounded` with a task id, and the
+completion arrives as the usual notification — or, without a background
+manager, fails as an ordinary timeout. Both tool descriptions tell the model
+about the cap so it plans around it.
+
 SDK users can enable the same built-ins that the CLI uses without copying
 prompts:
 

--- a/README.md
+++ b/README.md
@@ -160,16 +160,26 @@ try await coding.agent.prompt("Use the reviewer subagent to review Sources/KWWKA
 // `backgroundManager: nil` to disable background execution entirely.
 ```
 
+The `agent` tool follows the same timing contract as `bash`: its `timeout`
+is how long the call waits in the foreground (default
+`SubagentLimits.foregroundTimeoutSeconds` = 120, at most
+`maxForegroundTimeoutSeconds` = 600), not how long the child may run. A
+foreground child still running when `timeout` elapses is moved to the
+background — the work continues, the tool returns `auto_backgrounded` with a
+task id, and completion arrives as the usual notification — or, without a
+background manager, is cancelled as a timeout. A child's own runtime is
+unbounded by default (`SubagentLimits.timeoutSeconds` is nil; the background
+manager's last-resort watchdog still applies), so foreground and background
+children behave identically once launched.
+
 `CodingAgentConfig.maxTaskTimeoutSeconds` (also on `createAgentTool`,
-`createSubagentToolset`, and `SubagentRunner`) caps how long any single
-`bash` or `agent` call may keep the model waiting; for bash it folds into
-`bashDefaultTimeoutSeconds`/`bashMaxTimeoutSeconds`. It overrides the
-model's own `timeout` and its `run_in_background: false`: a command or
-subagent still running at the cap is moved to the background — the work
-continues, the tool returns `auto_backgrounded` with a task id, and the
-completion arrives as the usual notification — or, without a background
-manager, fails as an ordinary timeout. Both tool descriptions tell the model
-about the cap so it plans around it.
+`createSubagentToolset`, and `SubagentRunner`) is a runtime-wide ceiling on
+how long any single `bash` or `agent` call may keep the model waiting: it
+folds into bash's `bashDefaultTimeoutSeconds`/`bashMaxTimeoutSeconds` and the
+agent tool's foreground-wait bounds, overriding whatever `timeout` the model
+asks for (a larger value is lowered, not rejected) and its
+`run_in_background: false`. Both tool descriptions state the effective bound
+so the model plans around it.
 
 SDK users can enable the same built-ins that the CLI uses without copying
 prompts:

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -1864,7 +1864,7 @@ public enum AgentLoop {
         switch statusRaw {
         case "completed":
             status = .completed
-        case "background_started":
+        case "background_started", "auto_backgrounded":
             status = .backgroundStarted
         case "failed":
             status = .failed

--- a/Sources/KWWKAgent/BashTool.swift
+++ b/Sources/KWWKAgent/BashTool.swift
@@ -28,6 +28,15 @@ public struct BashToolOptions: Sendable {
     public var defaultTimeoutSeconds: Int
     /// Maximum allowed user-supplied `timeout` (seconds).
     public var maxTimeoutSeconds: Int
+    /// Hard ceiling on how long one `bash` call may keep the model waiting
+    /// (seconds). When set it caps both `defaultTimeoutSeconds` and any
+    /// model-supplied `timeout` — a `timeout` above it is silently lowered,
+    /// not rejected. With a `BackgroundTaskManager` attached the command
+    /// flips to the background at this deadline even though the model asked
+    /// for a foreground run; without one it fails as an ordinary timeout.
+    /// `nil` leaves the model's `timeout` (bounded by `maxTimeoutSeconds`) in
+    /// charge.
+    public var maxTaskTimeoutSeconds: Int?
     /// Opt-in background support. When set, the tool exposes
     /// `run_in_background` + auto-backgrounds foreground runs that exceed
     /// `timeout`.
@@ -56,7 +65,8 @@ public struct BashToolOptions: Sendable {
         autoBackgroundOnTimeout: Bool = true,
         hardTimeoutSeconds: Int = 1800,
         shellPath: String = kwwkDefaultShellPath,
-        commandPolicy: BashCommandPolicy = .unrestricted
+        commandPolicy: BashCommandPolicy = .unrestricted,
+        maxTaskTimeoutSeconds: Int? = nil
     ) {
         self.operations = operations ?? LocalBashOperations(
             shellPath: shellPath,
@@ -71,6 +81,23 @@ public struct BashToolOptions: Sendable {
         self.shellPath = shellPath
         self.environment = environment
         self.commandPolicy = commandPolicy
+        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
+    }
+
+    /// `maxTimeoutSeconds` after `maxTaskTimeoutSeconds` is applied: the
+    /// largest soft timeout any single call can end up with.
+    public var effectiveMaxTimeoutSeconds: Int {
+        clampToMaxTaskTimeout(max(1, maxTimeoutSeconds))
+    }
+
+    /// `defaultTimeoutSeconds` after both caps are applied.
+    public var effectiveDefaultTimeoutSeconds: Int {
+        min(max(1, defaultTimeoutSeconds), effectiveMaxTimeoutSeconds)
+    }
+
+    private func clampToMaxTaskTimeout(_ seconds: Int) -> Int {
+        guard let cap = maxTaskTimeoutSeconds else { return seconds }
+        return min(seconds, max(1, cap))
     }
 }
 
@@ -218,8 +245,9 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
         return options.operations
     }()
 
-    let defaultTimeoutSec = options.defaultTimeoutSeconds
-    let maxTimeoutSec = options.maxTimeoutSeconds
+    let defaultTimeoutSec = options.effectiveDefaultTimeoutSeconds
+    let maxTimeoutSec = options.effectiveMaxTimeoutSeconds
+    let taskTimeoutCapped = options.maxTaskTimeoutSeconds != nil
     let manager = options.manager
     let sessionId = options.sessionId
     let autoBg = options.autoBackgroundOnTimeout
@@ -231,11 +259,16 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
     var tool = AgentTool(
         name: "bash",
         label: "bash",
-        description: bashToolDescription(hasManager: hasManager, cwd: cwd),
+        description: bashToolDescription(
+            hasManager: hasManager,
+            cwd: cwd,
+            taskTimeoutCapSeconds: taskTimeoutCapped ? maxTimeoutSec : nil
+        ),
         parameters: bashToolParameters(
             hasManager: hasManager,
             defaultTimeoutSec: defaultTimeoutSec,
-            maxTimeoutSec: maxTimeoutSec
+            maxTimeoutSec: maxTimeoutSec,
+            taskTimeoutCapped: taskTimeoutCapped
         ),
         execute: { _, args, cancellation, _ in
             try cancellation?.throwIfCancelled()
@@ -286,9 +319,16 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
 
 // MARK: - Schema
 
-private func bashToolDescription(hasManager: Bool, cwd: String) -> String {
+private func bashToolDescription(
+    hasManager: Bool,
+    cwd: String,
+    taskTimeoutCapSeconds: Int?
+) -> String {
     let outputGuidance = "Inline output is already bounded. Do not append `head` or `tail` merely to truncate output; use them only when they are part of the command's actual intent."
     if hasManager {
+        let capNote = taskTimeoutCapSeconds.map {
+            " No foreground command waits longer than \($0)s here, whatever `timeout` says; anything slower is moved to the background at that point, so start commands you expect to outlast it with run_in_background=true."
+        } ?? ""
         return """
         Execute a shell command. Runs in \(cwd) by default. Stdout and stderr are returned on completion.
 
@@ -296,22 +336,29 @@ private func bashToolDescription(hasManager: Bool, cwd: String) -> String {
 
         Long-running commands (installs, builds, test suites) should be started with run_in_background=true so the agent isn't blocked. The tool returns a task ID immediately; you will receive an internal runtime completion notification when the task finishes. Use task_list({}) for bounded live status and task_read({"task_id":"...","offset":0,"limit":8192}) for manager-authorized stdout/stderr inspection — do NOT poll or sleep merely to retrieve output.
 
-        Foreground commands that exceed the `timeout` are automatically moved to the background (the process keeps running — no work is lost) and you are notified on completion.
+        Foreground commands that exceed the `timeout` are automatically moved to the background (the process keeps running — no work is lost) and you are notified on completion.\(capNote)
         """
     }
-    return "Execute a shell command and return its output. \(outputGuidance)"
+    let capNote = taskTimeoutCapSeconds.map {
+        " Commands are limited to \($0)s of runtime here, whatever `timeout` says; slower ones fail with a timeout, so keep each invocation short."
+    } ?? ""
+    return "Execute a shell command and return its output. \(outputGuidance)\(capNote)"
 }
 
 private func bashToolParameters(
     hasManager: Bool,
     defaultTimeoutSec: Int,
-    maxTimeoutSec: Int
+    maxTimeoutSec: Int,
+    taskTimeoutCapped: Bool
 ) -> JSONValue {
+    let capNote = taskTimeoutCapped
+        ? " This runtime caps every foreground wait at \(maxTimeoutSec)s: a larger value is lowered to \(maxTimeoutSec), it is not rejected."
+        : ""
     var props: [String: JSONValue] = [
         "command": ["type": "string"],
         "timeout": .object([
             "type": .string("number"),
-            "description": .string("Seconds before the foreground soft timeout. When a background manager is attached, the command auto-moves to background at this point. Default \(defaultTimeoutSec), max \(maxTimeoutSec)."),
+            "description": .string("Seconds before the foreground soft timeout. When a background manager is attached, the command auto-moves to background at this point. Default \(defaultTimeoutSec), max \(maxTimeoutSec).\(capNote)"),
             "minimum": .int(1),
             "maximum": .int(maxTimeoutSec),
         ]),
@@ -927,9 +974,10 @@ private final class OneShotContinuation<Value: Sendable>: @unchecked Sendable {
 
 extension BackgroundTaskManager {
     /// Allocate an output file inside the manager's output dir without
-    /// registering a task. Used by the foreground-with-flip path so the
-    /// adopted file lives under the same directory as spawned ones.
-    fileprivate func allocateForegroundOutputFile() -> URL {
+    /// registering a task. Used by the foreground-with-flip paths (bash and
+    /// agent) so the adopted file lives under the same directory as spawned
+    /// ones.
+    func allocateForegroundOutputFile() -> URL {
         try? FileManager.default.createDirectory(
             at: outputDir,
             withIntermediateDirectories: true,

--- a/Sources/KWWKAgent/BashTool.swift
+++ b/Sources/KWWKAgent/BashTool.swift
@@ -26,17 +26,15 @@ public struct BashToolOptions: Sendable {
     /// and `autoBackgroundOnTimeout` is true, the command flips to
     /// background on this deadline instead of erroring.
     public var defaultTimeoutSeconds: Int
-    /// Maximum allowed user-supplied `timeout` (seconds).
+    /// Maximum allowed user-supplied `timeout` (seconds). A larger `timeout`
+    /// is silently lowered, not rejected, so this is also the longest any one
+    /// call can keep the model waiting: with a `BackgroundTaskManager`
+    /// attached the command flips to the background at that point even
+    /// though the model asked for a foreground run; without one it fails as
+    /// an ordinary timeout. Hosts with a runtime-wide wait cap
+    /// (`CodingAgentConfig.maxTaskTimeoutSeconds`) fold it into this and
+    /// `defaultTimeoutSeconds`.
     public var maxTimeoutSeconds: Int
-    /// Hard ceiling on how long one `bash` call may keep the model waiting
-    /// (seconds). When set it caps both `defaultTimeoutSeconds` and any
-    /// model-supplied `timeout` — a `timeout` above it is silently lowered,
-    /// not rejected. With a `BackgroundTaskManager` attached the command
-    /// flips to the background at this deadline even though the model asked
-    /// for a foreground run; without one it fails as an ordinary timeout.
-    /// `nil` leaves the model's `timeout` (bounded by `maxTimeoutSeconds`) in
-    /// charge.
-    public var maxTaskTimeoutSeconds: Int?
     /// Opt-in background support. When set, the tool exposes
     /// `run_in_background` + auto-backgrounds foreground runs that exceed
     /// `timeout`.
@@ -65,8 +63,7 @@ public struct BashToolOptions: Sendable {
         autoBackgroundOnTimeout: Bool = true,
         hardTimeoutSeconds: Int = 1800,
         shellPath: String = kwwkDefaultShellPath,
-        commandPolicy: BashCommandPolicy = .unrestricted,
-        maxTaskTimeoutSeconds: Int? = nil
+        commandPolicy: BashCommandPolicy = .unrestricted
     ) {
         self.operations = operations ?? LocalBashOperations(
             shellPath: shellPath,
@@ -81,23 +78,6 @@ public struct BashToolOptions: Sendable {
         self.shellPath = shellPath
         self.environment = environment
         self.commandPolicy = commandPolicy
-        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
-    }
-
-    /// `maxTimeoutSeconds` after `maxTaskTimeoutSeconds` is applied: the
-    /// largest soft timeout any single call can end up with.
-    public var effectiveMaxTimeoutSeconds: Int {
-        clampToMaxTaskTimeout(max(1, maxTimeoutSeconds))
-    }
-
-    /// `defaultTimeoutSeconds` after both caps are applied.
-    public var effectiveDefaultTimeoutSeconds: Int {
-        min(max(1, defaultTimeoutSeconds), effectiveMaxTimeoutSeconds)
-    }
-
-    private func clampToMaxTaskTimeout(_ seconds: Int) -> Int {
-        guard let cap = maxTaskTimeoutSeconds else { return seconds }
-        return min(seconds, max(1, cap))
     }
 }
 
@@ -245,9 +225,8 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
         return options.operations
     }()
 
-    let defaultTimeoutSec = options.effectiveDefaultTimeoutSeconds
-    let maxTimeoutSec = options.effectiveMaxTimeoutSeconds
-    let taskTimeoutCapped = options.maxTaskTimeoutSeconds != nil
+    let maxTimeoutSec = max(1, options.maxTimeoutSeconds)
+    let defaultTimeoutSec = min(max(1, options.defaultTimeoutSeconds), maxTimeoutSec)
     let manager = options.manager
     let sessionId = options.sessionId
     let autoBg = options.autoBackgroundOnTimeout
@@ -262,13 +241,12 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
         description: bashToolDescription(
             hasManager: hasManager,
             cwd: cwd,
-            taskTimeoutCapSeconds: taskTimeoutCapped ? maxTimeoutSec : nil
+            maxTimeoutSec: maxTimeoutSec
         ),
         parameters: bashToolParameters(
             hasManager: hasManager,
             defaultTimeoutSec: defaultTimeoutSec,
-            maxTimeoutSec: maxTimeoutSec,
-            taskTimeoutCapped: taskTimeoutCapped
+            maxTimeoutSec: maxTimeoutSec
         ),
         execute: { _, args, cancellation, _ in
             try cancellation?.throwIfCancelled()
@@ -322,13 +300,11 @@ public func createBashTool(cwd: String, options: BashToolOptions) -> AgentTool {
 private func bashToolDescription(
     hasManager: Bool,
     cwd: String,
-    taskTimeoutCapSeconds: Int?
+    maxTimeoutSec: Int
 ) -> String {
     let outputGuidance = "Inline output is already bounded. Do not append `head` or `tail` merely to truncate output; use them only when they are part of the command's actual intent."
     if hasManager {
-        let capNote = taskTimeoutCapSeconds.map {
-            " No foreground command waits longer than \($0)s here, whatever `timeout` says; anything slower is moved to the background at that point, so start commands you expect to outlast it with run_in_background=true."
-        } ?? ""
+        let capNote = " No foreground command waits longer than \(maxTimeoutSec)s, whatever `timeout` says; anything slower is moved to the background at that point, so start commands you expect to outlast it with run_in_background=true."
         return """
         Execute a shell command. Runs in \(cwd) by default. Stdout and stderr are returned on completion.
 
@@ -339,26 +315,19 @@ private func bashToolDescription(
         Foreground commands that exceed the `timeout` are automatically moved to the background (the process keeps running — no work is lost) and you are notified on completion.\(capNote)
         """
     }
-    let capNote = taskTimeoutCapSeconds.map {
-        " Commands are limited to \($0)s of runtime here, whatever `timeout` says; slower ones fail with a timeout, so keep each invocation short."
-    } ?? ""
-    return "Execute a shell command and return its output. \(outputGuidance)\(capNote)"
+    return "Execute a shell command and return its output. Commands are limited to \(maxTimeoutSec)s of runtime, whatever `timeout` says; slower ones fail with a timeout. \(outputGuidance)"
 }
 
 private func bashToolParameters(
     hasManager: Bool,
     defaultTimeoutSec: Int,
-    maxTimeoutSec: Int,
-    taskTimeoutCapped: Bool
+    maxTimeoutSec: Int
 ) -> JSONValue {
-    let capNote = taskTimeoutCapped
-        ? " This runtime caps every foreground wait at \(maxTimeoutSec)s: a larger value is lowered to \(maxTimeoutSec), it is not rejected."
-        : ""
     var props: [String: JSONValue] = [
         "command": ["type": "string"],
         "timeout": .object([
             "type": .string("number"),
-            "description": .string("Seconds before the foreground soft timeout. When a background manager is attached, the command auto-moves to background at this point. Default \(defaultTimeoutSec), max \(maxTimeoutSec).\(capNote)"),
+            "description": .string("Seconds before the foreground soft timeout. When a background manager is attached, the command auto-moves to background at this point. Default \(defaultTimeoutSec), max \(maxTimeoutSec) (a larger value is lowered to \(maxTimeoutSec), not rejected)."),
             "minimum": .int(1),
             "maximum": .int(maxTimeoutSec),
         ]),

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -327,16 +327,19 @@ internal func buildCodingToolList(
         tools.append(createEditTool(cwd: cwd, fileAccessPolicy: fileAccessPolicy))
     }
     if selected.contains(.bash) {
+        // The runtime wait cap folds into bash's soft-timeout bounds: no call
+        // may wait longer than the cap, whatever `timeout` the model asks for.
+        let cappedMax = maxTaskTimeoutSeconds.map { min(bashMaxTimeoutSeconds, max(1, $0)) }
+            ?? bashMaxTimeoutSeconds
         tools.append(createBashTool(cwd: cwd, options: BashToolOptions(
             environment: bashEnvironment,
-            defaultTimeoutSeconds: bashDefaultTimeoutSeconds,
-            maxTimeoutSeconds: bashMaxTimeoutSeconds,
+            defaultTimeoutSeconds: min(bashDefaultTimeoutSeconds, cappedMax),
+            maxTimeoutSeconds: cappedMax,
             manager: backgroundManager,
             sessionId: sessionId,
             autoBackgroundOnTimeout: true,
             shellPath: bashShellPath,
-            commandPolicy: bashCommandPolicy,
-            maxTaskTimeoutSeconds: maxTaskTimeoutSeconds
+            commandPolicy: bashCommandPolicy
         )))
     }
     if selected.contains(.grep) {

--- a/Sources/KWWKAgent/CodingAgentBuilder.swift
+++ b/Sources/KWWKAgent/CodingAgentBuilder.swift
@@ -82,6 +82,12 @@ public struct CodingAgentConfig: Sendable {
     /// the background on this deadline when a `backgroundManager` is attached.
     public var bashDefaultTimeoutSeconds: Int
     public var bashMaxTimeoutSeconds: Int
+    /// Hard ceiling on how long any single `bash` or `agent` call may keep the
+    /// model waiting (seconds). It overrides the model's own `timeout` and its
+    /// choice of `run_in_background: false`: work still running at the
+    /// deadline is moved to the background when a `backgroundManager` is
+    /// attached (and fails as a timeout otherwise). `nil` disables the cap.
+    public var maxTaskTimeoutSeconds: Int?
     /// Exact environment passed to bash tool processes. Empty by default so
     /// SDK callers do not expose host process environment variables.
     public var bashEnvironment: [String: String]
@@ -109,6 +115,7 @@ public struct CodingAgentConfig: Sendable {
         bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600,
+        maxTaskTimeoutSeconds: Int? = nil,
         bashShellPath: String = kwwkDefaultShellPath
     ) {
         self.model = model
@@ -130,6 +137,7 @@ public struct CodingAgentConfig: Sendable {
         self.compactionModel = compactionModel
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
         self.bashEnvironment = bashEnvironment
         self.bashShellPath = bashShellPath
     }
@@ -215,6 +223,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> CodingAgent {
         fileAccessPolicy: config.fileAccessPolicy,
         bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
         bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds,
+        maxTaskTimeoutSeconds: config.maxTaskTimeoutSeconds,
         bashEnvironment: config.bashEnvironment,
         bashShellPath: config.bashShellPath
     )
@@ -249,6 +258,7 @@ public func makeCodingAgent(_ config: CodingAgentConfig) async -> CodingAgent {
             bashEnvironment: config.bashEnvironment,
             bashDefaultTimeoutSeconds: config.bashDefaultTimeoutSeconds,
             bashMaxTimeoutSeconds: config.bashMaxTimeoutSeconds,
+            maxTaskTimeoutSeconds: config.maxTaskTimeoutSeconds,
             bashShellPath: config.bashShellPath
         ))
         if bgManager != nil {
@@ -301,6 +311,7 @@ internal func buildCodingToolList(
     fileAccessPolicy: FileAccessPolicy = .unrestricted,
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
+    maxTaskTimeoutSeconds: Int? = nil,
     bashEnvironment: [String: String],
     bashShellPath: String = kwwkDefaultShellPath,
     bashCommandPolicy: BashCommandPolicy = .unrestricted
@@ -324,7 +335,8 @@ internal func buildCodingToolList(
             sessionId: sessionId,
             autoBackgroundOnTimeout: true,
             shellPath: bashShellPath,
-            commandPolicy: bashCommandPolicy
+            commandPolicy: bashCommandPolicy,
+            maxTaskTimeoutSeconds: maxTaskTimeoutSeconds
         )))
     }
     if selected.contains(.grep) {

--- a/Sources/KWWKAgent/SubagentDefinition.swift
+++ b/Sources/KWWKAgent/SubagentDefinition.swift
@@ -65,20 +65,48 @@ public struct SubagentLimits: Sendable, Equatable {
     public var maxConcurrentMutating: Int
     public var maxTotal: Int
     public var maxTurns: Int?
+    /// Optional hard ceiling on a child's own runtime, foreground or
+    /// background: a child still running at this point is cancelled and
+    /// fails with `failure_kind=timeout`. `nil` (the default) leaves a child
+    /// unbounded except for the background manager's last-resort watchdog —
+    /// how long a caller *waits* for it is `foregroundTimeoutSeconds`, not
+    /// this.
     public var timeoutSeconds: Int?
+    /// Default foreground wait for one `agent` call (seconds) — the model's
+    /// `timeout` when it passes none. Mirrors bash's soft timeout: with a
+    /// background manager the child moves to the background at this point;
+    /// without one it is cancelled as a timeout.
+    public var foregroundTimeoutSeconds: Int
+    /// Upper bound on the model's `timeout`; a larger value is lowered, not
+    /// rejected. This is the longest any one `agent` call can keep the
+    /// caller waiting.
+    public var maxForegroundTimeoutSeconds: Int
 
     public init(
         maxConcurrent: Int = 4,
         maxConcurrentMutating: Int = 1,
         maxTotal: Int = 64,
         maxTurns: Int? = 16,
-        timeoutSeconds: Int? = 600
+        timeoutSeconds: Int? = nil,
+        foregroundTimeoutSeconds: Int = 120,
+        maxForegroundTimeoutSeconds: Int = 600
     ) {
         self.maxConcurrent = max(1, maxConcurrent)
         self.maxConcurrentMutating = max(1, min(maxConcurrentMutating, self.maxConcurrent))
         self.maxTotal = max(1, maxTotal)
         self.maxTurns = maxTurns.map { max(1, $0) }
         self.timeoutSeconds = timeoutSeconds.map { max(1, $0) }
+        self.maxForegroundTimeoutSeconds = max(1, maxForegroundTimeoutSeconds)
+        self.foregroundTimeoutSeconds = min(max(1, foregroundTimeoutSeconds), self.maxForegroundTimeoutSeconds)
+    }
+
+    /// The same limits with every foreground wait bounded by `cap`.
+    func cappingForegroundWait(at cap: Int?) -> SubagentLimits {
+        guard let cap else { return self }
+        var copy = self
+        copy.maxForegroundTimeoutSeconds = min(maxForegroundTimeoutSeconds, max(1, cap))
+        copy.foregroundTimeoutSeconds = min(foregroundTimeoutSeconds, copy.maxForegroundTimeoutSeconds)
+        return copy
     }
 }
 

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -351,7 +351,14 @@ internal func _createAgentTool(
     bashShellPath: String = kwwkDefaultShellPath
 ) -> AgentTool {
     let registry = SubagentRegistry(subagents)
+    // The runtime wait cap folds into the foreground-wait bounds, exactly as
+    // it folds into bash's soft timeout: no call waits longer than the cap,
+    // whatever `timeout` the model asks for.
+    let limits = limits.cappingForegroundWait(at: maxTaskTimeoutSeconds)
     let limiter = SubagentLimiter(limits: limits)
+    let waitNote = backgroundManager != nil
+        ? "At that point the subagent moves to the background (it keeps running; you are notified on completion and get a task id)."
+        : "At that point the subagent is cancelled and the call fails with a timeout."
     let parameters: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -372,6 +379,12 @@ internal func _createAgentTool(
                 "type": .string("string"),
                 "description": .string("Optional model id override. Omit to use the subagent definition's model or inherit the parent model."),
             ]),
+            "timeout": .object([
+                "type": .string("number"),
+                "description": .string("Seconds to wait for the subagent in the foreground before this call returns. \(waitNote) Default \(limits.foregroundTimeoutSeconds), max \(limits.maxForegroundTimeoutSeconds) (a larger value is lowered to \(limits.maxForegroundTimeoutSeconds), not rejected)."),
+                "minimum": .int(1),
+                "maximum": .int(limits.maxForegroundTimeoutSeconds),
+            ]),
             "run_in_background": .object([
                 "type": .string("boolean"),
                 "description": .string("Run this independent subagent in the background. You will be notified when it completes."),
@@ -391,13 +404,13 @@ internal func _createAgentTool(
         description: buildAgentToolDescription(
             registry: registry,
             backgroundTasksAvailable: backgroundManager != nil,
-            foregroundWaitCapSeconds: maxTaskTimeoutSeconds
+            maxForegroundTimeoutSeconds: limits.maxForegroundTimeoutSeconds
         ),
         parameters: parameters,
         execute: { toolCallId, args, cancellation, onUpdate in
             try cancellation?.throwIfCancelled()
             try registry.validate()
-            let input = try parseAgentToolInput(args)
+            let input = try parseAgentToolInput(args, limits: limits)
             let requestedType = input.subagentType
             guard let definition = registry.definition(named: requestedType) else {
                 throw CodingToolError.invalidArgument(
@@ -519,32 +532,30 @@ internal func _createAgentTool(
                 ],
                 uiDisplay: ["agent \(definition.name) starting · 0 tokens"]
             ))
-            if let waitSeconds = maxTaskTimeoutSeconds {
-                if let backgroundManager {
-                    // The runtime caps foreground waits: run the child in the
-                    // foreground for `waitSeconds`, then hand a still-running
-                    // child to the background manager instead of blocking.
-                    return try await runSubagentForegroundWithFlip(
-                        runner: runner,
-                        definition: definition,
-                        input: input,
-                        childSessionId: childSessionId,
-                        toolCallId: toolCallId,
-                        waitSeconds: waitSeconds,
-                        manager: backgroundManager,
-                        sessionId: sessionId,
-                        historyStore: historyStore,
-                        cancellation: cancellation,
-                        onUpdate: onUpdate
-                    )
-                }
-                // No manager to hand the child to: the cap becomes the child's
-                // deadline, and overrunning it fails as an ordinary timeout.
-                runner.limits.timeoutSeconds = min(
-                    runner.limits.timeoutSeconds ?? waitSeconds,
-                    waitSeconds
+            if let backgroundManager {
+                // Same contract as bash: wait `timeout` in the foreground, then
+                // hand a still-running child to the background manager
+                // instead of blocking or killing it.
+                return try await runSubagentForegroundWithFlip(
+                    runner: runner,
+                    definition: definition,
+                    input: input,
+                    childSessionId: childSessionId,
+                    toolCallId: toolCallId,
+                    waitSeconds: input.timeoutSeconds,
+                    manager: backgroundManager,
+                    sessionId: sessionId,
+                    historyStore: historyStore,
+                    cancellation: cancellation,
+                    onUpdate: onUpdate
                 )
             }
+            // No manager to hand the child to: the wait becomes the child's
+            // deadline, and overrunning it fails as an ordinary timeout.
+            runner.limits.timeoutSeconds = min(
+                runner.limits.timeoutSeconds ?? input.timeoutSeconds,
+                input.timeoutSeconds
+            )
             let result: SubagentResult
             do {
                 result = try await runner.run(
@@ -618,13 +629,14 @@ private func completedSubagentToolResult(
     )
 }
 
-// MARK: - Foreground with auto-flip-to-background at the runtime wait cap
+// MARK: - Foreground with auto-flip-to-background at the foreground timeout
 
-/// Run the child in the foreground for at most `waitSeconds`. A child that is
-/// still running at the deadline is adopted by the background manager — it
-/// keeps running with its transcript intact, its progress keeps landing in
-/// the same output file, and the manager fires the completion notification —
-/// while the tool returns an `auto_backgrounded` result right away.
+/// Run the child in the foreground for at most `waitSeconds` (the call's
+/// `timeout`). A child that is still running at the deadline is adopted by
+/// the background manager — it keeps running with its transcript intact, its
+/// progress keeps landing in the same output file, and the manager fires the
+/// completion notification — while the tool returns an `auto_backgrounded`
+/// result right away. The bash foreground path does the same for processes.
 private func runSubagentForegroundWithFlip(
     runner: SubagentInvocationRunner,
     definition: SubagentDefinition,
@@ -737,10 +749,10 @@ private func runSubagentForegroundWithFlip(
     )
     historyStore.attachTask(taskId, childSessionId: childSessionId)
     let body = """
-    Subagent \(definition.name) exceeded the foreground wait cap of \(waitSeconds)s and has been moved to the background with task id \(taskId). It is still running — no work was lost — and you will receive an internal runtime completion notification when it finishes.
+    Subagent \(definition.name) exceeded the foreground timeout of \(waitSeconds)s and has been moved to the background with task id \(taskId). It is still running — no work was lost — and you will receive an internal runtime completion notification when it finishes.
     task_id: \(taskId)
     output_file: \(adoptedFile.path)
-    While parent work remains, inspect live progress with agent_history({"task_id":"\(taskId)"}). Use task_list({}) for bounded status; call task_poll only when otherwise blocked. For subagents you expect to outlast the cap, set run_in_background=true from the start.
+    While parent work remains, inspect live progress with agent_history({"task_id":"\(taskId)"}). Use task_list({}) for bounded status; call task_poll only when otherwise blocked. For subagents you expect to take long, set run_in_background=true from the start.
     """
     let display = "agent \(definition.name) auto-backgrounded · \(taskId) · \(adoptedFile.path)"
     return AgentToolResult(
@@ -753,7 +765,7 @@ private func runSubagentForegroundWithFlip(
             "subagent_type": .string(definition.name),
             "child_session_id": .string(childSessionId),
             "description": .string(input.description),
-            "wait_cap_seconds": .int(waitSeconds),
+            "softTimeoutSeconds": .int(waitSeconds),
         ]),
         runtimeEvents: [
             .subagent(SubagentLifecycleEvent(
@@ -764,7 +776,7 @@ private func runSubagentForegroundWithFlip(
                 description: input.description,
                 backgroundTaskId: taskId,
                 outputFile: adoptedFile.path,
-                message: "moved to background after \(waitSeconds)s wait cap"
+                message: "moved to background after \(waitSeconds)s foreground timeout"
             )),
         ],
         uiDisplay: [display]
@@ -844,14 +856,19 @@ private struct AgentToolInput {
     var subagentType: String
     var modelOverride: String?
     var runInBackground: Bool?
+    /// Foreground wait, already clamped to `[1, maxForegroundTimeoutSeconds]`.
+    var timeoutSeconds: Int
 }
 
-private func parseAgentToolInput(_ args: JSONValue) throws -> AgentToolInput {
+private func parseAgentToolInput(
+    _ args: JSONValue,
+    limits: SubagentLimits
+) throws -> AgentToolInput {
     guard case .object(let obj) = args else {
         throw CodingToolError.invalidArgument("agent: expected object input")
     }
     let allowedKeys: Set<String> = [
-        "description", "prompt", "subagent_type", "model", "run_in_background",
+        "description", "prompt", "subagent_type", "model", "run_in_background", "timeout",
     ]
     if let unknown = obj.keys.filter({ !allowedKeys.contains($0) }).sorted().first {
         throw CodingToolError.invalidArgument("agent: unknown argument `\(unknown)`")
@@ -891,12 +908,24 @@ private func parseAgentToolInput(_ args: JSONValue) throws -> AgentToolInput {
     } else {
         runInBackground = nil
     }
+    let timeoutSeconds: Int
+    switch obj["timeout"] ?? .null {
+    case .null:
+        timeoutSeconds = limits.foregroundTimeoutSeconds
+    case .int(let raw):
+        timeoutSeconds = min(max(raw, 1), limits.maxForegroundTimeoutSeconds)
+    case .double(let raw):
+        timeoutSeconds = min(max(Int(raw), 1), limits.maxForegroundTimeoutSeconds)
+    default:
+        throw CodingToolError.invalidArgument("agent: `timeout` must be a number when provided")
+    }
     return AgentToolInput(
         description: description,
         prompt: prompt,
         subagentType: subagentType,
         modelOverride: modelOverride,
-        runInBackground: runInBackground
+        runInBackground: runInBackground,
+        timeoutSeconds: timeoutSeconds
     )
 }
 
@@ -904,17 +933,15 @@ private enum SubagentPromptBuilder {
     static func agentToolDescription(
         registry: SubagentRegistry,
         backgroundTasksAvailable: Bool,
-        foregroundWaitCapSeconds: Int? = nil
+        maxForegroundTimeoutSeconds: Int
     ) -> String {
         let agents = registry.names.map { name -> String in
             guard let definition = registry.definition(named: name) else { return "- \(name)" }
             return "- \(name): \(definition.description) (Tools: \(subagentToolsDescription(definition.tools, backgroundTasksAvailable: backgroundTasksAvailable)))"
         }.joined(separator: "\n")
-        let waitCapNote = foregroundWaitCapSeconds.map { seconds in
-            backgroundTasksAvailable
-                ? "\n- This runtime never blocks on a subagent for more than \(seconds)s: a foreground subagent still running at that point is moved to the background automatically (its work continues; you get the completion notification and a task id), even if you passed `run_in_background: false`. Expect anything non-trivial to arrive as a background result."
-                : "\n- This runtime never blocks on a subagent for more than \(seconds)s: a subagent still running at that point fails with a timeout, so keep delegated tasks small."
-        } ?? ""
+        let waitCapNote = backgroundTasksAvailable
+            ? "\n- `timeout` is how long this call waits, not how long the subagent may run: a foreground subagent still running when `timeout` elapses is moved to the background automatically (its work continues; you get the completion notification and a task id), even if you passed `run_in_background: false`. No call waits longer than \(maxForegroundTimeoutSeconds)s, whatever `timeout` says, so expect anything slower to arrive as a background result."
+            : "\n- `timeout` bounds how long a subagent may run here (at most \(maxForegroundTimeoutSeconds)s, whatever you pass): one still running at that point fails with a timeout, so keep delegated tasks small."
         let backgroundNotes = backgroundTasksAvailable ? """
         - Background tasks started by the subagent's own tools are scoped to the subagent and are killed when that subagent ends.
         - Omit `run_in_background` to use the selected subagent's configured default.
@@ -979,12 +1006,12 @@ private enum SubagentPromptBuilder {
 private func buildAgentToolDescription(
     registry: SubagentRegistry,
     backgroundTasksAvailable: Bool,
-    foregroundWaitCapSeconds: Int?
+    maxForegroundTimeoutSeconds: Int
 ) -> String {
     SubagentPromptBuilder.agentToolDescription(
         registry: registry,
         backgroundTasksAvailable: backgroundTasksAvailable,
-        foregroundWaitCapSeconds: foregroundWaitCapSeconds
+        maxForegroundTimeoutSeconds: maxForegroundTimeoutSeconds
     )
 }
 
@@ -2588,7 +2615,7 @@ private func subagentToolArgumentSummary(toolName: String, args: JSONValue) -> S
     case "agent":
         // The child prompt can contain arbitrary repository text; description
         // and type convey intent without copying that prompt into the tail.
-        keys = ["description", "subagent_type", "run_in_background"]
+        keys = ["description", "subagent_type", "timeout", "run_in_background"]
     default:
         let keyList = object.keys.sorted().prefix(6).joined(separator: ",")
         return keyList.isEmpty

--- a/Sources/KWWKAgent/SubagentTool.swift
+++ b/Sources/KWWKAgent/SubagentTool.swift
@@ -29,6 +29,7 @@ public func createAgentTool(
     bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
+    maxTaskTimeoutSeconds: Int? = nil,
     bashShellPath: String = kwwkDefaultShellPath
 ) -> AgentTool {
     let effectiveSessionId = sessionId ?? "subagent-parent:\(UUID().uuidString)"
@@ -60,6 +61,7 @@ public func createAgentTool(
         bashEnvironment: bashEnvironment,
         bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
         bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+        maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
         bashShellPath: bashShellPath
     )
 }
@@ -81,6 +83,7 @@ public func createAgentTool(
     bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
+    maxTaskTimeoutSeconds: Int? = nil,
     bashShellPath: String = kwwkDefaultShellPath
 ) -> AgentTool {
     let effectiveSessionId = sessionId ?? parentAgent.sessionId
@@ -114,6 +117,7 @@ public func createAgentTool(
         bashEnvironment: bashEnvironment,
         bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
         bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+        maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
         bashShellPath: bashShellPath
     )
 }
@@ -343,6 +347,7 @@ internal func _createAgentTool(
     bashEnvironment: [String: String],
     bashDefaultTimeoutSeconds: Int = 120,
     bashMaxTimeoutSeconds: Int = 600,
+    maxTaskTimeoutSeconds: Int? = nil,
     bashShellPath: String = kwwkDefaultShellPath
 ) -> AgentTool {
     let registry = SubagentRegistry(subagents)
@@ -385,7 +390,8 @@ internal func _createAgentTool(
         label: "agent",
         description: buildAgentToolDescription(
             registry: registry,
-            backgroundTasksAvailable: backgroundManager != nil
+            backgroundTasksAvailable: backgroundManager != nil,
+            foregroundWaitCapSeconds: maxTaskTimeoutSeconds
         ),
         parameters: parameters,
         execute: { toolCallId, args, cancellation, onUpdate in
@@ -414,6 +420,7 @@ internal func _createAgentTool(
                 childSessionId: childSessionId,
                 bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
                 bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+                maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
                 bashEnvironment: bashEnvironment,
                 bashShellPath: bashShellPath
             )
@@ -512,6 +519,32 @@ internal func _createAgentTool(
                 ],
                 uiDisplay: ["agent \(definition.name) starting · 0 tokens"]
             ))
+            if let waitSeconds = maxTaskTimeoutSeconds {
+                if let backgroundManager {
+                    // The runtime caps foreground waits: run the child in the
+                    // foreground for `waitSeconds`, then hand a still-running
+                    // child to the background manager instead of blocking.
+                    return try await runSubagentForegroundWithFlip(
+                        runner: runner,
+                        definition: definition,
+                        input: input,
+                        childSessionId: childSessionId,
+                        toolCallId: toolCallId,
+                        waitSeconds: waitSeconds,
+                        manager: backgroundManager,
+                        sessionId: sessionId,
+                        historyStore: historyStore,
+                        cancellation: cancellation,
+                        onUpdate: onUpdate
+                    )
+                }
+                // No manager to hand the child to: the cap becomes the child's
+                // deadline, and overrunning it fails as an ordinary timeout.
+                runner.limits.timeoutSeconds = min(
+                    runner.limits.timeoutSeconds ?? waitSeconds,
+                    waitSeconds
+                )
+            }
             let result: SubagentResult
             do {
                 result = try await runner.run(
@@ -528,44 +561,213 @@ internal func _createAgentTool(
                     toolCallId: toolCallId
                 )
             }
-            let body = modelFacingSubagentSuccess(
-                subagentType: definition.name,
-                result: result.text
-            )
-            return AgentToolResult(
-                content: [.text(TextContent(text: body))],
-                details: .object([
-                    "status": .string("completed"),
-                    "subagent_type": .string(definition.name),
-                    "description": .string(input.description),
-                    "child_session_id": .string(childSessionId),
-                    "model": .string(result.model.id),
-                    "stop_reason": .string(result.stopReason.rawValue),
-                    "usage": usageDetails(result.usage),
-                    "turns": .int(result.turns),
-                    "cost": costDetails(result.cost),
-                    "duration_ms": .int(result.durationMs),
-                    "history_available": .bool(true),
-                ]),
-                runtimeEvents: [
-                    .subagent(SubagentLifecycleEvent(
-                        kind: .completed,
-                        toolCallId: toolCallId,
-                        subagentType: definition.name,
-                        childSessionId: childSessionId,
-                        description: input.description,
-                        model: result.model.id,
-                        stopReason: result.stopReason,
-                        usage: result.usage,
-                        turns: result.turns,
-                        cost: result.cost,
-                        durationMs: result.durationMs,
-                        message: shortSubagentSummary(result.text)
-                    )),
-                ],
-                uiDisplay: ["agent \(definition.name) completed · \(formatUsage(result.usage))"]
+            return completedSubagentToolResult(
+                definition: definition,
+                input: input,
+                childSessionId: childSessionId,
+                toolCallId: toolCallId,
+                result: result
             )
         }
+    )
+}
+
+private func completedSubagentToolResult(
+    definition: SubagentDefinition,
+    input: AgentToolInput,
+    childSessionId: String,
+    toolCallId: String,
+    result: SubagentResult
+) -> AgentToolResult {
+    let body = modelFacingSubagentSuccess(
+        subagentType: definition.name,
+        result: result.text
+    )
+    return AgentToolResult(
+        content: [.text(TextContent(text: body))],
+        details: .object([
+            "status": .string("completed"),
+            "subagent_type": .string(definition.name),
+            "description": .string(input.description),
+            "child_session_id": .string(childSessionId),
+            "model": .string(result.model.id),
+            "stop_reason": .string(result.stopReason.rawValue),
+            "usage": usageDetails(result.usage),
+            "turns": .int(result.turns),
+            "cost": costDetails(result.cost),
+            "duration_ms": .int(result.durationMs),
+            "history_available": .bool(true),
+        ]),
+        runtimeEvents: [
+            .subagent(SubagentLifecycleEvent(
+                kind: .completed,
+                toolCallId: toolCallId,
+                subagentType: definition.name,
+                childSessionId: childSessionId,
+                description: input.description,
+                model: result.model.id,
+                stopReason: result.stopReason,
+                usage: result.usage,
+                turns: result.turns,
+                cost: result.cost,
+                durationMs: result.durationMs,
+                message: shortSubagentSummary(result.text)
+            )),
+        ],
+        uiDisplay: ["agent \(definition.name) completed · \(formatUsage(result.usage))"]
+    )
+}
+
+// MARK: - Foreground with auto-flip-to-background at the runtime wait cap
+
+/// Run the child in the foreground for at most `waitSeconds`. A child that is
+/// still running at the deadline is adopted by the background manager — it
+/// keeps running with its transcript intact, its progress keeps landing in
+/// the same output file, and the manager fires the completion notification —
+/// while the tool returns an `auto_backgrounded` result right away.
+private func runSubagentForegroundWithFlip(
+    runner: SubagentInvocationRunner,
+    definition: SubagentDefinition,
+    input: AgentToolInput,
+    childSessionId: String,
+    toolCallId: String,
+    waitSeconds: Int,
+    manager: BackgroundTaskManager,
+    sessionId: String?,
+    historyStore: SubagentHistoryStore,
+    cancellation: CancellationHandle?,
+    onUpdate: AgentToolUpdate?
+) async throws -> AgentToolResult {
+    let outputFile = await manager.allocateForegroundOutputFile()
+    let progressWriter = BackgroundSubagentProgressWriter(outputFile: outputFile)
+    // Streams child progress to the parent only while the call is still in
+    // the foreground; closed at the flip so a detached child cannot keep
+    // pushing updates into a tool call that already returned.
+    let relay = SubagentUpdateGate(onUpdate)
+    // The child's cancellation is owned by whoever currently waits on it: the
+    // parent tool call before the flip, the background manager after it.
+    let runCancellation = CancellationHandle()
+    let parentRegistration = cancellation?.onCancel { reason in
+        runCancellation.cancel(reason: reason ?? "aborted")
+    }
+    let completion = SubagentRunCompletion()
+    Task.detached {
+        do {
+            let result = try await runner.run(
+                cancellation: runCancellation,
+                onUpdate: { update in
+                    progressWriter.record(update)
+                    relay.emit(update)
+                },
+                toolCallId: toolCallId
+            )
+            completion.resolve(.success(result))
+        } catch {
+            completion.resolve(.failure(error))
+        }
+    }
+
+    if let outcome = await completion.wait(upToSeconds: waitSeconds) {
+        // Settled within the cap: an ordinary foreground result.
+        parentRegistration?.cancel()
+        try? FileManager.default.removeItem(at: outputFile)
+        switch outcome {
+        case .success(let result):
+            return completedSubagentToolResult(
+                definition: definition,
+                input: input,
+                childSessionId: childSessionId,
+                toolCallId: toolCallId,
+                result: result
+            )
+        case .failure(let error):
+            throw structuredSubagentFailure(
+                error: error,
+                definition: definition,
+                input: input,
+                childSessionId: childSessionId,
+                toolCallId: toolCallId
+            )
+        }
+    }
+
+    // Deadline: flip. From here the manager owns the child's lifecycle.
+    relay.close()
+    parentRegistration?.cancel()
+    let (watchdogTimeout, overflow) = runner.timeoutSeconds.addingReportingOverflow(2)
+    let spec = BackgroundTaskSpec(
+        kind: "agent",
+        label: "agent:\(definition.name)",
+        description: input.description,
+        metadata: .object([
+            "subagent_type": .string(definition.name),
+            "child_session_id": .string(childSessionId),
+        ]),
+        hardTimeoutSeconds: overflow ? Int.max : watchdogTimeout
+    )
+    let subagentType = definition.name
+    let (taskId, adoptedFile) = await manager.adopt(
+        spec: spec,
+        outputFile: outputFile,
+        sessionId: sessionId,
+        waitForCompletion: { managerCancellation in
+            let registration = managerCancellation.onCancel { reason in
+                runCancellation.cancel(reason: reason ?? "aborted")
+            }
+            defer { registration.cancel() }
+            switch await completion.wait() {
+            case .success(let result):
+                return subagentBackgroundSuccess(
+                    result: result,
+                    subagentType: subagentType,
+                    childSessionId: childSessionId,
+                    progressWriter: progressWriter
+                )
+            case .failure(let error):
+                return subagentBackgroundFailure(
+                    error: error,
+                    subagentType: subagentType,
+                    childSessionId: childSessionId,
+                    progressWriter: progressWriter,
+                    historyStore: historyStore,
+                    cancelled: managerCancellation.isCancelled
+                )
+            }
+        }
+    )
+    historyStore.attachTask(taskId, childSessionId: childSessionId)
+    let body = """
+    Subagent \(definition.name) exceeded the foreground wait cap of \(waitSeconds)s and has been moved to the background with task id \(taskId). It is still running — no work was lost — and you will receive an internal runtime completion notification when it finishes.
+    task_id: \(taskId)
+    output_file: \(adoptedFile.path)
+    While parent work remains, inspect live progress with agent_history({"task_id":"\(taskId)"}). Use task_list({}) for bounded status; call task_poll only when otherwise blocked. For subagents you expect to outlast the cap, set run_in_background=true from the start.
+    """
+    let display = "agent \(definition.name) auto-backgrounded · \(taskId) · \(adoptedFile.path)"
+    return AgentToolResult(
+        content: [.text(TextContent(text: body))],
+        details: .object([
+            "status": .string("auto_backgrounded"),
+            "runner_state": .string(BackgroundTaskStatus.running.rawValue),
+            "task_id": .string(taskId),
+            "output_file": .string(adoptedFile.path),
+            "subagent_type": .string(definition.name),
+            "child_session_id": .string(childSessionId),
+            "description": .string(input.description),
+            "wait_cap_seconds": .int(waitSeconds),
+        ]),
+        runtimeEvents: [
+            .subagent(SubagentLifecycleEvent(
+                kind: .backgroundStarted,
+                toolCallId: toolCallId,
+                subagentType: definition.name,
+                childSessionId: childSessionId,
+                description: input.description,
+                backgroundTaskId: taskId,
+                outputFile: adoptedFile.path,
+                message: "moved to background after \(waitSeconds)s wait cap"
+            )),
+        ],
+        uiDisplay: [display]
     )
 }
 
@@ -701,21 +903,27 @@ private func parseAgentToolInput(_ args: JSONValue) throws -> AgentToolInput {
 private enum SubagentPromptBuilder {
     static func agentToolDescription(
         registry: SubagentRegistry,
-        backgroundTasksAvailable: Bool
+        backgroundTasksAvailable: Bool,
+        foregroundWaitCapSeconds: Int? = nil
     ) -> String {
         let agents = registry.names.map { name -> String in
             guard let definition = registry.definition(named: name) else { return "- \(name)" }
             return "- \(name): \(definition.description) (Tools: \(subagentToolsDescription(definition.tools, backgroundTasksAvailable: backgroundTasksAvailable)))"
         }.joined(separator: "\n")
+        let waitCapNote = foregroundWaitCapSeconds.map { seconds in
+            backgroundTasksAvailable
+                ? "\n- This runtime never blocks on a subagent for more than \(seconds)s: a foreground subagent still running at that point is moved to the background automatically (its work continues; you get the completion notification and a task id), even if you passed `run_in_background: false`. Expect anything non-trivial to arrive as a background result."
+                : "\n- This runtime never blocks on a subagent for more than \(seconds)s: a subagent still running at that point fails with a timeout, so keep delegated tasks small."
+        } ?? ""
         let backgroundNotes = backgroundTasksAvailable ? """
         - Background tasks started by the subagent's own tools are scoped to the subagent and are killed when that subagent ends.
         - Omit `run_in_background` to use the selected subagent's configured default.
         - Pass `run_in_background: false` when you must block for the result before continuing.
         - Use background mode for independent fan-out. You will be notified when work completes. To inspect live progress, call `agent_history` with `{"task_id":"..."}`. For bounded task status call `task_list` with `{}`; call `task_poll` only when otherwise blocked.
         """ : ""
-        let finalNotes = backgroundNotes.isEmpty
+        let finalNotes = (backgroundNotes.isEmpty
             ? "- Subagents cannot spawn other subagents."
-            : "\(backgroundNotes)\n- Subagents cannot spawn other subagents."
+            : "\(backgroundNotes)\n- Subagents cannot spawn other subagents.") + waitCapNote
 
         return """
         Launch a fresh-context subagent for a specialized task.
@@ -770,11 +978,13 @@ private enum SubagentPromptBuilder {
 
 private func buildAgentToolDescription(
     registry: SubagentRegistry,
-    backgroundTasksAvailable: Bool
+    backgroundTasksAvailable: Bool,
+    foregroundWaitCapSeconds: Int?
 ) -> String {
     SubagentPromptBuilder.agentToolDescription(
         registry: registry,
-        backgroundTasksAvailable: backgroundTasksAvailable
+        backgroundTasksAvailable: backgroundTasksAvailable,
+        foregroundWaitCapSeconds: foregroundWaitCapSeconds
     )
 }
 
@@ -950,6 +1160,7 @@ public struct SubagentRunner: Sendable {
     private var parentSnapshot: @Sendable () -> SubagentParentSnapshot
     private var bashDefaultTimeoutSeconds: Int
     private var bashMaxTimeoutSeconds: Int
+    private var maxTaskTimeoutSeconds: Int?
     private var bashEnvironment: [String: String]
     private var bashShellPath: String
     private var limiter: SubagentLimiter
@@ -980,6 +1191,7 @@ public struct SubagentRunner: Sendable {
         bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600,
+        maxTaskTimeoutSeconds: Int? = nil,
         bashShellPath: String = kwwkDefaultShellPath
     ) {
         let snapshot = SubagentParentSnapshot(
@@ -1007,6 +1219,7 @@ public struct SubagentRunner: Sendable {
         self.parentSnapshot = { snapshot }
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
         self.bashEnvironment = bashEnvironment
         self.bashShellPath = bashShellPath
         self.limits = limits
@@ -1030,6 +1243,7 @@ public struct SubagentRunner: Sendable {
         bashEnvironment: [String: String],
         bashDefaultTimeoutSeconds: Int = 120,
         bashMaxTimeoutSeconds: Int = 600,
+        maxTaskTimeoutSeconds: Int? = nil,
         bashShellPath: String = kwwkDefaultShellPath
     ) {
         let parentBox = SubagentParentBox(
@@ -1059,6 +1273,7 @@ public struct SubagentRunner: Sendable {
         self.parentSnapshot = { parentBox.snapshot() }
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
         self.bashEnvironment = bashEnvironment
         self.bashShellPath = bashShellPath
         self.limits = limits
@@ -1146,6 +1361,7 @@ public struct SubagentRunner: Sendable {
             childSessionId: makeSubagentSessionId(parent: parentSessionId, name: definition.name),
             bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
             bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+            maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
             bashEnvironment: bashEnvironment,
             bashShellPath: bashShellPath
         )
@@ -1283,6 +1499,7 @@ private struct SubagentInvocationRunner: Sendable {
     var childSessionId: String
     var bashDefaultTimeoutSeconds: Int
     var bashMaxTimeoutSeconds: Int
+    var maxTaskTimeoutSeconds: Int?
     var bashEnvironment: [String: String]
     var bashShellPath: String
     var reservedPermit: SubagentPermit?
@@ -1303,6 +1520,7 @@ private struct SubagentInvocationRunner: Sendable {
         childSessionId: String,
         bashDefaultTimeoutSeconds: Int,
         bashMaxTimeoutSeconds: Int,
+        maxTaskTimeoutSeconds: Int?,
         bashEnvironment: [String: String],
         bashShellPath: String,
         reservedPermit: SubagentPermit? = nil,
@@ -1322,6 +1540,7 @@ private struct SubagentInvocationRunner: Sendable {
         self.childSessionId = childSessionId
         self.bashDefaultTimeoutSeconds = bashDefaultTimeoutSeconds
         self.bashMaxTimeoutSeconds = bashMaxTimeoutSeconds
+        self.maxTaskTimeoutSeconds = maxTaskTimeoutSeconds
         self.bashEnvironment = bashEnvironment
         self.bashShellPath = bashShellPath
         self.reservedPermit = reservedPermit
@@ -1495,6 +1714,7 @@ private struct SubagentInvocationRunner: Sendable {
             fileAccessPolicy: fileAccessPolicy,
             bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
             bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+            maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
             bashEnvironment: bashEnvironment,
             bashShellPath: bashShellPath,
             bashCommandPolicy: definition.bashCommandPolicy
@@ -1634,6 +1854,7 @@ private final class SubagentRunCompletion: @unchecked Sendable {
     private let lock = NSLock()
     private var outcome: Outcome?
     private var waiter: CheckedContinuation<Outcome, Never>?
+    private var waiters: [SubagentSettleSignal] = []
 
     func wait() async -> Outcome {
         await withCheckedContinuation { continuation in
@@ -1646,17 +1867,75 @@ private final class SubagentRunCompletion: @unchecked Sendable {
         }
     }
 
+    /// Wait at most `seconds` for the outcome; `nil` when the deadline passes
+    /// first. The outcome stays available for a later unbounded `wait()`.
+    func wait(upToSeconds seconds: Int) async -> Outcome? {
+        if let ready = lock.withLock({ outcome }) { return ready }
+        let signal = SubagentSettleSignal()
+        let deadline = Task {
+            try? await Task.sleep(nanoseconds: UInt64(max(0, seconds)) * 1_000_000_000)
+            signal.fire()
+        }
+        let observer = lock.withLock { () -> Outcome? in
+            if let outcome { return outcome }
+            waiters.append(signal)
+            return nil
+        }
+        if let observer {
+            deadline.cancel()
+            return observer
+        }
+        await signal.wait()
+        deadline.cancel()
+        return lock.withLock {
+            waiters.removeAll { $0 === signal }
+            return outcome
+        }
+    }
+
     @discardableResult
     func resolve(_ result: Outcome) -> Bool {
-        let resolution = lock.withLock { () -> (Bool, CheckedContinuation<Outcome, Never>?) in
-            guard outcome == nil else { return (false, nil) }
+        let resolution = lock.withLock { () -> (Bool, CheckedContinuation<Outcome, Never>?, [SubagentSettleSignal]) in
+            guard outcome == nil else { return (false, nil, []) }
             outcome = result
             let pending = waiter
             waiter = nil
-            return (true, pending)
+            let signals = waiters
+            waiters.removeAll()
+            return (true, pending, signals)
         }
         resolution.1?.resume(returning: result)
+        for signal in resolution.2 { signal.fire() }
         return resolution.0
+    }
+}
+
+/// One-shot latch: `wait()` returns once `fire()` has been called, whichever
+/// order the two happen in. Backs the timed wait on `SubagentRunCompletion`.
+private final class SubagentSettleSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func fire() {
+        let pending = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            fired = true
+            let pending = continuation
+            continuation = nil
+            return pending
+        }
+        pending?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let ready = lock.withLock { () -> Bool in
+                if fired { return true }
+                self.continuation = continuation
+                return false
+            }
+            if ready { continuation.resume() }
+        }
     }
 }
 
@@ -1969,72 +2248,109 @@ private struct SubagentBackgroundRunner: CapacityQueuedBackgroundTaskRunner {
                         progressWriter.record(update)
                     }
                 )
-                let outputBytes = try progressWriter.finish(
-                    section: "final",
-                    text: result.text
-                )
-                onDone(BackgroundTaskOutcome(
-                    success: true,
-                    summary: "completed",
-                    details: .object([
-                        "status": .string("completed"),
-                        "subagent_type": .string(subagentType),
-                        "child_session_id": .string(runner.childSessionId),
-                        "model": .string(result.model.id),
-                        "stop_reason": .string(result.stopReason.rawValue),
-                        "usage": usageDetails(result.usage),
-                        "turns": .int(result.turns),
-                        "cost": costDetails(result.cost),
-                        "duration_ms": .int(result.durationMs),
-                        "output_bytes": .int(outputBytes),
-                        "history_available": .bool(true),
-                    ])
+                onDone(subagentBackgroundSuccess(
+                    result: result,
+                    subagentType: subagentType,
+                    childSessionId: runner.childSessionId,
+                    progressWriter: progressWriter
                 ))
             } catch {
-                let message = subagentErrorMessage(error)
-                let failureKind = subagentFailureKind(error)
-                let isIncomplete = failureKind == "incomplete"
-                runner.historyStore.finish(
+                onDone(subagentBackgroundFailure(
+                    error: error,
+                    subagentType: subagentType,
                     childSessionId: runner.childSessionId,
-                    status: subagentHistoryStatus(for: error),
-                    errorMessage: message
-                )
-                let terminal = normalizedSubagentError(error) as? SubagentTerminalFailure
-                let report = [
-                    terminal?.partialOutput.map { "Partial output:\n\($0)" },
-                    "Subagent \(subagentType) \(isIncomplete ? "incomplete" : "failed"): \(message)",
-                ].compactMap { $0 }.joined(separator: "\n\n")
-                let outputBytes = try? progressWriter.finish(
-                    section: isIncomplete ? "incomplete" : "error",
-                    text: report
-                )
-                var details: [String: JSONValue] = [
-                    "status": .string(isIncomplete ? "incomplete" : "failed"),
-                    "subagent_type": .string(subagentType),
-                    "child_session_id": .string(runner.childSessionId),
-                    "failure_kind": .string(failureKind),
-                    "error_message": .string(message),
-                    "output_bytes": .int(outputBytes ?? 0),
-                    "history_available": .bool(true),
-                ]
-                if failureKind == "timeout" || failureKind == "aborted" {
-                    details["capacity_retained_until_runner_exit"] = .bool(true)
-                }
-                details.merge(
-                    subagentFailureTelemetry(error),
-                    uniquingKeysWith: { _, telemetry in telemetry }
-                )
-                onDone(BackgroundTaskOutcome(
-                    success: false,
-                    summary: cancellation.isCancelled
-                        ? "aborted"
-                        : isIncomplete ? "incomplete" : "failed",
-                    details: .object(details),
-                    errorMessage: isIncomplete ? nil : message
+                    progressWriter: progressWriter,
+                    historyStore: runner.historyStore,
+                    cancelled: cancellation.isCancelled
                 ))
             }
         }
     }
+}
+
+/// Terminal outcome of a background-owned child that finished: seals the
+/// output file with the final text and reports the run's telemetry.
+private func subagentBackgroundSuccess(
+    result: SubagentResult,
+    subagentType: String,
+    childSessionId: String,
+    progressWriter: BackgroundSubagentProgressWriter
+) -> BackgroundTaskOutcome {
+    let outputBytes = (try? progressWriter.finish(
+        section: "final",
+        text: result.text
+    )) ?? 0
+    return BackgroundTaskOutcome(
+        success: true,
+        summary: "completed",
+        details: .object([
+            "status": .string("completed"),
+            "subagent_type": .string(subagentType),
+            "child_session_id": .string(childSessionId),
+            "model": .string(result.model.id),
+            "stop_reason": .string(result.stopReason.rawValue),
+            "usage": usageDetails(result.usage),
+            "turns": .int(result.turns),
+            "cost": costDetails(result.cost),
+            "duration_ms": .int(result.durationMs),
+            "output_bytes": .int(outputBytes),
+            "history_available": .bool(true),
+        ])
+    )
+}
+
+/// Terminal outcome of a background-owned child that failed, timed out, was
+/// aborted, or yielded incomplete: closes the history entry, seals the output
+/// file with the report, and keeps the structured failure telemetry.
+private func subagentBackgroundFailure(
+    error: Error,
+    subagentType: String,
+    childSessionId: String,
+    progressWriter: BackgroundSubagentProgressWriter,
+    historyStore: SubagentHistoryStore,
+    cancelled: Bool
+) -> BackgroundTaskOutcome {
+    let message = subagentErrorMessage(error)
+    let failureKind = subagentFailureKind(error)
+    let isIncomplete = failureKind == "incomplete"
+    historyStore.finish(
+        childSessionId: childSessionId,
+        status: subagentHistoryStatus(for: error),
+        errorMessage: message
+    )
+    let terminal = normalizedSubagentError(error) as? SubagentTerminalFailure
+    let report = [
+        terminal?.partialOutput.map { "Partial output:\n\($0)" },
+        "Subagent \(subagentType) \(isIncomplete ? "incomplete" : "failed"): \(message)",
+    ].compactMap { $0 }.joined(separator: "\n\n")
+    let outputBytes = try? progressWriter.finish(
+        section: isIncomplete ? "incomplete" : "error",
+        text: report
+    )
+    var details: [String: JSONValue] = [
+        "status": .string(isIncomplete ? "incomplete" : "failed"),
+        "subagent_type": .string(subagentType),
+        "child_session_id": .string(childSessionId),
+        "failure_kind": .string(failureKind),
+        "error_message": .string(message),
+        "output_bytes": .int(outputBytes ?? 0),
+        "history_available": .bool(true),
+    ]
+    if failureKind == "timeout" || failureKind == "aborted" {
+        details["capacity_retained_until_runner_exit"] = .bool(true)
+    }
+    details.merge(
+        subagentFailureTelemetry(error),
+        uniquingKeysWith: { _, telemetry in telemetry }
+    )
+    return BackgroundTaskOutcome(
+        success: false,
+        summary: cancelled
+            ? "aborted"
+            : isIncomplete ? "incomplete" : "failed",
+        details: .object(details),
+        errorMessage: isIncomplete ? nil : message
+    )
 }
 
 private func buildSubagentSystemPrompt(

--- a/Sources/KWWKAgent/SubagentToolset.swift
+++ b/Sources/KWWKAgent/SubagentToolset.swift
@@ -37,7 +37,11 @@ public func createSubagentToolset(
     bashEnvironment: [String: String],
     fileAccessPolicy: FileAccessPolicy = .unrestricted,
     contextFiles: [(path: String, content: String)] = [],
-    authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil
+    authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil,
+    bashDefaultTimeoutSeconds: Int = 120,
+    bashMaxTimeoutSeconds: Int = 600,
+    maxTaskTimeoutSeconds: Int? = nil,
+    bashShellPath: String = kwwkDefaultShellPath
 ) -> SubagentToolset {
     let parent = SubagentParentBox(
         childCwd: cwd,
@@ -68,7 +72,11 @@ public func createSubagentToolset(
             historyStore: historyStore,
             parentSnapshot: { parent.snapshot() },
             limits: limits,
-            bashEnvironment: bashEnvironment
+            bashEnvironment: bashEnvironment,
+            bashDefaultTimeoutSeconds: bashDefaultTimeoutSeconds,
+            bashMaxTimeoutSeconds: bashMaxTimeoutSeconds,
+            maxTaskTimeoutSeconds: maxTaskTimeoutSeconds,
+            bashShellPath: bashShellPath
         ),
     ]
     if backgroundManager != nil {

--- a/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
+++ b/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
@@ -133,8 +133,23 @@ struct MaxTaskTimeoutTests {
             bashEnvironment: testBashEnvironment,
             maxTaskTimeoutSeconds: 45
         )
-        #expect(capped.description.contains("more than 45s"))
+        #expect(capped.description.contains("longer than 45s"))
         #expect(capped.description.contains("moved to the background automatically"))
+        guard case .object(let schema) = capped.parameters,
+              case .object(let props) = schema["properties"] ?? .null,
+              case .object(let timeout) = props["timeout"] ?? .null else {
+            Issue.record("expected agent timeout schema")
+            return
+        }
+        #expect(timeout["maximum"] == .int(45))
+        if case .string(let text) = timeout["description"] ?? .null {
+            #expect(text.contains("Default 45, max 45"))
+        } else {
+            Issue.record("expected timeout description")
+        }
+
+        // Without a cap the limits' own foreground bounds stand (bash parity:
+        // default 120, max 600).
         let uncapped = createAgentTool(
             cwd: outputDir.path,
             subagents: [slowSubagent()],
@@ -142,7 +157,113 @@ struct MaxTaskTimeoutTests {
             parentTools: .readOnly,
             bashEnvironment: testBashEnvironment
         )
-        #expect(!uncapped.description.contains("more than"))
+        #expect(uncapped.description.contains("at most 600s"))
+        guard case .object(let schema2) = uncapped.parameters,
+              case .object(let props2) = schema2["properties"] ?? .null,
+              case .object(let timeout2) = props2["timeout"] ?? .null else {
+            Issue.record("expected agent timeout schema")
+            return
+        }
+        #expect(timeout2["maximum"] == .int(600))
+        if case .string(let text) = timeout2["description"] ?? .null {
+            #expect(text.contains("Default 120, max 600"))
+        } else {
+            Issue.record("expected timeout description")
+        }
+    }
+
+    @Test("agent: the model's own `timeout` is the foreground wait, and the cap bounds it")
+    func agentModelTimeoutDrivesTheFlip() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let releaseFile = outputDir.appendingPathComponent("release-child")
+        faux.setResponses([
+            .factory { _, _, _, _ in
+                while !FileManager.default.fileExists(atPath: releaseFile.path) {
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                }
+                return yieldMessage("late answer")
+            },
+        ])
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        // No runtime cap: a 1s `timeout` from the model flips at 1s.
+        let tool = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: manager,
+            sessionId: "parent-timeout",
+            bashEnvironment: testBashEnvironment
+        )
+        let started = Date()
+        let result = try await tool.execute(
+            "call-timeout",
+            .object([
+                "description": .string("slow child"),
+                "prompt": .string("take your time"),
+                "subagent_type": .string("slow"),
+                "timeout": .int(1),
+            ]),
+            nil, nil
+        )
+        #expect(Date().timeIntervalSince(started) < 10)
+        #expect(detail(result, "status") == .string("auto_backgrounded"))
+        #expect(detail(result, "softTimeoutSeconds") == .int(1))
+        FileManager.default.createFile(atPath: releaseFile.path, contents: Data())
+        guard case .string(let taskId) = detail(result, "task_id") ?? .null else {
+            Issue.record("expected task_id")
+            return
+        }
+        #expect(await awaitUntil(10_000) {
+            await manager.get(taskId)?.status == .completed
+        })
+
+        // With a 1s cap, a `timeout` of 300 is lowered to 1, not rejected.
+        try? FileManager.default.removeItem(at: releaseFile)
+        faux.setResponses([
+            .factory { _, _, _, _ in
+                while !FileManager.default.fileExists(atPath: releaseFile.path) {
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                }
+                return yieldMessage("late answer 2")
+            },
+        ])
+        let capped = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: manager,
+            sessionId: "parent-timeout-capped",
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 1
+        )
+        let started2 = Date()
+        let result2 = try await capped.execute(
+            "call-timeout-capped",
+            .object([
+                "description": .string("slow child"),
+                "prompt": .string("take your time"),
+                "subagent_type": .string("slow"),
+                "timeout": .int(300),
+                "run_in_background": .bool(false),
+            ]),
+            nil, nil
+        )
+        #expect(Date().timeIntervalSince(started2) < 10)
+        #expect(detail(result2, "status") == .string("auto_backgrounded"))
+        #expect(detail(result2, "softTimeoutSeconds") == .int(1))
+        FileManager.default.createFile(atPath: releaseFile.path, contents: Data())
+        guard case .string(let taskId2) = detail(result2, "task_id") ?? .null else {
+            Issue.record("expected task_id")
+            return
+        }
+        #expect(await awaitUntil(10_000) {
+            await manager.get(taskId2)?.status == .completed
+        })
     }
 
     @Test("agent: a child that finishes inside the cap returns a normal foreground result")
@@ -222,7 +343,7 @@ struct MaxTaskTimeoutTests {
         )
         #expect(Date().timeIntervalSince(started) < 10)
         #expect(detail(result, "status") == .string("auto_backgrounded"))
-        #expect(detail(result, "wait_cap_seconds") == .int(1))
+        #expect(detail(result, "softTimeoutSeconds") == .int(1))
         #expect(detail(result, "subagent_type") == .string("slow"))
         #expect(text(of: result).contains("moved to the background"))
         guard case .string(let taskId) = detail(result, "task_id") ?? .null else {

--- a/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
+++ b/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
@@ -1,0 +1,374 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+/// `maxTaskTimeoutSeconds`: the runtime-wide ceiling on how long one `bash`
+/// or `agent` call may keep the model waiting. It beats the model's own
+/// `timeout` and its `run_in_background: false`; work that outlives it is
+/// moved to the background when a manager is attached.
+@Suite("maxTaskTimeoutSeconds wait cap")
+struct MaxTaskTimeoutTests {
+    // MARK: - bash
+
+    @Test("bash: cap lowers the schema maximum and the default")
+    func bashSchemaReflectsCap() {
+        let tool = createBashTool(cwd: "/", options: BashToolOptions(
+            environment: testBashEnvironment,
+            defaultTimeoutSeconds: 120,
+            maxTimeoutSeconds: 600,
+            manager: BackgroundTaskManager(outputDir: makeTempDir()),
+            maxTaskTimeoutSeconds: 45
+        ))
+        guard case .object(let schema) = tool.parameters,
+              case .object(let props) = schema["properties"] ?? .null,
+              case .object(let timeout) = props["timeout"] ?? .null else {
+            Issue.record("expected timeout schema")
+            return
+        }
+        #expect(timeout["maximum"] == .int(45))
+        if case .string(let text) = timeout["description"] ?? .null {
+            #expect(text.contains("Default 45, max 45"))
+        } else {
+            Issue.record("expected timeout description")
+        }
+        #expect(tool.description.contains("45s"))
+    }
+
+    @Test("bash: cap without a manager leaves the schema at the cap too")
+    func bashSchemaWithoutManager() {
+        let options = BashToolOptions(
+            environment: testBashEnvironment,
+            defaultTimeoutSeconds: 10,
+            maxTimeoutSeconds: 600,
+            maxTaskTimeoutSeconds: 45
+        )
+        #expect(options.effectiveMaxTimeoutSeconds == 45)
+        #expect(options.effectiveDefaultTimeoutSeconds == 10)
+        let uncapped = BashToolOptions(environment: testBashEnvironment)
+        #expect(uncapped.effectiveMaxTimeoutSeconds == 600)
+        #expect(uncapped.effectiveDefaultTimeoutSeconds == 120)
+    }
+
+    @Test("bash: a model timeout above the cap still flips at the cap")
+    func bashModelTimeoutIsOverriddenByCap() async throws {
+        let cwdDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: cwdDir) }
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let releaseFile = cwdDir.appendingPathComponent("release-cap")
+        let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
+            environment: testBashEnvironment,
+            defaultTimeoutSeconds: 120,
+            maxTimeoutSeconds: 600,
+            manager: manager,
+            sessionId: "cap-session",
+            autoBackgroundOnTimeout: true,
+            maxTaskTimeoutSeconds: 1
+        ))
+        let started = Date()
+        let result = try await tool.execute(
+            "call-1",
+            .object([
+                "command": .string("while [ ! -f \(shellQuote(releaseFile.path)) ]; do sleep 0.1; done"),
+                "timeout": .int(300),
+                "run_in_background": .bool(false),
+            ]),
+            nil, nil
+        )
+        // Returned around the 1s cap, not the 300s the model asked for.
+        #expect(Date().timeIntervalSince(started) < 10)
+        guard case .object(let details) = result.details ?? .null else {
+            Issue.record("expected details object")
+            return
+        }
+        #expect(details["status"] == .string("auto_backgrounded"))
+        #expect(details["softTimeoutSeconds"] == .int(1))
+        guard case .string(let taskId) = details["taskId"] ?? .null else {
+            Issue.record("expected taskId")
+            return
+        }
+        #expect(await manager.get(taskId)?.status == .running)
+        FileManager.default.createFile(atPath: releaseFile.path, contents: Data())
+        #expect(await awaitUntil(10_000) {
+            await manager.get(taskId)?.status == .completed
+        })
+    }
+
+    // MARK: - agent
+
+    @Test("agent: description advertises the wait cap")
+    func agentDescriptionMentionsCap() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let capped = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: "parent",
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 45
+        )
+        #expect(capped.description.contains("more than 45s"))
+        #expect(capped.description.contains("moved to the background automatically"))
+        let uncapped = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            bashEnvironment: testBashEnvironment
+        )
+        #expect(!uncapped.description.contains("more than"))
+    }
+
+    @Test("agent: a child that finishes inside the cap returns a normal foreground result")
+    func agentFastChildStaysForeground() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(yieldMessage("quick answer"))])
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let tool = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: manager,
+            sessionId: "parent-fast",
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 30
+        )
+        let result = try await tool.execute(
+            "call-fast",
+            .object([
+                "description": .string("fast child"),
+                "prompt": .string("answer quickly"),
+                "subagent_type": .string("slow"),
+                "run_in_background": .bool(false),
+            ]),
+            nil, nil
+        )
+        #expect(text(of: result).contains("quick answer"))
+        #expect(detail(result, "status") == .string("completed"))
+        // Nothing was registered with the manager and no stray output file
+        // remains from the foreground phase.
+        #expect(await manager.list().isEmpty)
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: outputDir.path)) ?? []
+        #expect(leftovers.filter { $0.hasPrefix("fg_") }.isEmpty)
+    }
+
+    @Test("agent: a child still running at the cap is moved to the background despite run_in_background=false")
+    func agentSlowChildFlipsToBackground() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let releaseFile = outputDir.appendingPathComponent("release-child")
+        faux.setResponses([
+            .factory { _, _, _, _ in
+                // Hold the child's only model turn until the test releases it.
+                while !FileManager.default.fileExists(atPath: releaseFile.path) {
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                }
+                return yieldMessage("late answer")
+            },
+        ])
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let tool = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: manager,
+            sessionId: "parent-slow",
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 1
+        )
+        let started = Date()
+        let result = try await tool.execute(
+            "call-slow",
+            .object([
+                "description": .string("slow child"),
+                "prompt": .string("take your time"),
+                "subagent_type": .string("slow"),
+                "run_in_background": .bool(false),
+            ]),
+            nil, nil
+        )
+        #expect(Date().timeIntervalSince(started) < 10)
+        #expect(detail(result, "status") == .string("auto_backgrounded"))
+        #expect(detail(result, "wait_cap_seconds") == .int(1))
+        #expect(detail(result, "subagent_type") == .string("slow"))
+        #expect(text(of: result).contains("moved to the background"))
+        guard case .string(let taskId) = detail(result, "task_id") ?? .null else {
+            Issue.record("expected task_id")
+            return
+        }
+        let events = result.runtimeEvents ?? []
+        #expect(events.contains { event in
+            if case .subagent(let lifecycle) = event {
+                return lifecycle.kind == .backgroundStarted && lifecycle.backgroundTaskId == taskId
+            }
+            return false
+        })
+
+        // Registered as a running agent task under the parent session, and
+        // the child is still alive: no completion yet.
+        let snapshot = try #require(await manager.get(taskId))
+        #expect(snapshot.status == .running)
+        #expect(snapshot.spec.kind == "agent")
+        #expect(snapshot.sessionId == "parent-slow")
+        #expect(await manager.drainNotifications(sessionId: "parent-slow").isEmpty)
+
+        // Release the child: the manager sees it finish and notifies with
+        // the same terminal shape a background-started child produces.
+        FileManager.default.createFile(atPath: releaseFile.path, contents: Data())
+        #expect(await awaitUntil(10_000) {
+            await manager.get(taskId)?.status == .completed
+        })
+        let done = try #require(await manager.get(taskId))
+        #expect(done.outcome?.success == true)
+        guard case .object(let outcome) = done.outcome?.details ?? .null else {
+            Issue.record("expected outcome details")
+            return
+        }
+        #expect(outcome["status"] == .string("completed"))
+        #expect(outcome["subagent_type"] == .string("slow"))
+        #expect(done.outputTail.contains("[final]"))
+        #expect(done.outputTail.contains("late answer"))
+        let notifications = await manager.drainNotifications(sessionId: "parent-slow")
+        #expect(notifications.map(\.taskId) == [taskId])
+    }
+
+    @Test("agent: killing the adopted task cancels the child")
+    func agentFlippedChildHonoursManagerKill() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        faux.setResponses([
+            .factory { _, _, _, _ in
+                // Never answers on its own; only cancellation ends this turn.
+                while true {
+                    try Task.checkCancellation()
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                }
+            },
+        ])
+        let manager = BackgroundTaskManager(outputDir: outputDir)
+        let tool = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            backgroundManager: manager,
+            sessionId: "parent-kill",
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 1
+        )
+        let result = try await tool.execute(
+            "call-kill",
+            .object([
+                "description": .string("stuck child"),
+                "prompt": .string("hang"),
+                "subagent_type": .string("slow"),
+            ]),
+            nil, nil
+        )
+        guard case .string(let taskId) = detail(result, "task_id") ?? .null else {
+            Issue.record("expected task_id")
+            return
+        }
+        try await manager.kill(taskId)
+        #expect(await awaitUntil(10_000) {
+            let status = await manager.get(taskId)?.status
+            return status == .killed || status == .failed
+        })
+    }
+
+    @Test("agent: without a manager the cap is the child's deadline")
+    func agentCapWithoutManagerTimesOut() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([
+            .factory { _, _, _, _ in
+                while true {
+                    try Task.checkCancellation()
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                }
+            },
+        ])
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let tool = createAgentTool(
+            cwd: outputDir.path,
+            subagents: [slowSubagent()],
+            parentModel: faux.getModel(),
+            parentTools: .readOnly,
+            limits: SubagentLimits(timeoutSeconds: 600),
+            bashEnvironment: testBashEnvironment,
+            maxTaskTimeoutSeconds: 1
+        )
+        let started = Date()
+        do {
+            _ = try await tool.execute(
+                "call-nomanager",
+                .object([
+                    "description": .string("stuck child"),
+                    "prompt": .string("hang"),
+                    "subagent_type": .string("slow"),
+                ]),
+                nil, nil
+            )
+            Issue.record("expected the capped child to time out")
+        } catch let error as StructuredToolExecutionError {
+            #expect(Date().timeIntervalSince(started) < 10)
+            guard case .object(let details) = error.details ?? .null else {
+                Issue.record("expected structured failure details")
+                return
+            }
+            #expect(details["failure_kind"] == .string("timeout"))
+        }
+    }
+}
+
+private func slowSubagent() -> SubagentDefinition {
+    SubagentDefinition(
+        name: "slow",
+        description: "Exercises the foreground wait cap.",
+        prompt: "Answer the task.",
+        tools: .readOnly
+    )
+}
+
+private func yieldMessage(_ result: String) -> AssistantMessage {
+    fauxAssistantMessage(
+        blocks: [fauxToolCall(
+            name: "subagent_yield",
+            arguments: .object([
+                "status": .string("complete"),
+                "result": .string(result),
+            ]),
+            id: UUID().uuidString
+        )],
+        stopReason: .toolUse
+    )
+}
+
+private func text(of result: AgentToolResult) -> String {
+    result.content.compactMap { block in
+        if case .text(let text) = block { return text.text }
+        return nil
+    }.joined()
+}
+
+private func detail(_ result: AgentToolResult, _ key: String) -> JSONValue? {
+    guard case .object(let details) = result.details ?? .null else { return nil }
+    return details[key]
+}

--- a/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
+++ b/Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift
@@ -11,15 +11,21 @@ import Testing
 struct MaxTaskTimeoutTests {
     // MARK: - bash
 
-    @Test("bash: cap lowers the schema maximum and the default")
-    func bashSchemaReflectsCap() {
-        let tool = createBashTool(cwd: "/", options: BashToolOptions(
-            environment: testBashEnvironment,
-            defaultTimeoutSeconds: 120,
-            maxTimeoutSeconds: 600,
-            manager: BackgroundTaskManager(outputDir: makeTempDir()),
-            maxTaskTimeoutSeconds: 45
-        ))
+    @Test("bash: the cap folds into the soft-timeout bounds and the schema")
+    func bashSchemaReflectsCap() throws {
+        let outputDir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+        let tools = buildCodingToolList(
+            cwd: "/",
+            selected: [.bash],
+            backgroundManager: BackgroundTaskManager(outputDir: outputDir),
+            sessionId: "s",
+            bashDefaultTimeoutSeconds: 120,
+            bashMaxTimeoutSeconds: 600,
+            maxTaskTimeoutSeconds: 45,
+            bashEnvironment: testBashEnvironment
+        )
+        let tool = try #require(tools.first { $0.name == "bash" })
         guard case .object(let schema) = tool.parameters,
               case .object(let props) = schema["properties"] ?? .null,
               case .object(let timeout) = props["timeout"] ?? .null else {
@@ -32,22 +38,33 @@ struct MaxTaskTimeoutTests {
         } else {
             Issue.record("expected timeout description")
         }
-        #expect(tool.description.contains("45s"))
+        #expect(tool.description.contains("longer than 45s"))
     }
 
-    @Test("bash: cap without a manager leaves the schema at the cap too")
-    func bashSchemaWithoutManager() {
-        let options = BashToolOptions(
-            environment: testBashEnvironment,
-            defaultTimeoutSeconds: 10,
-            maxTimeoutSeconds: 600,
-            maxTaskTimeoutSeconds: 45
+    @Test("bash: without a cap the configured bounds stand")
+    func bashBoundsWithoutCap() throws {
+        let tools = buildCodingToolList(
+            cwd: "/",
+            selected: [.bash],
+            backgroundManager: nil,
+            sessionId: "s",
+            bashDefaultTimeoutSeconds: 10,
+            bashMaxTimeoutSeconds: 600,
+            bashEnvironment: testBashEnvironment
         )
-        #expect(options.effectiveMaxTimeoutSeconds == 45)
-        #expect(options.effectiveDefaultTimeoutSeconds == 10)
-        let uncapped = BashToolOptions(environment: testBashEnvironment)
-        #expect(uncapped.effectiveMaxTimeoutSeconds == 600)
-        #expect(uncapped.effectiveDefaultTimeoutSeconds == 120)
+        let tool = try #require(tools.first { $0.name == "bash" })
+        guard case .object(let schema) = tool.parameters,
+              case .object(let props) = schema["properties"] ?? .null,
+              case .object(let timeout) = props["timeout"] ?? .null else {
+            Issue.record("expected timeout schema")
+            return
+        }
+        #expect(timeout["maximum"] == .int(600))
+        if case .string(let text) = timeout["description"] ?? .null {
+            #expect(text.contains("Default 10, max 600"))
+        } else {
+            Issue.record("expected timeout description")
+        }
     }
 
     @Test("bash: a model timeout above the cap still flips at the cap")
@@ -58,15 +75,17 @@ struct MaxTaskTimeoutTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
         let manager = BackgroundTaskManager(outputDir: outputDir)
         let releaseFile = cwdDir.appendingPathComponent("release-cap")
-        let tool = createBashTool(cwd: cwdDir.path, options: BashToolOptions(
-            environment: testBashEnvironment,
-            defaultTimeoutSeconds: 120,
-            maxTimeoutSeconds: 600,
-            manager: manager,
+        let tools = buildCodingToolList(
+            cwd: cwdDir.path,
+            selected: [.bash],
+            backgroundManager: manager,
             sessionId: "cap-session",
-            autoBackgroundOnTimeout: true,
-            maxTaskTimeoutSeconds: 1
-        ))
+            bashDefaultTimeoutSeconds: 120,
+            bashMaxTimeoutSeconds: 600,
+            maxTaskTimeoutSeconds: 1,
+            bashEnvironment: testBashEnvironment
+        )
+        let tool = try #require(tools.first { $0.name == "bash" })
         let started = Date()
         let result = try await tool.execute(
             "call-1",


### PR DESCRIPTION
## Summary
- The `agent` tool now follows the same timing contract as `bash`:
  - new model-facing `timeout` = seconds to wait in the foreground (default `SubagentLimits.foregroundTimeoutSeconds` = 120, max `maxForegroundTimeoutSeconds` = 600; a larger value is lowered, not rejected);
  - a foreground child still running at `timeout` is adopted by `BackgroundTaskManager` (same output file / progress / notification / `agent_history` / kill semantics as a `run_in_background` child) and the tool returns `status: auto_backgrounded` + `task_id` (+ `softTimeoutSeconds`, like bash). Without a manager the wait becomes the child's deadline (timeout failure);
  - a child's own runtime is unbounded by default: `SubagentLimits.timeoutSeconds` defaults to `nil` (was 600); the manager's last-resort watchdog stays.
- New `maxTaskTimeoutSeconds` on `CodingAgentConfig`, `createAgentTool`, `createSubagentToolset`, `SubagentRunner`: a runtime-wide ceiling on how long one `bash` or `agent` call may keep the model waiting. It folds into bash's `bashDefaultTimeoutSeconds`/`bashMaxTimeoutSeconds` and the agent tool's foreground-wait bounds — overriding the model's own `timeout` and its `run_in_background: false`.
- Both tool descriptions/schemas state the effective bounds; `AgentLoop` maps `auto_backgrounded` to `.backgroundStarted`.

## Test plan
- [x] `Tests/KWWKAgentTests/MaxTaskTimeoutTests.swift` (bash bounds/schema/flip; agent schema, model `timeout` flip, cap-lowered `timeout`, fast child stays foreground, kill after flip, no-manager deadline)
- [x] Full `swift test`: 1351 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkR1T6a5ufaTf63iQgP2eq