### PR TITLE
chore(kwwk): bump version to 0.1.47

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.46"
+    static let version = "0.1.47"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Release v0.1.47.

Notable since v0.1.46:
- #122 — builtin subagents (explore/plan/code-reviewer/test-runner) now inherit the parent file access policy instead of forcing a bare workspaceOnly boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)