### PR TITLE
chore(kwwk): bump version to 0.1.46

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.45"
+    static let version = "0.1.46"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.46: model catalog refresh (#118), retained bash artifacts as the search surface (#119), never garbage-collect retained bash artifacts (#120).