### PR TITLE
fix(subagent): builtin subagents inherit the parent file access policy

### DIFF
--- a/Sources/KWWKAgent/SubagentDefinition.swift
+++ b/Sources/KWWKAgent/SubagentDefinition.swift
@@ -271,8 +271,7 @@ public extension SubagentDefinition {
             - Rollback or compatibility risks when relevant.
             - Open questions only if they block execution.
             """,
-            tools: tools.intersection(.readOnly),
-            fileAccessPolicy: .workspaceOnly
+            tools: tools.intersection(.readOnly)
         )
     }
 
@@ -296,8 +295,7 @@ public extension SubagentDefinition {
             - Explain the user-visible impact for each real bug.
             - If no issues are found, say so and call out residual risk or test gaps.
             """,
-            tools: tools.intersection(.readOnly),
-            fileAccessPolicy: .workspaceOnly
+            tools: tools.intersection(.readOnly)
         )
     }
 
@@ -329,8 +327,7 @@ public extension SubagentDefinition {
             - Recommended next steps.
             """,
             tools: safeTools,
-            bashCommandPolicy: .buildAndTestOnly,
-            fileAccessPolicy: .workspaceOnly
+            bashCommandPolicy: .buildAndTestOnly
         )
     }
 

--- a/Sources/KWWKAgent/SubagentDefinition.swift
+++ b/Sources/KWWKAgent/SubagentDefinition.swift
@@ -245,8 +245,7 @@ public extension SubagentDefinition {
             - Use line references when they are available and useful.
             - Mention uncertainty when evidence is incomplete.
             """,
-            tools: tools.intersection(.readOnly),
-            fileAccessPolicy: .workspaceOnly
+            tools: tools.intersection(.readOnly)
         )
     }
 


### PR DESCRIPTION
## Problem

The builtin subagent definitions (`explore`, `plan`, `code-reviewer`, `test-runner`) hard-coded `fileAccessPolicy: .workspaceOnly` with no additional roots. Combined with the root-intersection in `effectiveSubagentFileAccessPolicy`, this meant:

- Even when the embedder granted the **parent** agent `additionalReadRoots` (e.g. a mounted project root like `/projects/<id>` in AirBuild), the child's empty requested-root set intersected to nothing, silently dropping the grant.
- Even a fully **unrestricted** parent was narrowed to bare `workspaceOnly`, confining children to the parent workspace directory (e.g. `/run/airbuild/team/state/team/reviewer`).

In practice builtin subagents could never see anything outside the parent's workspace, regardless of platform-level authorization.

## Change

Remove the `fileAccessPolicy` override from all four builtin definitions so the field is `nil` and each child **inherits the parent policy** (`effectiveSubagentFileAccessPolicy` returns the parent policy when the definition requests none).

Safety still holds through tool selection:
- `explore` / `plan` / `code-reviewer` only register the read-only path tools (`read`/`grep`/`find`/`ls`) — no bash, no write/edit.
- `test-runner` keeps `bashCommandPolicy: .buildAndTestOnly`, which restricts bash to a single direct build/test process per call.

## Testing

- `swift build` passes
- `swift test --filter "BuiltinSubagentDefinition|SubagentPathContainment|SubagentHardening|SubagentTool"` — 56 tests in 5 suites, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)