### PR TITLE
chore(kwwk): bump version to 0.1.45

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.44"
+    static let version = "0.1.45"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.45.

Since v0.1.44:
- #116 — `maxTaskTimeoutSeconds` caps how long bash and agent keep the model waiting; the agent tool gains bash's timing contract (`timeout` = foreground wait, auto-flip to background, unbounded child runtime by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkR1T6a5ufaTf63iQgP2eq