### PR TITLE
chore: refresh bundled model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -2627,6 +2627,29 @@
       "provider" : "amazon-bedrock",
       "reasoning" : true
     },
+    "xai.grok-4.6" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "compat" : {
+        "supportsStrictMode" : true
+      },
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.55,
+        "cacheWrite" : 0,
+        "input" : 2.2,
+        "output" : 6.6
+      },
+      "id" : "xai.grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.6",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true
+    },
     "zai.glm-4.7" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -2791,8 +2814,26 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
         "allowedFallbackModels" : [
-          "claude-opus-4-8",
-          "claude-opus-5"
+          {
+            "cost" : {
+              "cacheRead" : 0.5,
+              "cacheWrite" : 6.25,
+              "input" : 5,
+              "output" : 25
+            },
+            "model" : "claude-opus-4-8",
+            "provider" : "anthropic"
+          },
+          {
+            "cost" : {
+              "cacheRead" : 0.5,
+              "cacheWrite" : 6.25,
+              "input" : 5,
+              "output" : 25
+            },
+            "model" : "claude-opus-5",
+            "provider" : "anthropic"
+          }
         ],
         "forceAdaptiveThinking" : true,
         "supportsStrictTools" : true
@@ -3001,7 +3042,16 @@
       "baseUrl" : "https:\/\/api.anthropic.com",
       "compat" : {
         "allowedFallbackModels" : [
-          "claude-opus-4-8"
+          {
+            "cost" : {
+              "cacheRead" : 0.5,
+              "cacheWrite" : 6.25,
+              "input" : 5,
+              "output" : 25
+            },
+            "model" : "claude-opus-4-8",
+            "provider" : "anthropic"
+          }
         ],
         "forceAdaptiveThinking" : true,
         "supportsStrictTools" : true,
@@ -3848,10 +3898,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.4,
+        "cacheWrite" : 5,
+        "input" : 4,
+        "output" : 20
       },
       "id" : "gpt-5.6-sol",
       "input" : [
@@ -4062,7 +4112,7 @@
         "text"
       ],
       "maxTokens" : 384000,
-      "name" : "Deepseek V4 Flash 0731",
+      "name" : "DeepSeek V4 Flash 0731",
       "provider" : "baseten",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -4100,7 +4150,7 @@
         "text"
       ],
       "maxTokens" : 262144,
-      "name" : "Deepseek V4 Pro",
+      "name" : "DeepSeek V4 Pro",
       "provider" : "baseten",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -4138,7 +4188,7 @@
         "text"
       ],
       "maxTokens" : 262144,
-      "name" : "Deepseek V4 Pro 0813",
+      "name" : "DeepSeek V4 Pro 0813",
       "provider" : "baseten",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -5077,51 +5127,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "gpt-4" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 8192,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 30,
-        "output" : 60
-      },
-      "id" : "gpt-4",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 8192,
-      "name" : "GPT-4",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
-    "gpt-4-turbo" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 30
-      },
-      "id" : "gpt-4-turbo",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "GPT-4 Turbo",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false
-    },
     "gpt-4.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -5174,7 +5179,7 @@
       "compat" : {
         "supportsStrictMode" : true
       },
-      "contextWindow" : 1047576,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
@@ -5244,7 +5249,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.125,
         "cacheWrite" : 0,
@@ -5277,7 +5282,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
@@ -5310,7 +5315,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.0050000000000000001,
         "cacheWrite" : 0,
@@ -5336,39 +5341,6 @@
         "xhigh" : null
       }
     },
-    "gpt-5-pro" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 15,
-        "output" : 120
-      },
-      "id" : "gpt-5-pro",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 272000,
-      "name" : "GPT-5 Pro",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "gpt-5.1" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -5376,7 +5348,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.125,
         "cacheWrite" : 0,
@@ -5402,199 +5374,6 @@
         "xhigh" : null
       }
     },
-    "gpt-5.2" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.2",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.2",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.2-chat-latest" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.2-chat-latest",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.2 Chat",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : null,
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.2-pro" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 21,
-        "output" : 168
-      },
-      "id" : "gpt-5.2-pro",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.2 Pro",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.3-chat-latest" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.3-chat-latest",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "GPT-5.3 Chat (latest)",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : false,
-      "thinkingLevelMap" : {
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.3-codex" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.3-codex",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.3 Codex",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.3-codex-spark" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.175,
-        "cacheWrite" : 0,
-        "input" : 1.75,
-        "output" : 14
-      },
-      "id" : "gpt-5.3-codex-spark",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32000,
-      "name" : "GPT-5.3 Codex Spark",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
     "gpt-5.4" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -5602,7 +5381,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 1050000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
@@ -5635,7 +5414,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
@@ -5668,7 +5447,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 400000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0.02,
         "cacheWrite" : 0,
@@ -5701,7 +5480,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 1050000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -5734,9 +5513,9 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 1050000,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
         "input" : 5,
         "output" : 30
@@ -5767,7 +5546,7 @@
         "supportsOpenAIGrammarTools" : true,
         "supportsStrictMode" : true
       },
-      "contextWindow" : 1050000,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -5787,39 +5566,6 @@
         "high" : "high",
         "low" : null,
         "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "gpt-5.6" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsOpenAIGrammarTools" : true,
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
-      },
-      "id" : "gpt-5.6",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "GPT-5.6",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
         "medium" : "medium",
         "minimal" : null,
         "off" : null,
@@ -5877,10 +5623,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "gpt-5.6-sol",
       "input" : [
@@ -5941,70 +5687,6 @@
         "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
-      }
-    },
-    "o1" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 7.5,
-        "cacheWrite" : 0,
-        "input" : 15,
-        "output" : 60
-      },
-      "id" : "o1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o1",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "o1-pro" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 150,
-        "output" : 600
-      },
-      "id" : "o1-pro",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o1-pro",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
       }
     },
     "o3" : {
@@ -6070,38 +5752,6 @@
         "xhigh" : null
       }
     },
-    "o3-pro" : {
-      "api" : "openai-responses",
-      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 20,
-        "output" : 80
-      },
-      "id" : "o3-pro",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o3-pro",
-      "provider" : "cloudflare-ai-gateway",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "o4-mini" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/openai",
@@ -6132,6 +5782,80 @@
         "minimal" : null,
         "off" : null,
         "xhigh" : null
+      }
+    },
+    "workers-ai\/@cf\/deepseek-ai\/deepseek-v4-flash-0731" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.014,
+        "cacheWrite" : 0,
+        "input" : 0.44,
+        "output" : 1.32
+      },
+      "id" : "workers-ai\/@cf\/deepseek-ai\/deepseek-v4-flash-0731",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "DeepSeek V4 Flash 0731",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "workers-ai\/@cf\/deepseek-ai\/deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.043999999999999997,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "workers-ai\/@cf\/deepseek-ai\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
       }
     },
     "workers-ai\/@cf\/google\/gemma-4-26b-a4b-it" : {
@@ -6443,6 +6167,35 @@
       ],
       "maxTokens" : 32768,
       "name" : "Qwen3 30B A3b fp8",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
+    "workers-ai\/@cf\/qwen\/qwen3.8-27b" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.45,
+        "output" : 3.2
+      },
+      "id" : "workers-ai\/@cf\/qwen\/qwen3.8-27b",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Qwen3.8 27B",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
     },
@@ -7024,6 +6777,40 @@
       ],
       "maxTokens" : 384000,
       "name" : "DeepSeek V4 Flash",
+      "provider" : "deepseek",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "deepseek-v4-flash-vision-exp" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.deepseek.com",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.0028,
+        "cacheWrite" : 0,
+        "input" : 0.14,
+        "output" : 0.28
+      },
+      "id" : "deepseek-v4-flash-vision-exp",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Flash Vision Exp",
       "provider" : "deepseek",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -8580,17 +8367,17 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30,
+        "cacheRead" : 0.25,
+        "cacheWrite" : 3.125,
+        "input" : 2.5,
+        "output" : 15,
         "tiers" : [
           {
-            "cacheRead" : 1,
-            "cacheWrite" : 12.5,
-            "input" : 10,
+            "cacheRead" : 0.5,
+            "cacheWrite" : 6.25,
+            "input" : 5,
             "inputTokensAbove" : 272000,
-            "output" : 45
+            "output" : 22.5
           }
         ]
       },
@@ -9227,10 +9014,10 @@
       "baseUrl" : "https:\/\/generativelanguage.googleapis.com\/v1beta",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.15,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
-        "input" : 1.5,
-        "output" : 7.5
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "gemini-3.6-flash",
       "input" : [
@@ -9601,10 +9388,10 @@
       "baseUrl" : "https:\/\/{location}-aiplatform.googleapis.com",
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.15,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
-        "input" : 1.5,
-        "output" : 7.5
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "gemini-3.6-flash",
       "input" : [
@@ -11018,6 +10805,38 @@
         "xhigh" : "xhigh"
       }
     },
+    "Qwen\/Qwen3.8-27B" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.4,
+        "output" : 3
+      },
+      "id" : "Qwen\/Qwen3.8-27B",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Qwen3.8 27B",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "stepfun-ai\/Step-3.5-Flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/router.huggingface.co\/v1",
@@ -11328,6 +11147,29 @@
       ],
       "maxTokens" : 131072,
       "name" : "GLM-4.6",
+      "provider" : "huggingface",
+      "reasoning" : true
+    },
+    "zai-org\/GLM-4.6V-Flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.3,
+        "output" : 0.9
+      },
+      "id" : "zai-org\/GLM-4.6V-Flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 32768,
+      "name" : "GLM-4.6V-Flash",
       "provider" : "huggingface",
       "reasoning" : true
     },
@@ -12869,6 +12711,45 @@
     }
   },
   "nvidia" : {
+    "deepseek-ai\/deepseek-v4-flash-0731" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "NVCF-POLL-SECONDS" : "3600"
+      },
+      "id" : "deepseek-ai\/deepseek-v4-flash-0731",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Flash 0731",
+      "provider" : "nvidia",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
     "google\/gemma-3-4b-it" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -13203,6 +13084,37 @@
       ],
       "maxTokens" : 262144,
       "name" : "Kimi K2.6",
+      "provider" : "nvidia",
+      "reasoning" : true
+    },
+    "moonshotai\/kimi-k3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "NVCF-POLL-SECONDS" : "3600"
+      },
+      "id" : "moonshotai\/kimi-k3",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Kimi K3",
       "provider" : "nvidia",
       "reasoning" : true
     },
@@ -13748,67 +13660,6 @@
       ],
       "maxTokens" : 16384,
       "name" : "Step 3.7 Flash",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "thinkingmachines\/inkling" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "thinkingmachines\/inkling",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Inkling",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "z-ai\/glm-5.2" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "z-ai\/glm-5.2",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "GLM-5.2",
       "provider" : "nvidia",
       "reasoning" : true
     }
@@ -14727,17 +14578,17 @@
       },
       "contextWindow" : 272000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30,
+        "cacheRead" : 0.4,
+        "cacheWrite" : 5,
+        "input" : 4,
+        "output" : 20,
         "tiers" : [
           {
-            "cacheRead" : 1,
-            "cacheWrite" : 12.5,
-            "input" : 10,
+            "cacheRead" : 0.8,
+            "cacheWrite" : 10,
+            "input" : 8,
             "inputTokensAbove" : 272000,
-            "output" : 45
+            "output" : 30
           }
         ]
       },
@@ -15607,40 +15458,6 @@
         "xhigh" : null
       }
     },
-    "deepseek-v4-flash-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "requiresReasoningContentOnAssistantMessages" : true,
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "deepseek-v4-flash-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 128000,
-      "name" : "DeepSeek V4 Flash Free",
-      "provider" : "opencode",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "deepseek-v4-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -16469,10 +16286,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 6.25,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "gpt-5.6-sol",
       "input" : [
@@ -16480,7 +16297,7 @@
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "GPT-5.6 Sol",
+      "name" : "GPT-5.6 Sol (50% Off)",
       "provider" : "opencode",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -16534,7 +16351,7 @@
       },
       "contextWindow" : 500000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.3,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -16766,39 +16583,6 @@
         "xhigh" : null
       }
     },
-    "laguna-s-2.1-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "laguna-s-2.1-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32000,
-      "name" : "Laguna S 2.1 Free",
-      "provider" : "opencode",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "mimo-v2.5-free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -16930,6 +16714,38 @@
         "xhigh" : "xhigh"
       }
     },
+    "muse-spark-1.2-contributor-free" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "sessionAffinityFormat" : "openai-nosession"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "muse-spark-1.2-contributor-free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Spark 1.2 Free",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "nemotron-3-ultra-free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -17017,6 +16833,40 @@
       "name" : "Qwen3.6 Plus",
       "provider" : "opencode",
       "reasoning" : true
+    },
+    "x-preview-f-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "x-preview-f-free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Ox Alpha Free (Unlimited)",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     }
   },
   "opencode-go" : {
@@ -17043,6 +16893,40 @@
       ],
       "maxTokens" : 384000,
       "name" : "DeepSeek V4 Flash",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "deepseek-v4-flash-vision-exp" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.0070000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.22,
+        "output" : 0.66
+      },
+      "id" : "deepseek-v4-flash-vision-exp",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Flash Vision Exp",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -17184,10 +17068,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0.125,
-        "input" : 0.1,
-        "output" : 0.6
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "gpt-5.6-luna",
       "input" : [
@@ -17195,7 +17079,7 @@
         "image"
       ],
       "maxTokens" : 128000,
-      "name" : "GPT-5.6 Luna (2x usage)",
+      "name" : "GPT-5.6 Luna",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -17208,7 +17092,7 @@
         "xhigh" : "xhigh"
       }
     },
-    "grok-4.5" : {
+    "grok-4.6" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
       "compat" : {
@@ -17221,13 +17105,13 @@
         "input" : 2,
         "output" : 6
       },
-      "id" : "grok-4.5",
+      "id" : "grok-4.6",
       "input" : [
         "text",
         "image"
       ],
       "maxTokens" : 500000,
-      "name" : "Grok 4.5",
+      "name" : "Grok 4.6",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -17237,7 +17121,7 @@
         "medium" : "medium",
         "minimal" : null,
         "off" : null,
-        "xhigh" : null
+        "xhigh" : "xhigh"
       }
     },
     "hy3" : {
@@ -17250,17 +17134,17 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.0043750000000000004,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.58
+        "input" : 0.017500000000000002,
+        "output" : 0.072499999999999995
       },
       "id" : "hy3",
       "input" : [
         "text"
       ],
       "maxTokens" : 64000,
-      "name" : "Hy3",
+      "name" : "Hy3 (8x usage)",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -17365,6 +17249,30 @@
         "xhigh" : null
       }
     },
+    "longcat-2.0" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.0060000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.3,
+        "output" : 1.2
+      },
+      "id" : "longcat-2.0",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "LongCat-2.0",
+      "provider" : "opencode-go",
+      "reasoning" : true
+    },
     "mimo-v2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
@@ -17457,6 +17365,72 @@
       "name" : "MiniMax-M3",
       "provider" : "opencode-go",
       "reasoning" : true
+    },
+    "muse-spark-1.2-contributor" : {
+      "api" : "openai-responses",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "sessionAffinityFormat" : "openai-nosession"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.002,
+        "cacheWrite" : 0,
+        "input" : 0.1,
+        "output" : 0.2
+      },
+      "id" : "muse-spark-1.2-contributor",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Muse Spark 1.2 Contributor",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "ox-alpha-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "ox-alpha-free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Ox Alpha Free (Unlimited)",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "qwen3.6-plus" : {
       "api" : "openai-completions",
@@ -17583,7 +17557,16 @@
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Fable Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "~anthropic\/claude-haiku-latest" : {
       "api" : "openai-completions",
@@ -17633,7 +17616,16 @@
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Opus Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "~anthropic\/claude-sonnet-latest" : {
       "api" : "openai-completions",
@@ -17658,7 +17650,16 @@
       "maxTokens" : 128000,
       "name" : "Anthropic Claude Sonnet Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "~deepseek\/deepseek-v4-flash-latest" : {
       "api" : "openai-completions",
@@ -17668,18 +17669,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.015299999999999999,
+        "cacheRead" : 0.0070000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.076499999999999999,
-        "output" : 0.153
+        "input" : 0.029999999999999999,
+        "output" : 0.074999999999999997
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "DeepSeek V4 Flash Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -17689,6 +17690,7 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -17714,7 +17716,16 @@
       "maxTokens" : 65536,
       "name" : "Google Gemini Flash Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "~google\/gemini-pro-latest" : {
       "api" : "openai-completions",
@@ -17738,7 +17749,16 @@
       "maxTokens" : 65536,
       "name" : "Google Gemini Pro Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "~moonshotai\/kimi-latest" : {
       "api" : "openai-completions",
@@ -17747,12 +17767,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 974842,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.29,
+        "cacheRead" : 0.256,
         "cacheWrite" : 0,
-        "input" : 2.6,
-        "output" : 13
+        "input" : 2.55,
+        "output" : 12.75
       },
       "id" : "~moonshotai\/kimi-latest",
       "input" : [
@@ -17762,7 +17782,16 @@
       "maxTokens" : 131072,
       "name" : "MoonshotAI Kimi Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "~openai\/gpt-latest" : {
       "api" : "openai-completions",
@@ -17773,10 +17802,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "~openai\/gpt-latest",
       "input" : [
@@ -17786,7 +17815,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI GPT Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "~openai\/gpt-mini-latest" : {
       "api" : "openai-completions",
@@ -17810,7 +17848,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI GPT Mini Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "~x-ai\/grok-latest" : {
       "api" : "openai-completions",
@@ -17831,33 +17878,51 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 450000,
       "name" : "xAI: Grok Latest",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
-    "ai21\/jamba-large-1.7" : {
+    "~z-ai\/glm-latest" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
       "compat" : {
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
+        "input" : 1.4,
+        "output" : 4.4
       },
-      "id" : "ai21\/jamba-large-1.7",
+      "id" : "~z-ai\/glm-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
-      "name" : "AI21: Jamba Large 1.7",
+      "maxTokens" : 131072,
+      "name" : "Z.ai: GLM Latest",
       "provider" : "openrouter",
-      "reasoning" : false
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "aion-labs\/aion-2.0" : {
       "api" : "openai-completions",
@@ -17880,7 +17945,10 @@
       "maxTokens" : 32768,
       "name" : "AionLabs: Aion-2.0",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "aion-labs\/aion-3.0" : {
       "api" : "openai-completions",
@@ -17903,7 +17971,10 @@
       "maxTokens" : 32768,
       "name" : "AionLabs: Aion-3.0",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "aion-labs\/aion-3.0-mini" : {
       "api" : "openai-completions",
@@ -17926,7 +17997,10 @@
       "maxTokens" : 32768,
       "name" : "AionLabs: Aion-3.0-Mini",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "amazon\/nova-2-lite-v1" : {
       "api" : "openai-completions",
@@ -18095,7 +18169,11 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -18124,7 +18202,11 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
       }
@@ -18321,7 +18403,13 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "max" : "max"
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "anthropic\/claude-opus-4.6:batch" : {
@@ -18348,7 +18436,13 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "max" : "max"
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "anthropic\/claude-opus-4.7" : {
@@ -18375,7 +18469,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18403,7 +18502,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18431,7 +18535,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18459,7 +18568,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18487,7 +18601,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18515,7 +18634,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18543,7 +18667,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18571,7 +18700,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18599,7 +18733,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18699,7 +18838,13 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "max" : "max"
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "anthropic\/claude-sonnet-4.6:batch" : {
@@ -18726,7 +18871,13 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "max" : "max"
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "anthropic\/claude-sonnet-5" : {
@@ -18753,7 +18904,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18781,7 +18937,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -18803,10 +18964,13 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Arcee AI: Trinity Large Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "arcee-ai\/virtuoso-large" : {
       "api" : "openai-completions",
@@ -18922,7 +19086,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "ByteDance Seed: Seed 2.1 Turbo",
       "provider" : "openrouter",
       "reasoning" : true
@@ -18949,7 +19113,16 @@
       "maxTokens" : 131072,
       "name" : "ByteDance Seed: Seed-2.0-Code",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "bytedance-seed\/seed-2.0-lite" : {
       "api" : "openai-completions",
@@ -18973,7 +19146,16 @@
       "maxTokens" : 131072,
       "name" : "ByteDance Seed: Seed-2.0-Lite",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "bytedance-seed\/seed-2.0-mini" : {
       "api" : "openai-completions",
@@ -18997,7 +19179,16 @@
       "maxTokens" : 131072,
       "name" : "ByteDance Seed: Seed-2.0-Mini",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "cohere\/command-r-08-2024" : {
       "api" : "openai-completions",
@@ -19100,16 +19291,16 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.135,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.27,
-        "output" : 1.12
+        "input" : 0.25,
+        "output" : 1
       },
       "id" : "deepseek\/deepseek-chat-v3-0324",
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 147456,
       "name" : "DeepSeek: DeepSeek V3 0324",
       "provider" : "openrouter",
       "reasoning" : false
@@ -19121,18 +19312,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 163840,
+      "contextWindow" : 161000,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0.55,
         "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 0.95
+        "input" : 0.55,
+        "output" : 1.65
       },
       "id" : "deepseek\/deepseek-chat-v3.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 144900,
       "name" : "DeepSeek: DeepSeek V3.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19158,7 +19349,10 @@
       "maxTokens" : 16000,
       "name" : "DeepSeek: R1",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "deepseek\/deepseek-r1-0528" : {
       "api" : "openai-completions",
@@ -19181,7 +19375,10 @@
       "maxTokens" : 32768,
       "name" : "DeepSeek: R1 0528",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "deepseek\/deepseek-v3.1-terminus" : {
       "api" : "openai-completions",
@@ -19190,9 +19387,9 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 163840,
+      "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.135,
         "cacheWrite" : 0,
         "input" : 0.27,
         "output" : 1
@@ -19201,7 +19398,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 163840,
+      "maxTokens" : 32768,
       "name" : "DeepSeek: DeepSeek V3.1 Terminus",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19215,16 +19412,16 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.1345,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.269,
-        "output" : 0.4
+        "input" : 0.26,
+        "output" : 0.38
       },
       "id" : "deepseek\/deepseek-v3.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 147456,
       "name" : "DeepSeek: DeepSeek V3.2",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19262,10 +19459,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.014840000000000001,
+        "cacheRead" : 0.017721000000000001,
         "cacheWrite" : 0,
-        "input" : 0.074200000000000002,
-        "output" : 0.1484
+        "input" : 0.088606000000000004,
+        "output" : 0.177212
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -19281,6 +19478,7 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -19294,16 +19492,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.012,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
+        "input" : 0.059999999999999998,
+        "output" : 0.12
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
       "input" : [
         "text"
       ],
-      "maxTokens" : 393216,
+      "maxTokens" : 943718,
       "name" : "DeepSeek: DeepSeek V4 Flash 0731",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -19313,6 +19511,41 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek\/deepseek-v4-flash-vision-exp" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.0070000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.22,
+        "output" : 0.66
+      },
+      "id" : "deepseek\/deepseek-v4-flash-vision-exp",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek: DeepSeek V4 Flash Vision Exp",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -19324,12 +19557,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.021999999999999999,
+        "cacheRead" : 0.072499999999999995,
         "cacheWrite" : 0,
-        "input" : 0.66,
-        "output" : 1.98
+        "input" : 0.87,
+        "output" : 1.74
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
@@ -19345,6 +19578,7 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -19356,18 +19590,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1048575,
       "cost" : {
-        "cacheRead" : 0.021999999999999999,
+        "cacheRead" : 0.037400000000000003,
         "cacheWrite" : 0,
-        "input" : 0.66,
-        "output" : 1.98
+        "input" : 1.122,
+        "output" : 3.366
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
         "text"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 943717,
       "name" : "DeepSeek: DeepSeek V4 Pro 0813",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -19377,6 +19611,7 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -19399,7 +19634,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 512000,
+      "maxTokens" : 460800,
       "name" : "Dots Studio: Dots3-Note Preview (free)",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19522,7 +19757,10 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 2.5 Pro",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "google\/gemini-2.5-pro-preview" : {
       "api" : "openai-completions",
@@ -19546,7 +19784,10 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 2.5 Pro Preview 06-05",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "google\/gemini-2.5-pro-preview-05-06" : {
       "api" : "openai-completions",
@@ -19570,7 +19811,10 @@
       "maxTokens" : 65535,
       "name" : "Google: Gemini 2.5 Pro Preview 05-06",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "google\/gemini-2.5-pro:batch" : {
       "api" : "openai-completions",
@@ -19594,7 +19838,10 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 2.5 Pro (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "google\/gemini-3-flash-preview" : {
       "api" : "openai-completions",
@@ -19618,7 +19865,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3 Flash Preview",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "google\/gemini-3-flash-preview:batch" : {
       "api" : "openai-completions",
@@ -19642,7 +19898,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3 Flash Preview (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "google\/gemini-3-pro-image" : {
       "api" : "openai-completions",
@@ -19651,7 +19916,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 65536,
+      "contextWindow" : 131072,
       "cost" : {
         "cacheRead" : 0.2,
         "cacheWrite" : 0.375,
@@ -19666,7 +19931,10 @@
       "maxTokens" : 32768,
       "name" : "Google: Nano Banana Pro (Gemini 3 Pro Image)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "google\/gemini-3.1-flash-lite" : {
       "api" : "openai-completions",
@@ -19690,7 +19958,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Flash Lite",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.1-flash-lite-preview" : {
       "api" : "openai-completions",
@@ -19714,7 +19991,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Flash Lite Preview",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.1-flash-lite:batch" : {
       "api" : "openai-completions",
@@ -19738,7 +20024,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Flash Lite (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.1-pro-preview" : {
       "api" : "openai-completions",
@@ -19762,7 +20057,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Pro Preview",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.1-pro-preview-customtools" : {
       "api" : "openai-completions",
@@ -19786,7 +20090,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Pro Preview Custom Tools",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.1-pro-preview:batch" : {
       "api" : "openai-completions",
@@ -19810,7 +20123,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.1 Pro Preview (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.5-flash" : {
       "api" : "openai-completions",
@@ -19834,7 +20156,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.5 Flash",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.5-flash-lite" : {
       "api" : "openai-completions",
@@ -19858,7 +20189,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.5 Flash Lite",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.5-flash-lite:batch" : {
       "api" : "openai-completions",
@@ -19882,7 +20222,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.5 Flash Lite (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.5-flash:batch" : {
       "api" : "openai-completions",
@@ -19906,7 +20255,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.5 Flash (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.6-flash" : {
       "api" : "openai-completions",
@@ -19930,7 +20288,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.6 Flash",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.6-flash:batch" : {
       "api" : "openai-completions",
@@ -19954,7 +20321,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.6 Flash (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.7-flash" : {
       "api" : "openai-completions",
@@ -19978,7 +20354,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.7 Flash",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemini-3.7-flash:batch" : {
       "api" : "openai-completions",
@@ -19989,10 +20374,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0093749999999999997,
-        "cacheWrite" : 0.010416999999999999,
-        "input" : 0.09375,
-        "output" : 0.46875
+        "cacheRead" : 0.018749999999999999,
+        "cacheWrite" : 0.020833000000000001,
+        "input" : 0.1875,
+        "output" : 0.9375
       },
       "id" : "google\/gemini-3.7-flash:batch",
       "input" : [
@@ -20002,7 +20387,16 @@
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.7 Flash (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "google\/gemma-3-12b-it" : {
       "api" : "openai-completions",
@@ -20047,7 +20441,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "Google: Gemma 3 27B",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20109,9 +20503,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.1,
+        "input" : 0.089999999999999997,
         "output" : 0.34
       },
       "id" : "google\/gemma-4-31b-it",
@@ -20119,7 +20513,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 16384,
       "name" : "Google: Gemma 4 31B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -20166,7 +20560,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "IBM: Granite 4.1 8B",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20194,54 +20588,14 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
-        "off" : null
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
       }
-    },
-    "inclusionai\/ling-2.6-1t" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.014999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.625
-      },
-      "id" : "inclusionai\/ling-2.6-1t",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "inclusionAI: Ling-2.6-1T",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "inclusionai\/ling-2.6-flash" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.002,
-        "cacheWrite" : 0,
-        "input" : 0.01,
-        "output" : 0.029999999999999999
-      },
-      "id" : "inclusionai\/ling-2.6-flash",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "inclusionAI: Ling-2.6-flash",
-      "provider" : "openrouter",
-      "reasoning" : false
     },
     "inclusionai\/ling-3.0-flash" : {
       "api" : "openai-completions",
@@ -20263,29 +20617,6 @@
       ],
       "maxTokens" : 32768,
       "name" : "Ling-3.0-flash",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "inclusionai\/ring-2.6-1t" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.014999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.625
-      },
-      "id" : "inclusionai\/ring-2.6-1t",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 65536,
-      "name" : "inclusionAI: Ring-2.6-1T",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -20365,7 +20696,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 128000,
+      "contextWindow" : 65536,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -20379,7 +20710,10 @@
       "maxTokens" : 8192,
       "name" : "LiquidAI: LFM2.5-2.6B (free)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "meituan\/longcat-2.0" : {
       "api" : "openai-completions",
@@ -20422,7 +20756,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "Meta: Llama 3.1 8B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20457,18 +20791,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.71,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.32
+        "input" : 0.71,
+        "output" : 0.71
       },
       "id" : "meta-llama\/llama-3.3-70b-instruct",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 115200,
       "name" : "Meta: Llama 3.3 70B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20504,19 +20838,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 327680,
+      "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.055,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.3
+        "input" : 0.11,
+        "output" : 0.34
       },
       "id" : "meta-llama\/llama-4-scout",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 8192,
       "name" : "Meta: Llama 4 Scout",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20540,10 +20874,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 117964,
       "name" : "Meta: Muse Glimmer 30B",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "meta\/muse-spark-1.1" : {
       "api" : "openai-completions",
@@ -20564,10 +20907,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 943718,
       "name" : "Meta: Muse Spark 1.1",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "meta\/muse-spark-1.2" : {
       "api" : "openai-completions",
@@ -20588,10 +20940,52 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 943718,
       "name" : "Meta: Muse Spark 1.2",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "meta\/muse-spark-1.2-contributor" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.002,
+        "cacheWrite" : 0,
+        "input" : 0.1,
+        "output" : 0.2
+      },
+      "id" : "meta\/muse-spark-1.2-contributor",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 943718,
+      "name" : "Meta: Muse Spark 1.2 Contributor",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "minimax\/minimax-m1" : {
       "api" : "openai-completions",
@@ -20637,7 +21031,10 @@
       "maxTokens" : 131072,
       "name" : "MiniMax: MiniMax M2",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "minimax\/minimax-m2.1" : {
       "api" : "openai-completions",
@@ -20660,7 +21057,10 @@
       "maxTokens" : 131072,
       "name" : "MiniMax: MiniMax M2.1",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "minimax\/minimax-m2.5" : {
       "api" : "openai-completions",
@@ -20669,21 +21069,24 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 196608,
+      "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.027,
         "cacheWrite" : 0,
-        "input" : 0.22,
-        "output" : 0.9
+        "input" : 0.27,
+        "output" : 1.08
       },
       "id" : "minimax\/minimax-m2.5",
       "input" : [
         "text"
       ],
-      "maxTokens" : 196608,
+      "maxTokens" : 128000,
       "name" : "MiniMax: MiniMax M2.5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "minimax\/minimax-m2.7" : {
       "api" : "openai-completions",
@@ -20706,7 +21109,36 @@
       "maxTokens" : 131072,
       "name" : "MiniMax: MiniMax M2.7",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
+    },
+    "minimax\/minimax-m2.7:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 196608,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "minimax\/minimax-m2.7:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 176947,
+      "name" : "MiniMax: MiniMax M2.7 (free)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "minimax\/minimax-m3" : {
       "api" : "openai-completions",
@@ -20751,8 +21183,32 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 471859,
       "name" : "MiniMax: MiniMax M3 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "minimax\/minimax-m3:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "minimax\/minimax-m3:free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 943718,
+      "name" : "MiniMax: MiniMax M3 (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -20774,8 +21230,31 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 204800,
       "name" : "Mistral: Codestral 2508",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
+    "mistralai\/devstral-2512" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.043999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.44,
+        "output" : 2.2
+      },
+      "id" : "mistralai\/devstral-2512",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 209715,
+      "name" : "Mistral: Devstral 2 2512",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -20798,7 +21277,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 104857,
       "name" : "Mistral: Ministral 3 3B 2512",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20822,7 +21301,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 209715,
       "name" : "Mistral: Ministral 3 8B 2512",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20846,7 +21325,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 209715,
       "name" : "Mistral: Ministral 3 14B 2512",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20869,7 +21348,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 102400,
       "name" : "Mistral Large",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20892,7 +21371,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 104857,
       "name" : "Mistral Large 2407",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20916,7 +21395,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 209715,
       "name" : "Mistral: Mistral Large 3 2512",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20940,7 +21419,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 104857,
       "name" : "Mistral: Mistral Medium 3",
       "provider" : "openrouter",
       "reasoning" : false
@@ -20964,10 +21443,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 209715,
       "name" : "Mistral: Mistral Medium 3.5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "mistralai\/mistral-medium-3.1" : {
       "api" : "openai-completions",
@@ -20988,7 +21476,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 104857,
       "name" : "Mistral: Mistral Medium 3.1",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21034,7 +21522,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 26214,
       "name" : "Mistral: Saba",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21046,12 +21534,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 256000,
+      "contextWindow" : 128000,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.09375,
-        "output" : 0.25
+        "input" : 0.074999999999999997,
+        "output" : 0.2
       },
       "id" : "mistralai\/mistral-small-3.2-24b-instruct",
       "input" : [
@@ -21082,10 +21570,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 209715,
       "name" : "Mistral: Mistral Small 4",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "mistralai\/mixtral-8x22b-instruct" : {
       "api" : "openai-completions",
@@ -21105,7 +21602,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 52428,
       "name" : "Mistral: Mixtral 8x22B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21128,7 +21625,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 25600,
       "name" : "Mistral: Voxtral Small 24B 2507",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21200,7 +21697,10 @@
       "maxTokens" : 100352,
       "name" : "MoonshotAI: Kimi K2 Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "moonshotai\/kimi-k2.5" : {
       "api" : "openai-completions",
@@ -21246,7 +21746,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "MoonshotAI: Kimi K2.6",
       "provider" : "openrouter",
       "reasoning" : true
@@ -21260,20 +21760,23 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.15,
+        "cacheRead" : 0.19,
         "cacheWrite" : 0,
-        "input" : 0.71,
-        "output" : 3.5
+        "input" : 0.67,
+        "output" : 3.4
       },
       "id" : "moonshotai\/kimi-k2.7-code",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "MoonshotAI: Kimi K2.7 Code",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "moonshotai\/kimi-k2.7-code:batch" : {
       "api" : "openai-completions",
@@ -21294,10 +21797,13 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 235929,
       "name" : "MoonshotAI: Kimi K2.7 Code (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "moonshotai\/kimi-k3" : {
       "api" : "openai-completions",
@@ -21321,7 +21827,16 @@
       "maxTokens" : 131072,
       "name" : "MoonshotAI: Kimi K3",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nex-agi\/nex-n2-mini" : {
       "api" : "openai-completions",
@@ -21342,7 +21857,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Nex AGI: Nex-N2-Mini",
       "provider" : "openrouter",
       "reasoning" : true
@@ -21366,7 +21881,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Nex AGI: Nex-N2-Pro",
       "provider" : "openrouter",
       "reasoning" : true
@@ -21389,31 +21904,8 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "NVIDIA: Nemotron 3 Nano 30B A3B",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "nvidia\/nemotron-3-nano-30b-a3b:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "nvidia\/nemotron-3-nano-30b-a3b:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "NVIDIA: Nemotron 3 Nano 30B A3B (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -21462,7 +21954,16 @@
       "maxTokens" : 16384,
       "name" : "NVIDIA: Nemotron 3 Super",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nvidia\/nemotron-3-super-120b-a12b:free" : {
       "api" : "openai-completions",
@@ -21482,10 +21983,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "NVIDIA: Nemotron 3 Super (free)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nvidia\/nemotron-3-ultra-550b-a55b" : {
       "api" : "openai-completions",
@@ -21505,10 +22015,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 461059,
       "name" : "NVIDIA: Nemotron 3 Ultra",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nvidia\/nemotron-3-ultra-550b-a55b:batch" : {
       "api" : "openai-completions",
@@ -21528,10 +22047,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 461059,
       "name" : "NVIDIA: Nemotron 3 Ultra (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nvidia\/nemotron-3-ultra-550b-a55b:free" : {
       "api" : "openai-completions",
@@ -21554,7 +22082,16 @@
       "maxTokens" : 65536,
       "name" : "NVIDIA: Nemotron 3 Ultra (free)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "nvidia\/nemotron-3.5-lightning" : {
       "api" : "openai-completions",
@@ -21599,53 +22136,6 @@
       ],
       "maxTokens" : 65536,
       "name" : "NVIDIA: Nemotron 3.5 Lightning (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "nvidia\/nemotron-nano-9b-v2:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "nvidia\/nemotron-nano-9b-v2:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "NVIDIA: Nemotron Nano 9B V2 (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "nvidia\/nemotron-nano-12b-v2-vl:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "nvidia\/nemotron-nano-12b-v2-vl:free",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "NVIDIA: Nemotron Nano 12B 2 VL (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -21710,7 +22200,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 3685,
       "name" : "OpenAI: GPT-3.5 Turbo (older v0613)",
       "provider" : "openrouter",
       "reasoning" : false
@@ -22170,7 +22660,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-codex:batch" : {
       "api" : "openai-completions",
@@ -22193,7 +22692,10 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Codex (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "openai\/gpt-5-mini" : {
       "api" : "openai-completions",
@@ -22216,7 +22718,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Mini",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-mini:batch" : {
       "api" : "openai-completions",
@@ -22239,7 +22750,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Mini (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-nano" : {
       "api" : "openai-completions",
@@ -22262,7 +22782,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Nano",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-nano:batch" : {
       "api" : "openai-completions",
@@ -22285,7 +22814,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Nano (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-pro" : {
       "api" : "openai-completions",
@@ -22308,7 +22846,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Pro",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5-pro:batch" : {
       "api" : "openai-completions",
@@ -22331,7 +22878,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Pro (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5:batch" : {
       "api" : "openai-completions",
@@ -22354,7 +22910,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5.1" : {
       "api" : "openai-completions",
@@ -22377,7 +22942,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5.1-codex" : {
       "api" : "openai-completions",
@@ -22400,7 +22974,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1-Codex",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5.1-codex-max" : {
       "api" : "openai-completions",
@@ -22423,7 +23006,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1-Codex-Max",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "openai\/gpt-5.1-codex-mini" : {
       "api" : "openai-completions",
@@ -22446,7 +23038,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1-Codex-Mini",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5.1:batch" : {
       "api" : "openai-completions",
@@ -22469,7 +23070,16 @@
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1 (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "openai\/gpt-5.2" : {
       "api" : "openai-completions",
@@ -22494,6 +23104,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22546,6 +23162,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22572,6 +23194,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22598,6 +23226,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22624,6 +23258,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22650,6 +23290,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22676,6 +23322,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22702,6 +23354,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22728,6 +23386,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22754,6 +23418,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22780,6 +23450,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22806,6 +23482,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22832,6 +23514,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22858,6 +23546,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22884,6 +23578,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22910,7 +23610,10 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
         "low" : null,
+        "max" : null,
+        "medium" : "medium",
         "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
@@ -22939,6 +23642,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
         "xhigh" : "xhigh"
       }
     },
@@ -22965,6 +23674,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -22991,7 +23706,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23018,7 +23738,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23045,7 +23770,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23072,7 +23802,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23084,10 +23819,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "openai\/gpt-5.6-sol",
       "input" : [
@@ -23099,7 +23834,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23111,10 +23851,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "openai\/gpt-5.6-sol-pro",
       "input" : [
@@ -23126,7 +23866,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23138,10 +23883,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 7.5
+        "cacheRead" : 0.1,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 5
       },
       "id" : "openai\/gpt-5.6-sol-pro:batch",
       "input" : [
@@ -23153,7 +23898,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23165,10 +23915,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 7.5
+        "cacheRead" : 0.1,
+        "cacheWrite" : 1.25,
+        "input" : 1,
+        "output" : 5
       },
       "id" : "openai\/gpt-5.6-sol:batch",
       "input" : [
@@ -23180,7 +23930,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23207,7 +23962,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23234,7 +23994,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23261,7 +24026,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23288,7 +24058,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
         "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23376,32 +24151,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "OpenAI: gpt-oss-20b",
       "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/gpt-oss-20b:free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "openai\/gpt-oss-20b:free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "OpenAI: gpt-oss-20b (free)",
-      "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-oss-120b" : {
       "api" : "openai-completions",
@@ -23411,19 +24173,28 @@
       },
       "contextWindow" : 131072,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.029999999999999999,
+        "input" : 0.036999999999999998,
         "output" : 0.17
       },
       "id" : "openai\/gpt-oss-120b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "OpenAI: gpt-oss-120b",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/gpt-oss-safeguard-20b" : {
       "api" : "openai-completions",
@@ -23445,7 +24216,10 @@
       "maxTokens" : 65536,
       "name" : "OpenAI: gpt-oss-safeguard-20b",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "openai\/o1" : {
       "api" : "openai-completions",
@@ -23558,7 +24332,16 @@
       "maxTokens" : 100000,
       "name" : "OpenAI: o3 Mini High",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/o3-mini-high:batch" : {
       "api" : "openai-completions",
@@ -23580,7 +24363,16 @@
       "maxTokens" : 100000,
       "name" : "OpenAI: o3 Mini High (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/o3-mini:batch" : {
       "api" : "openai-completions",
@@ -23717,7 +24509,16 @@
       "maxTokens" : 100000,
       "name" : "OpenAI: o4 Mini High",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/o4-mini-high:batch" : {
       "api" : "openai-completions",
@@ -23740,7 +24541,16 @@
       "maxTokens" : 100000,
       "name" : "OpenAI: o4 Mini High (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "openai\/o4-mini:batch" : {
       "api" : "openai-completions",
@@ -23970,7 +24780,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 29491,
       "name" : "Qwen: Qwen2.5 7B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -24044,29 +24854,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "qwen\/qwen-plus-2025-07-28:thinking" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.26,
-        "output" : 0.78
-      },
-      "id" : "qwen\/qwen-plus-2025-07-28:thinking",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 32768,
-      "name" : "Qwen: Qwen Plus 0728 (thinking)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
     "qwen\/qwen3-8b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -24120,18 +24907,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 40960,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.13,
-        "output" : 0.52
+        "input" : 0.12,
+        "output" : 0.5
       },
       "id" : "qwen\/qwen3-30b-a3b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24180,7 +24967,10 @@
       "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 30B A3B Thinking 2507",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3-32b" : {
       "api" : "openai-completions",
@@ -24269,10 +25059,13 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 117964,
       "name" : "Qwen: Qwen3 235B A22B Thinking 2507",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3-coder" : {
       "api" : "openai-completions",
@@ -24315,7 +25108,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3 Coder 30B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -24361,7 +25154,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3 Coder Next",
       "provider" : "openrouter",
       "reasoning" : false
@@ -24453,7 +25246,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3 Next 80B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -24479,7 +25272,10 @@
       "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 Next 80B A3B Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3-vl-8b-instruct" : {
       "api" : "openai-completions",
@@ -24527,7 +25323,10 @@
       "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 VL 8B Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3-vl-30b-a3b-instruct" : {
       "api" : "openai-completions",
@@ -24575,7 +25374,10 @@
       "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 VL 30B A3B Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3-vl-32b-instruct" : {
       "api" : "openai-completions",
@@ -24647,7 +25449,10 @@
       "maxTokens" : 32768,
       "name" : "Qwen: Qwen3 VL 235B A22B Thinking",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "qwen\/qwen3.5-9b" : {
       "api" : "openai-completions",
@@ -24668,7 +25473,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3.5-9B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24706,17 +25511,17 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.225,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 0.225,
-        "output" : 1.8
+        "input" : 0.25,
+        "output" : 1.25
       },
       "id" : "qwen\/qwen3.5-35b-a3b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3.5-35B-A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24732,15 +25537,15 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.29,
-        "output" : 2.4
+        "input" : 0.26,
+        "output" : 2.08
       },
       "id" : "qwen\/qwen3.5-122b-a10b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 81920,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3.5-122B-A10B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24848,19 +25653,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.12,
         "cacheWrite" : 0,
-        "input" : 0.289,
-        "output" : 2.4
+        "input" : 0.6,
+        "output" : 3.6
       },
       "id" : "qwen\/qwen3.6-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3.6 27B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -24884,7 +25689,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3.6 35B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -25038,7 +25843,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1000000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
@@ -25049,10 +25854,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "Qwen: Qwen3.8 2.4T A95B",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "qwen\/qwen3.8-27b" : {
       "api" : "openai-completions",
@@ -25061,12 +25875,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.45,
-        "output" : 3.2
+        "cacheRead" : 0.085000000000000006,
+        "cacheWrite" : 0.53125,
+        "input" : 0.425,
+        "output" : 2.55
       },
       "id" : "qwen\/qwen3.8-27b",
       "input" : [
@@ -25076,7 +25890,16 @@
       "maxTokens" : 131072,
       "name" : "Qwen: Qwen3.8 27B",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "qwen\/qwen3.8-max" : {
       "api" : "openai-completions",
@@ -25100,7 +25923,16 @@
       "maxTokens" : 131072,
       "name" : "Qwen: Qwen3.8 Max",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "rekaai\/reka-edge" : {
       "api" : "openai-completions",
@@ -25121,7 +25953,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 14745,
       "name" : "Reka Edge",
       "provider" : "openrouter",
       "reasoning" : false
@@ -25171,7 +26003,16 @@
       "maxTokens" : 128000,
       "name" : "Sakana: Fugu Ultra",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "sakana\/sakana-namazu" : {
       "api" : "openai-completions",
@@ -25195,7 +26036,16 @@
       "maxTokens" : 65536,
       "name" : "Sakana: Sakana Namazu",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "sao10k\/l3.1-euryale-70b" : {
       "api" : "openai-completions",
@@ -25220,6 +26070,39 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "stealth\/ox-alpha" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "stealth\/ox-alpha",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Ox Alpha",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "stepfun\/step-3.5-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -25241,7 +26124,10 @@
       "maxTokens" : 65536,
       "name" : "StepFun: Step 3.5 Flash",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "stepfun\/step-3.7-flash" : {
       "api" : "openai-completions",
@@ -25262,10 +26148,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 256000,
+      "maxTokens" : 230400,
       "name" : "StepFun: Step 3.7 Flash",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "tencent\/hy3" : {
       "api" : "openai-completions",
@@ -25288,7 +26183,16 @@
       "maxTokens" : 128000,
       "name" : "Tencent: Hy3",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "tencent\/hy3-preview" : {
       "api" : "openai-completions",
@@ -25308,10 +26212,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 235929,
       "name" : "Tencent: Hy3 preview",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "thedrummer\/unslopnemo-12b" : {
       "api" : "openai-completions",
@@ -25320,7 +26233,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1024000,
+      "contextWindow" : 32768,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
@@ -25331,7 +26244,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 1024000,
+      "maxTokens" : 26214,
       "name" : "TheDrummer: UnslopNemo 12B",
       "provider" : "openrouter",
       "reasoning" : false
@@ -25358,7 +26271,16 @@
       "maxTokens" : 262144,
       "name" : "Thinking Machines: Inkling",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "thinkingmachines\/inkling-small" : {
       "api" : "openai-completions",
@@ -25382,7 +26304,49 @@
       "maxTokens" : 262144,
       "name" : "Thinking Machines: Inkling Small",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "thinkingmachines\/inkling-small:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "thinkingmachines\/inkling-small:free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Thinking Machines: Inkling Small (free)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "thinkingmachines\/inkling:batch" : {
       "api" : "openai-completions",
@@ -25403,10 +26367,52 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 471859,
       "name" : "Thinking Machines: Inkling (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "thinkingmachines\/inkling:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "thinkingmachines\/inkling:free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 262144,
+      "name" : "Thinking Machines: Inkling (free)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "upstage\/solar-pro-3" : {
       "api" : "openai-completions",
@@ -25426,7 +26432,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 117964,
       "name" : "Upstage: Solar Pro 3",
       "provider" : "openrouter",
       "reasoning" : true
@@ -25473,10 +26479,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 900000,
       "name" : "SpaceXAI: Grok 4.3",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "x-ai\/grok-4.5" : {
       "api" : "openai-completions",
@@ -25497,10 +26512,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 450000,
       "name" : "SpaceXAI: Grok 4.5",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "x-ai\/grok-4.6" : {
       "api" : "openai-completions",
@@ -25521,10 +26545,19 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 450000,
       "name" : "SpaceXAI: Grok 4.6",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     },
     "x-ai\/grok-4.20" : {
       "api" : "openai-completions",
@@ -25545,7 +26578,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 1800000,
       "name" : "SpaceXAI: Grok 4.20",
       "provider" : "openrouter",
       "reasoning" : true
@@ -25569,10 +26602,13 @@
         "text",
         "image"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 230400,
       "name" : "SpaceXAI: Grok Build 0.1",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "off" : null
+      }
     },
     "xiaomi\/mimo-v2.5" : {
       "api" : "openai-completions",
@@ -25837,18 +26873,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 200000,
+      "contextWindow" : 202752,
       "cost" : {
-        "cacheRead" : 0.1794,
+        "cacheRead" : 0.234,
         "cacheWrite" : 0,
-        "input" : 0.966,
-        "output" : 3.036
+        "input" : 1.26,
+        "output" : 3.96
       },
       "id" : "z-ai\/glm-5.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 182476,
       "name" : "Z.ai: GLM 5.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -25876,6 +26912,12 @@
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -25886,7 +26928,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 512000,
+      "contextWindow" : 1048575,
       "cost" : {
         "cacheRead" : 0.26,
         "cacheWrite" : 0,
@@ -25897,10 +26939,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 4096,
+      "maxTokens" : 943717,
       "name" : "Z.ai: GLM 5.2 (batch)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "z-ai\/glm-5.2:free" : {
       "api" : "openai-completions",
@@ -25920,10 +26971,19 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 256000,
+      "maxTokens" : 230400,
       "name" : "Z.ai: GLM 5.2 (free)",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
     },
     "z-ai\/glm-5.3" : {
       "api" : "openai-completions",
@@ -25946,7 +27006,16 @@
       "maxTokens" : 131072,
       "name" : "Z.ai: GLM 5.3",
       "provider" : "openrouter",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "z-ai\/glm-5v-turbo" : {
       "api" : "openai-completions",
@@ -28342,7 +29411,8 @@
       },
       "id" : "alibaba\/qwen3.8-2.4t-a95b",
       "input" : [
-        "text"
+        "text",
+        "image"
       ],
       "maxTokens" : 131072,
       "name" : "Qwen3.8 2.4T A95B",
@@ -28352,19 +29422,19 @@
     "alibaba\/qwen3.8-27b" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 262144,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.01,
+        "cacheRead" : 0.11,
         "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.4
+        "input" : 0.55,
+        "output" : 3.3
       },
       "id" : "alibaba\/qwen3.8-27b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 262133,
+      "maxTokens" : 131072,
       "name" : "Qwen3.8 27B",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -28854,25 +29924,6 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
-    "arcee-ai\/trinity-mini" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.044999999999999998,
-        "output" : 0.15
-      },
-      "id" : "arcee-ai\/trinity-mini",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Trinity Mini",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
     "bytedance\/seed-1.6" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29070,10 +30121,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.014,
         "cacheWrite" : 0,
-        "input" : 0.13,
-        "output" : 0.26
+        "input" : 0.075999999999999998,
+        "output" : 0.153
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
       "input" : [
@@ -29081,6 +30132,26 @@
       ],
       "maxTokens" : 384000,
       "name" : "DeepSeek V4 Flash 0731",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "deepseek\/deepseek-v4-flash-vision-exp" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.0070000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.22,
+        "output" : 0.66
+      },
+      "id" : "deepseek\/deepseek-v4-flash-vision-exp",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Flash Vision Exp",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -29108,10 +30179,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.132,
+        "cacheRead" : 0.066000000000000003,
         "cacheWrite" : 0,
-        "input" : 1.32,
-        "output" : 3.96
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
@@ -29808,6 +30879,25 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "minimax\/minimax-m2.7-free" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 196608,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "minimax\/minimax-m2.7-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 196608,
+      "name" : "Minimax M2.7 (Free)",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "minimax\/minimax-m2.7-highspeed" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -29844,6 +30934,26 @@
       ],
       "maxTokens" : 1000000,
       "name" : "MiniMax M3",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "minimax\/minimax-m3-free" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "minimax\/minimax-m3-free",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "MiniMax M3 (Free)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -29904,46 +31014,6 @@
       "name" : "Devstral Small 2",
       "provider" : "vercel-ai-gateway",
       "reasoning" : false
-    },
-    "mistral\/magistral-medium" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 5
-      },
-      "id" : "mistral\/magistral-medium",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Magistral Medium 2509",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "mistral\/magistral-small" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 1.5
-      },
-      "id" : "mistral\/magistral-small",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Magistral Small 2509",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
     },
     "mistral\/ministral-3b" : {
       "api" : "anthropic-messages",
@@ -30345,10 +31415,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.01,
+        "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
-        "output" : 0.2
+        "output" : 0.15
       },
       "id" : "nvidia\/nemotron-3.5-lightning",
       "input" : [
@@ -31276,10 +32346,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10
       },
       "id" : "openai\/gpt-5.6-sol",
       "input" : [
@@ -31299,10 +32369,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 3.125,
-        "input" : 5,
-        "output" : 30
+        "cacheRead" : 0.4,
+        "cacheWrite" : 2.5,
+        "input" : 4,
+        "output" : 20
       },
       "id" : "openai\/gpt-5.6-sol-fast",
       "input" : [
@@ -31404,19 +32474,38 @@
     "openai\/gpt-oss-safeguard-20b" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 131072,
+      "contextWindow" : 128000,
       "cost" : {
-        "cacheRead" : 0.036999999999999998,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.3
+        "input" : 0.070000000000000007,
+        "output" : 0.2
       },
       "id" : "openai\/gpt-oss-safeguard-20b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 65536,
+      "maxTokens" : 16000,
       "name" : "GPT OSS Safeguard 20B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "openai\/gpt-oss-safeguard-120b" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 128000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.6
+      },
+      "id" : "openai\/gpt-oss-safeguard-120b",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 16000,
+      "name" : "GPT OSS Safeguard 120B",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -31457,26 +32546,6 @@
       ],
       "maxTokens" : 100000,
       "name" : "o3",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "openai\/o3-deep-research" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 2.5,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 40
-      },
-      "id" : "openai\/o3-deep-research",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "o3-deep-research",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -31657,6 +32726,246 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "spacexai\/grok-4.1-fast-non-reasoning" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 0.5
+      },
+      "id" : "spacexai\/grok-4.1-fast-non-reasoning",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1000000,
+      "name" : "Grok 4.1 Fast Non-Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
+    "spacexai\/grok-4.1-fast-reasoning" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.2,
+        "output" : 0.5
+      },
+      "id" : "spacexai\/grok-4.1-fast-reasoning",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1000000,
+      "name" : "Grok 4.1 Fast Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.3" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.3",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1000000,
+      "name" : "Grok 4.3",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.5" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.3,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "spacexai\/grok-4.5",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.5",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.6" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 500000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "spacexai\/grok-4.6",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 500000,
+      "name" : "Grok 4.6",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.20-multi-agent" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-multi-agent",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Multi-Agent",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.20-multi-agent-beta" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-multi-agent-beta",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Multi Agent Beta",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.20-non-reasoning" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-non-reasoning",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Non-Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
+    "spacexai\/grok-4.20-non-reasoning-beta" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-non-reasoning-beta",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Beta Non-Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : false
+    },
+    "spacexai\/grok-4.20-reasoning" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-reasoning",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-4.20-reasoning-beta" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 2000000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1.25,
+        "output" : 2.5
+      },
+      "id" : "spacexai\/grok-4.20-reasoning-beta",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 2000000,
+      "name" : "Grok 4.20 Beta Reasoning",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "spacexai\/grok-build-0.1" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0.2,
+        "cacheWrite" : 0,
+        "input" : 1,
+        "output" : 2
+      },
+      "id" : "spacexai\/grok-build-0.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 256000,
+      "name" : "Grok Build 0.1",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "stepfun\/step-3.5-flash" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -31700,18 +33009,18 @@
     "tencent\/hy3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 262144,
+      "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.033000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.58
+        "input" : 0.132,
+        "output" : 0.528
       },
       "id" : "tencent\/hy3",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 128000,
       "name" : "Hy3",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -31753,246 +33062,6 @@
       ],
       "maxTokens" : 1000000,
       "name" : "Inkling Small",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.1-fast-non-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.2,
-        "output" : 0.5
-      },
-      "id" : "xai\/grok-4.1-fast-non-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 1000000,
-      "name" : "Grok 4.1 Fast Non-Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-4.1-fast-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.2,
-        "output" : 0.5
-      },
-      "id" : "xai\/grok-4.1-fast-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 1000000,
-      "name" : "Grok 4.1 Fast Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.3" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.3",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 1000000,
-      "name" : "Grok 4.3",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.5" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 500000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
-      },
-      "id" : "xai\/grok-4.5",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 500000,
-      "name" : "Grok 4.5",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.6" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 500000,
-      "cost" : {
-        "cacheRead" : 0.5,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 6
-      },
-      "id" : "xai\/grok-4.6",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 500000,
-      "name" : "Grok 4.6",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.20-multi-agent" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-multi-agent",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Multi-Agent",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.20-multi-agent-beta" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-multi-agent-beta",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Multi Agent Beta",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.20-non-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-non-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Non-Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-4.20-non-reasoning-beta" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-non-reasoning-beta",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Beta Non-Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
-    "xai\/grok-4.20-reasoning" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-reasoning",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-4.20-reasoning-beta" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 2000000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 2.5
-      },
-      "id" : "xai\/grok-4.20-reasoning-beta",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 2000000,
-      "name" : "Grok 4.20 Beta Reasoning",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "xai\/grok-build-0.1" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.2,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 2
-      },
-      "id" : "xai\/grok-build-0.1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 256000,
-      "name" : "Grok Build 0.1",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -32109,46 +33178,6 @@
       ],
       "maxTokens" : 96000,
       "name" : "GLM 4.6",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "zai\/glm-4.6v" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 0.9
-      },
-      "id" : "zai\/glm-4.6v",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 24000,
-      "name" : "GLM-4.6V",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : true
-    },
-    "zai\/glm-4.6v-flash" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "zai\/glm-4.6v-flash",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 24000,
-      "name" : "GLM-4.6V-Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -32271,10 +33300,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.275,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
-        "input" : 1.1,
-        "output" : 3.851
+        "input" : 0.8,
+        "output" : 2.55
       },
       "id" : "zai\/glm-5.2",
       "input" : [
@@ -32771,10 +33800,12 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : "high",
+        "low" : null,
         "max" : "max",
-        "medium" : "high",
-        "minimal" : null
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "glm-5.2-highspeed" : {
@@ -32783,7 +33814,7 @@
       "compat" : {
         "maxTokensField" : "max_tokens",
         "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
+        "supportsReasoningEffort" : true,
         "supportsStore" : false,
         "thinkingFormat" : "zai",
         "zaiToolStream" : true
@@ -32802,7 +33833,16 @@
       "maxTokens" : 131072,
       "name" : "GLM-5.2 Highspeed",
       "provider" : "zai",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "glm-5.3" : {
       "api" : "openai-completions",
@@ -32810,17 +33850,17 @@
       "compat" : {
         "maxTokensField" : "max_tokens",
         "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
+        "supportsReasoningEffort" : true,
         "supportsStore" : false,
         "thinkingFormat" : "zai",
         "zaiToolStream" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.3",
       "input" : [
@@ -32829,7 +33869,16 @@
       "maxTokens" : 131072,
       "name" : "GLM-5.3",
       "provider" : "zai",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     }
   },
   "zai-coding-cn" : {
@@ -32970,10 +34019,12 @@
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
-        "low" : "high",
+        "low" : null,
         "max" : "max",
-        "medium" : "high",
-        "minimal" : null
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
       }
     },
     "glm-5.2-highspeed" : {
@@ -32982,7 +34033,7 @@
       "compat" : {
         "maxTokensField" : "max_tokens",
         "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
+        "supportsReasoningEffort" : true,
         "supportsStore" : false,
         "thinkingFormat" : "zai",
         "zaiToolStream" : true
@@ -33001,7 +34052,16 @@
       "maxTokens" : 131072,
       "name" : "GLM-5.2 Highspeed",
       "provider" : "zai-coding-cn",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
     },
     "glm-5.3" : {
       "api" : "openai-completions",
@@ -33009,17 +34069,17 @@
       "compat" : {
         "maxTokensField" : "max_tokens",
         "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
+        "supportsReasoningEffort" : true,
         "supportsStore" : false,
         "thinkingFormat" : "zai",
         "zaiToolStream" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
+        "input" : 1.4,
+        "output" : 4.4
       },
       "id" : "glm-5.3",
       "input" : [
@@ -33028,7 +34088,16 @@
       "maxTokens" : 131072,
       "name" : "GLM-5.3",
       "provider" : "zai-coding-cn",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "glm-5v-turbo" : {
       "api" : "openai-completions",


### PR DESCRIPTION
## Summary

- refresh `models.json` from authoritative `badlogic/pi-mono` main commit `8fa7eebd235355522c8104166b4f1f959b4e2f10`
- add 41 models and remove 45 models (1,300 total across 39 providers)
- update metadata for 246 models, primarily thinking-level maps, token limits, pricing, and context windows
- regenerate Cursor GetUsableModels catalog; it remains unchanged at 198 models

Additions are concentrated in Vercel AI Gateway (16), OpenRouter (9), opencode-go (5), Cloudflare AI Gateway (3), NVIDIA (2), Hugging Face (2), opencode (2), Amazon Bedrock (1), and DeepSeek (1). Removals are concentrated in Vercel AI Gateway (18), Cloudflare AI Gateway (13), OpenRouter (9), NVIDIA (2), opencode (2), and opencode-go (1).

## Validation

- JSON parsed successfully with `jq`
- `git diff --check`
- private/localhost endpoint and credential-pattern scans
- `swift test --filter GenerateModelsCoreTests` (5 tests)
- `swift test --filter CursorProtoTests` (31 tests)
- `swift test` (1,355 tests / 198 suites)
