### PR TITLE
Drop garbage collection of retained bash output artifacts

### DIFF
--- a/Sources/KWWKAgent/BackgroundTaskManager.swift
+++ b/Sources/KWWKAgent/BackgroundTaskManager.swift
@@ -122,14 +122,6 @@ public actor BackgroundTaskManager {
     /// slow-but-silent work is not flagged prematurely.
     public var silentStallThresholdSeconds: Double = 180
     public var tailBytes: Int = 4096
-    /// Bounds for raw output artifacts of already-completed foreground
-    /// commands (`retainForegroundOutputFile`). Oldest artifacts are deleted
-    /// first once either bound is exceeded; the newest artifact always
-    /// survives even when it alone exceeds the byte bound.
-    public var retainedForegroundOutputLimit: Int = 16
-    public var retainedForegroundOutputByteLimit: Int = 64 * 1024 * 1024
-    /// Retained foreground artifacts, oldest first.
-    private var retainedForegroundOutputs: [URL] = []
 
     // MARK: - Init
 
@@ -597,39 +589,6 @@ public actor BackgroundTaskManager {
             terminalTaskIsHeld(id, queuedForListener: queuedForListener) ? nil : id
         }
         for id in stale { removeTerminalTask(id) }
-        retainedForegroundOutputs.removeAll { url in
-            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
-            guard let modified = attrs?[.modificationDate] as? Date else {
-                return true  // already gone; drop the tracking entry
-            }
-            guard modified < cutoff else { return false }
-            try? FileManager.default.removeItem(at: url)
-            return true
-        }
-    }
-
-    /// Keep a completed foreground command's raw output artifact around so the
-    /// model can grep/page content the inline truncation dropped. Retained
-    /// artifacts are bounded by `retainedForegroundOutputLimit` /
-    /// `retainedForegroundOutputByteLimit` (oldest deleted first) and also age
-    /// out through `cleanup(olderThanSeconds:)`.
-    public func retainForegroundOutputFile(_ url: URL) {
-        retainedForegroundOutputs.removeAll { $0.path == url.path }
-        retainedForegroundOutputs.append(url)
-        pruneRetainedForegroundOutputs()
-    }
-
-    private func pruneRetainedForegroundOutputs() {
-        var totalBytes = retainedForegroundOutputs.reduce(0) {
-            $0 + Int(fileSize($1))
-        }
-        while retainedForegroundOutputs.count > max(1, retainedForegroundOutputLimit)
-            || (totalBytes > retainedForegroundOutputByteLimit
-                && retainedForegroundOutputs.count > 1) {
-            let oldest = retainedForegroundOutputs.removeFirst()
-            totalBytes -= Int(fileSize(oldest))
-            try? FileManager.default.removeItem(at: oldest)
-        }
     }
 
     private func pruneTerminalTasksIfNeeded() {

--- a/Sources/KWWKAgent/BashTool.swift
+++ b/Sources/KWWKAgent/BashTool.swift
@@ -717,13 +717,11 @@ private func runBashForegroundWithFlip(
 
     if let status = exit {
         // Completed within soft timeout. If the inline output had to be
-        // truncated, keep the raw artifact (manager-bounded GC) so the model
-        // can grep/page the omitted middle — a build's first compile error
+        // truncated, the raw artifact stays on disk so the model can
+        // grep/page the omitted middle — a build's first compile error
         // routinely lands there. Untruncated output needs no artifact.
         let output = bundle.readOutput(fullOutputPath: outputFile.path)
-        if output.truncated {
-            await manager.retainForegroundOutputFile(outputFile)
-        } else {
+        if !output.truncated {
             try? FileManager.default.removeItem(at: outputFile)
         }
         if cancellation?.isCancelled == true {

--- a/Tests/KWWKAgentTests/BashForegroundArtifactTests.swift
+++ b/Tests/KWWKAgentTests/BashForegroundArtifactTests.swift
@@ -6,9 +6,9 @@ import Testing
 /// A foreground command whose inline output was truncated used to have its raw
 /// output file deleted on completion, permanently losing the middle of the log
 /// — exactly where a build's first compile error lands. These tests pin the
-/// replacement contract: truncated output keeps a manager-tracked artifact and
-/// the truncation notice points at it, untruncated output leaves nothing
-/// behind, and retained artifacts are garbage-collected oldest first.
+/// replacement contract: truncated output keeps its raw artifact on disk and
+/// the truncation notice points at it; untruncated output leaves nothing
+/// behind.
 @Suite("Bash foreground output artifacts", .serialized)
 struct BashForegroundArtifactTests {
     private func makeTool(manager: BackgroundTaskManager, cwd: URL) -> AgentTool {
@@ -98,45 +98,5 @@ struct BashForegroundArtifactTests {
                 .contentsOfDirectory(atPath: outputDir.path)) ?? []
             #expect(leftovers.contains { $0.hasPrefix("fg_") })
         }
-    }
-
-    @Test("retained artifacts are garbage-collected oldest first")
-    func retainedArtifactsPruneOldestFirst() async throws {
-        let outputDir = makeTempDir()
-        defer { try? FileManager.default.removeItem(at: outputDir) }
-        let cwdDir = makeTempDir()
-        defer { try? FileManager.default.removeItem(at: cwdDir) }
-        let manager = BackgroundTaskManager(outputDir: outputDir)
-        await manager.setRetainedForegroundOutputLimits(
-            count: 2,
-            bytes: 64 * 1024 * 1024
-        )
-        let tool = makeTool(manager: manager, cwd: cwdDir)
-
-        var paths: [String] = []
-        for call in 0..<3 {
-            let result = try await tool.execute(
-                "gc-fg-\(call)",
-                ["command": .string("seq 1 100000")],
-                nil, nil
-            )
-            guard case .object(let details) = result.details ?? .null,
-                  case .string(let path) = details["outputFile"] ?? .null else {
-                Issue.record("expected details.outputFile for truncated output")
-                return
-            }
-            paths.append(path)
-        }
-        #expect(!FileManager.default.fileExists(atPath: paths[0]))
-        #expect(FileManager.default.fileExists(atPath: paths[1]))
-        #expect(FileManager.default.fileExists(atPath: paths[2]))
-    }
-}
-
-/// Expose the retention bounds so the GC test can squeeze them.
-extension BackgroundTaskManager {
-    func setRetainedForegroundOutputLimits(count: Int, bytes: Int) {
-        retainedForegroundOutputLimit = count
-        retainedForegroundOutputByteLimit = bytes
     }
 }


### PR DESCRIPTION
Follow-up to #119 per owner decision: retained foreground output artifacts are simply left on disk — no `retainedForegroundOutputLimit`/byte bound, no oldest-first pruning, no age-out in `cleanup(olderThanSeconds:)`, and no manager tracking at all (`retainForegroundOutputFile` is gone; BashTool just skips the delete when output was truncated). The GC test and its limits-tweaking helper are removed with it.

Full suite: 1355 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)