### PR TITLE
chore: refresh bundled model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -4044,10 +4044,11 @@
         "maxTokensField" : "max_tokens",
         "supportsDeveloperRole" : false,
         "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
+        "supportsReasoningEffort" : true,
         "supportsStore" : false,
         "supportsStrictMode" : true,
-        "supportsUsageInStreaming" : true
+        "supportsUsageInStreaming" : true,
+        "thinkingFormat" : "openai"
       },
       "contextWindow" : 1048576,
       "cost" : {
@@ -4063,7 +4064,16 @@
       "maxTokens" : 384000,
       "name" : "Deepseek V4 Flash 0731",
       "provider" : "baseten",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "deepseek-ai\/DeepSeek-V4-Pro" : {
       "api" : "openai-completions",
@@ -4135,10 +4145,10 @@
         "high" : "high",
         "low" : "low",
         "max" : "max",
-        "medium" : "medium",
-        "minimal" : "minimal",
+        "medium" : null,
+        "minimal" : null,
         "off" : "none",
-        "xhigh" : "xhigh"
+        "xhigh" : null
       }
     },
     "moonshotai\/Kimi-K2.5" : {
@@ -17658,18 +17668,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1024000,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.015719,
+        "cacheRead" : 0.015299999999999999,
         "cacheWrite" : 0,
-        "input" : 0.078595999999999999,
-        "output" : 0.157192
+        "input" : 0.076499999999999999,
+        "output" : 0.153
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 262144,
       "name" : "DeepSeek V4 Flash Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -19252,10 +19262,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.01652,
+        "cacheRead" : 0.014840000000000001,
         "cacheWrite" : 0,
-        "input" : 0.082600000000000007,
-        "output" : 0.1652
+        "input" : 0.074200000000000002,
+        "output" : 0.1484
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -19979,10 +19989,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.018749999999999999,
-        "cacheWrite" : 0.020833000000000001,
-        "input" : 0.1875,
-        "output" : 0.9375
+        "cacheRead" : 0.0093749999999999997,
+        "cacheWrite" : 0.010416999999999999,
+        "input" : 0.09375,
+        "output" : 0.46875
       },
       "id" : "google\/gemini-3.7-flash:batch",
       "input" : [
@@ -20348,6 +20358,29 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "liquid\/lfm-2.5-2.6b:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "liquid\/lfm-2.5-2.6b:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 8192,
+      "name" : "LiquidAI: LFM2.5-2.6B (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "meituan\/longcat-2.0" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -20708,10 +20741,10 @@
       },
       "contextWindow" : 524288,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 0.6
+        "input" : 0.3,
+        "output" : 1.2
       },
       "id" : "minimax\/minimax-m3:batch",
       "input" : [
@@ -21203,10 +21236,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.094399999999999998,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 0.5605,
-        "output" : 2.36
+        "input" : 0.95,
+        "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.6",
       "input" : [
@@ -21251,10 +21284,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.095000000000000001,
+        "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.475,
-        "output" : 2
+        "input" : 0.95,
+        "output" : 4
       },
       "id" : "moonshotai\/kimi-k2.7-code:batch",
       "input" : [
@@ -21486,10 +21519,10 @@
       },
       "contextWindow" : 512288,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 1.8
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b:batch",
       "input" : [
@@ -25360,10 +25393,10 @@
       },
       "contextWindow" : 524288,
       "cost" : {
-        "cacheRead" : 0.085000000000000006,
+        "cacheRead" : 0.17,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2.025
+        "input" : 1,
+        "output" : 4.05
       },
       "id" : "thinkingmachines\/inkling:batch",
       "input" : [
@@ -25829,16 +25862,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.090999999999999998,
+        "cacheRead" : 0.221,
         "cacheWrite" : 0,
-        "input" : 0.49,
-        "output" : 1.54
+        "input" : 1.19,
+        "output" : 3.74
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 262144,
       "name" : "Z.ai: GLM 5.2",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -25855,10 +25888,10 @@
       },
       "contextWindow" : 512000,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0.7,
-        "output" : 2.2
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "z-ai\/glm-5.2:batch",
       "input" : [
@@ -25866,6 +25899,52 @@
       ],
       "maxTokens" : 4096,
       "name" : "Z.ai: GLM 5.2 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "z-ai\/glm-5.2:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "z-ai\/glm-5.2:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 256000,
+      "name" : "Z.ai: GLM 5.2 (free)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "z-ai\/glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "z-ai\/glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Z.ai: GLM 5.3",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -30266,10 +30345,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.01,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 0.050000000000000003,
+        "output" : 0.2
       },
       "id" : "nvidia\/nemotron-3.5-lightning",
       "input" : [
@@ -32222,6 +32301,25 @@
       ],
       "maxTokens" : 128000,
       "name" : "GLM 5.2 Fast",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "zai\/glm-5.3" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "zai\/glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 12800,
+      "name" : "GLM 5.3",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },


### PR DESCRIPTION
## Summary

- refresh `Sources/KWWKAI/Resources/models.json` from authoritative `badlogic/pi-mono` main commit `59a71b235dadb4ad0d67557a8abb0aaa093e68b4`
- add 4 models, remove 0 models, and update metadata for 13 models
- regenerate the Cursor catalog from GetUsableModels; it remains unchanged at 198 models
- resulting pi-mono catalog contains 39 providers and 1,304 models

## Validation

- both bundled catalogs parsed successfully with `jq`
- `git diff --check`
- added-line scan for localhost/private endpoints and credential-like data
- `swift test --filter GenerateModelsCoreTests` (5 tests)
- `swift test --filter CursorProtoTests` (31 tests)
- `swift test` (1,352 tests across 197 suites)
