### PR TITLE
chore: release v0.1.48

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.47"
+    static let version = "0.1.48"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
## Summary

- bump the embedded kwwk version from `0.1.47` to `0.1.48`
- include the refreshed bundled model catalog merged in #124

## Validation

- `git diff --check`
- `swift build -c release --product kwwk`
- release binary `--self-test` (`resources: ok`)
