### PR TITLE
Forward tool-result images through the Responses provider

### DIFF
--- a/Sources/KWWKAI/OpenAIResponsesProvider.swift
+++ b/Sources/KWWKAI/OpenAIResponsesProvider.swift
@@ -941,11 +941,37 @@ public final class OpenAIResponsesProvider: APIProvider, APIProviderSessionLifec
                 let text = tr.content.compactMap { block -> String? in
                     if case .text(let t) = block { return t.text } else { return nil }
                 }.joined(separator: "\n")
+                let imageParts: [JSONValue] = model.input.contains(.image)
+                    ? tr.content.compactMap { block in
+                        guard case .image(let i) = block else { return nil }
+                        return .object([
+                            "type": .string("input_image"),
+                            "image_url": .string("data:\(i.mimeType);base64,\(i.data)"),
+                        ])
+                    }
+                    : []
                 out.append(.object([
                     "type": .string("function_call_output"),
                     "call_id": .string(tr.toolCallId),
-                    "output": .string(text),
+                    "output": .string(text.isEmpty && !imageParts.isEmpty ? "(see attached image)" : text),
                 ]))
+                // `function_call_output.output` is a plain string on every
+                // Responses-compatible endpoint we speak to (OpenAI, Codex,
+                // OpenRouter), so tool-result images ride on a user message
+                // right after the output — the same carrier the Completions
+                // provider uses. Without this the model only ever saw the
+                // "[image/webp, 1254x1254, ...]" note and went looking for OCR.
+                if !imageParts.isEmpty {
+                    var carrier: [JSONValue] = [
+                        .object(["type": .string("input_text"), "text": .string("Attached image(s) from tool result:")]),
+                    ]
+                    carrier.append(contentsOf: imageParts)
+                    out.append(.object([
+                        "type": .string("message"),
+                        "role": .string("user"),
+                        "content": .array(carrier),
+                    ]))
+                }
             }
         }
         return out

--- a/Tests/KWWKAITests/OpenAIResponsesTests.swift
+++ b/Tests/KWWKAITests/OpenAIResponsesTests.swift
@@ -524,6 +524,53 @@ struct OpenAIResponsesTests {
         #expect(input?[2]["call_id"] as? String == "call_1")
     }
 
+    @Test("forwards tool_result images on a user message after function_call_output")
+    func toolResultImageEncoding() async throws {
+        let client = StubSSEClient(body: Self.textSSE)
+        let provider = OpenAIResponsesProvider(client: client, webSocketClient: nil, defaultAPIKey: "k")
+        let assistant = AssistantMessage(
+            content: [.toolCall(ToolCall(id: "call_1", name: "read", arguments: ["path": "a.png"]))],
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5",
+            stopReason: .toolUse
+        )
+        let context = Context(messages: [
+            .user(UserMessage(text: "look")),
+            .assistant(assistant),
+            .toolResult(ToolResultMessage(
+                toolCallId: "call_1",
+                toolName: "read",
+                content: [
+                    .text(TextContent(text: "Read image file [image/png, 1x1, 3 bytes]")),
+                    .image(ImageContent(data: "QUJD", mimeType: "image/png")),
+                ]
+            )),
+        ])
+        let s1 = provider.stream(model: Self.model, context: context, options: nil)
+        for await _ in s1 {}
+        let req = try #require(client.lastRequest?.body)
+        let json = try JSONSerialization.jsonObject(with: req) as? [String: Any]
+        let input = json?["input"] as? [[String: Any]]
+        #expect(input?.count == 4)
+        #expect(input?[2]["type"] as? String == "function_call_output")
+        #expect(input?[2]["output"] as? String == "Read image file [image/png, 1x1, 3 bytes]")
+        #expect(input?[3]["role"] as? String == "user")
+        let parts = input?[3]["content"] as? [[String: Any]]
+        #expect(parts?.count == 2)
+        #expect(parts?[1]["type"] as? String == "input_image")
+        #expect(parts?[1]["image_url"] as? String == "data:image/png;base64,QUJD")
+
+        // A model without image input keeps the plain function_call_output only.
+        var textOnly = Self.model
+        textOnly.input = [.text]
+        let s2 = provider.stream(model: textOnly, context: context, options: nil)
+        for await _ in s2 {}
+        let req2 = try #require(client.lastRequest?.body)
+        let json2 = try JSONSerialization.jsonObject(with: req2) as? [String: Any]
+        #expect((json2?["input"] as? [[String: Any]])?.count == 3)
+    }
+
     @Test("reports upstream error event as terminal stream error")
     func providerError() async throws {
         let errorSSE = """


### PR DESCRIPTION
## Problem

`OpenAIResponsesProvider.encodeInput` turned a tool result into `function_call_output` by joining only its text blocks — every `.image` block was dropped. The `read` tool returns `[text note, image]` for image files, so any Responses-backed model (`openai`, `openai-codex` / `chatgpt-codex`) only saw `Read image file [image/webp, 1254x1254, 5460 bytes]` and had no way to actually look at the picture (observed in AirBuild: the Developer agent tried to OCR the file instead).

The Completions provider already handled this by attaching tool images to a user message right after the tool message; the Responses provider never got the equivalent.

## Fix

- After `function_call_output`, when the model has `.image` input and the result carries images, append a `message`/`user` item with `Attached image(s) from tool result:` + `input_image` parts (same carrier as Completions).
- An image-only result gets `(see attached image)` as its `output` instead of an empty string.
- Models without image input keep the plain `function_call_output` (the `downgradeUnsupportedImages` pass has already replaced the blocks with a placeholder by then).

## Tests

New `toolResultImageEncoding` test covers both the image-capable and text-only model paths. `swift test --filter KWWKAITests`: 415 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2H1pfB2rszqe5nea8LtTn