### PR TITLE
chore(kwwk): bump version to 0.1.49

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.48"
+    static let version = "0.1.49"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Version bump for v0.1.49 — carries #126 (Responses provider forwards tool-result images).