### PR TITLE
chore(kwwk): refresh model catalog

### DIFF
--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -1049,15 +1049,12 @@
     "global.openai.gpt-5.6-luna" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.021999999999999999,
-        "cacheWrite" : 0.275,
-        "input" : 0.22,
-        "output" : 1.32
+        "cacheRead" : 0.02,
+        "cacheWrite" : 0.25,
+        "input" : 0.2,
+        "output" : 1.2
       },
       "id" : "global.openai.gpt-5.6-luna",
       "input" : [
@@ -1075,15 +1072,12 @@
     "global.openai.gpt-5.6-sol" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.55,
-        "cacheWrite" : 6.875,
-        "input" : 5.5,
-        "output" : 33
+        "cacheRead" : 0.4,
+        "cacheWrite" : 5,
+        "input" : 4,
+        "output" : 20
       },
       "id" : "global.openai.gpt-5.6-sol",
       "input" : [
@@ -1101,15 +1095,12 @@
     "global.openai.gpt-5.6-terra" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
-      "compat" : {
-        "supportsStrictMode" : true
-      },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.22,
-        "cacheWrite" : 2.75,
-        "input" : 2.2,
-        "output" : 13.2
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 12
       },
       "id" : "global.openai.gpt-5.6-terra",
       "input" : [
@@ -1911,10 +1902,10 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.55,
-        "cacheWrite" : 6.875,
-        "input" : 5.5,
-        "output" : 33
+        "cacheRead" : 0.44,
+        "cacheWrite" : 5.5,
+        "input" : 4.4,
+        "output" : 22
       },
       "id" : "openai.gpt-5.6-sol",
       "input" : [
@@ -4790,6 +4781,83 @@
         "off" : "none",
         "xhigh" : null
       }
+    },
+    "zai-org\/GLM-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/inference.baseten.co\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "supportsStrictMode" : true,
+        "supportsUsageInStreaming" : true,
+        "thinkingFormat" : "openai"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.14,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "zai-org\/GLM-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "GLM 5.3",
+      "provider" : "baseten",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "zai-org\/GLM-5.3-Flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/inference.baseten.co\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "supportsStrictMode" : true,
+        "supportsUsageInStreaming" : true,
+        "thinkingFormat" : "openai"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "zai-org\/GLM-5.3-Flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM 5.3 Flash",
+      "provider" : "baseten",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     }
   },
   "cerebras" : {
@@ -6254,6 +6322,63 @@
       "name" : "Glm 5.2",
       "provider" : "cloudflare-ai-gateway",
       "reasoning" : true
+    },
+    "workers-ai\/@cf\/zai-org\/glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "workers-ai\/@cf\/zai-org\/glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1310720,
+      "name" : "Glm 5.3",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
+    },
+    "workers-ai\/@cf\/zai-org\/glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/gateway.ai.cloudflare.com\/v1\/{CLOUDFLARE_ACCOUNT_ID}\/{CLOUDFLARE_GATEWAY_ID}\/compat",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "workers-ai\/@cf\/zai-org\/glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "Glm 5.3 Flash",
+      "provider" : "cloudflare-ai-gateway",
+      "reasoning" : true
     }
   },
   "cloudflare-workers-ai" : {
@@ -6751,6 +6876,66 @@
         "off" : null,
         "xhigh" : null
       }
+    },
+    "@cf\/zai-org\/glm-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "@cf\/zai-org\/glm-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 1310720,
+      "name" : "Glm 5.3",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "@cf\/zai-org\/glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.cloudflare.com\/client\/v4\/accounts\/{CLOUDFLARE_ACCOUNT_ID}\/ai\/v1",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1310720,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "@cf\/zai-org\/glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 1048576,
+      "name" : "Glm 5.3 Flash",
+      "provider" : "cloudflare-workers-ai",
+      "reasoning" : true
     }
   },
   "deepseek" : {
@@ -6856,31 +7041,6 @@
     }
   },
   "fireworks" : {
-    "accounts\/fireworks\/models\/deepseek-v4-flash" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.028000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
-      },
-      "id" : "accounts\/fireworks\/models\/deepseek-v4-flash",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 384000,
-      "name" : "DeepSeek V4 Flash",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
     "accounts\/fireworks\/models\/deepseek-v4-flash-0731" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
@@ -6903,31 +7063,6 @@
       ],
       "maxTokens" : 384000,
       "name" : "DeepSeek V4 Flash 0731",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/models\/deepseek-v4-pro" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0.145,
-        "cacheWrite" : 0,
-        "input" : 1.74,
-        "output" : 3.48
-      },
-      "id" : "accounts\/fireworks\/models\/deepseek-v4-pro",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 384000,
-      "name" : "DeepSeek V4 Pro",
       "provider" : "fireworks",
       "reasoning" : true
     },
@@ -6990,7 +7125,7 @@
         "xhigh" : null
       }
     },
-    "accounts\/fireworks\/models\/gpt-oss-20b" : {
+    "accounts\/fireworks\/models\/glm-5p3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
       "compat" : {
@@ -6999,19 +7134,45 @@
         "supportsEagerToolInputStreaming" : false,
         "supportsLongCacheRetention" : false
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.035000000000000003,
+        "cacheRead" : 0.26,
         "cacheWrite" : 0,
-        "input" : 0.070000000000000007,
-        "output" : 0.3
+        "input" : 1.4,
+        "output" : 4.4
       },
-      "id" : "accounts\/fireworks\/models\/gpt-oss-20b",
+      "id" : "accounts\/fireworks\/models\/glm-5p3",
       "input" : [
         "text"
       ],
-      "maxTokens" : 32768,
-      "name" : "GPT OSS 20B",
+      "maxTokens" : 131072,
+      "name" : "GLM 5.3",
+      "provider" : "fireworks",
+      "reasoning" : true
+    },
+    "accounts\/fireworks\/models\/glm-5p3-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "compat" : {
+        "sendSessionAffinityHeaders" : true,
+        "supportsCacheControlOnTools" : false,
+        "supportsEagerToolInputStreaming" : false,
+        "supportsLongCacheRetention" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.029000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "accounts\/fireworks\/models\/glm-5p3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM 5.3 Flash",
       "provider" : "fireworks",
       "reasoning" : true
     },
@@ -7155,31 +7316,6 @@
         "off" : null,
         "xhigh" : null
       }
-    },
-    "accounts\/fireworks\/models\/minimax-m2p7" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 196608,
-      "cost" : {
-        "cacheRead" : 0.059999999999999998,
-        "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 1.2
-      },
-      "id" : "accounts\/fireworks\/models\/minimax-m2p7",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 196608,
-      "name" : "MiniMax-M2.7",
-      "provider" : "fireworks",
-      "reasoning" : true
     },
     "accounts\/fireworks\/models\/minimax-m3" : {
       "api" : "anthropic-messages",
@@ -7367,84 +7503,6 @@
         "off" : "none",
         "xhigh" : null
       }
-    },
-    "accounts\/fireworks\/routers\/kimi-k2p6-fast" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 262000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
-      },
-      "id" : "accounts\/fireworks\/routers\/kimi-k2p6-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 262000,
-      "name" : "Kimi K2.6 Fast",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/routers\/kimi-k2p6-turbo" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 262000,
-      "cost" : {
-        "cacheRead" : 0.3,
-        "cacheWrite" : 0,
-        "input" : 2,
-        "output" : 8
-      },
-      "id" : "accounts\/fireworks\/routers\/kimi-k2p6-turbo",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 262000,
-      "name" : "Kimi K2.6 Turbo",
-      "provider" : "fireworks",
-      "reasoning" : true
-    },
-    "accounts\/fireworks\/routers\/kimi-k2p7-code-fast" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
-      "compat" : {
-        "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
-      },
-      "contextWindow" : 262000,
-      "cost" : {
-        "cacheRead" : 0.38,
-        "cacheWrite" : 0,
-        "input" : 1.9,
-        "output" : 8
-      },
-      "id" : "accounts\/fireworks\/routers\/kimi-k2p7-code-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 262000,
-      "name" : "Kimi K2.7 Code Fast",
-      "provider" : "fireworks",
-      "reasoning" : true
     },
     "accounts\/fireworks\/routers\/kimi-k3-fast" : {
       "api" : "openai-completions",
@@ -7919,10 +7977,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.15,
+        "cacheRead" : 0.074999999999999997,
         "cacheWrite" : 0,
-        "input" : 1.5,
-        "output" : 7.5
+        "input" : 0.75,
+        "output" : 3.75
       },
       "headers" : {
         "Copilot-Integration-Id" : "vscode-chat",
@@ -8321,13 +8379,13 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.02,
-        "cacheWrite" : 0,
+        "cacheWrite" : 0.25,
         "input" : 0.2,
         "output" : 1.2,
         "tiers" : [
           {
             "cacheRead" : 0.040000000000000001,
-            "cacheWrite" : 0,
+            "cacheWrite" : 0.5,
             "input" : 0.4,
             "inputTokensAbove" : 200000,
             "output" : 1.8
@@ -8367,17 +8425,17 @@
       },
       "contextWindow" : 1050000,
       "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 3.125,
-        "input" : 2.5,
-        "output" : 15,
+        "cacheRead" : 0.2,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 10,
         "tiers" : [
           {
-            "cacheRead" : 0.5,
-            "cacheWrite" : 6.25,
-            "input" : 5,
+            "cacheRead" : 0.4,
+            "cacheWrite" : 5,
+            "input" : 4,
             "inputTokensAbove" : 272000,
-            "output" : 22.5
+            "output" : 15
           }
         ]
       },
@@ -8415,13 +8473,13 @@
       "contextWindow" : 1050000,
       "cost" : {
         "cacheRead" : 0.2,
-        "cacheWrite" : 0,
+        "cacheWrite" : 2.5,
         "input" : 2,
         "output" : 12,
         "tiers" : [
           {
             "cacheRead" : 0.4,
-            "cacheWrite" : 0,
+            "cacheWrite" : 5,
             "input" : 4,
             "inputTokensAbove" : 272000,
             "output" : 18
@@ -9984,7 +10042,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 131072,
       "name" : "MiniMax-M2",
       "provider" : "huggingface",
       "reasoning" : true
@@ -10073,7 +10131,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 512000,
       "name" : "MiniMax-M3",
       "provider" : "huggingface",
       "reasoning" : true
@@ -11282,6 +11340,69 @@
       "name" : "GLM-5.2",
       "provider" : "huggingface",
       "reasoning" : true
+    },
+    "zai-org\/GLM-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "zai-org\/GLM-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "zai-org\/GLM-5.3-Flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/router.huggingface.co\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "zai-org\/GLM-5.3-Flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3-Flash",
+      "provider" : "huggingface",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     }
   },
   "kimi-coding" : {
@@ -11440,7 +11561,7 @@
     "MiniMax-M3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.minimax.io\/anthropic",
-      "contextWindow" : 1000000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
@@ -11452,7 +11573,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 512000,
       "name" : "MiniMax-M3",
       "provider" : "minimax",
       "reasoning" : true
@@ -11500,7 +11621,7 @@
     "MiniMax-M3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.minimaxi.com\/anthropic",
-      "contextWindow" : 1000000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
@@ -11512,7 +11633,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 512000,
       "name" : "MiniMax-M3",
       "provider" : "minimax-cn",
       "reasoning" : true
@@ -12120,6 +12241,25 @@
       "name" : "Voxtral Small (latest)",
       "provider" : "mistral",
       "reasoning" : false
+    },
+    "zai-glm-5-2" : {
+      "api" : "mistral-conversations",
+      "baseUrl" : "https:\/\/api.mistral.ai",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.14,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "zai-glm-5-2",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.2",
+      "provider" : "mistral",
+      "reasoning" : true
     }
   },
   "moonshotai" : {
@@ -12750,6 +12890,45 @@
         "minimal" : null
       }
     },
+    "deepseek-ai\/deepseek-v4-pro-0813" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "deepseek"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "headers" : {
+        "NVCF-POLL-SECONDS" : "3600"
+      },
+      "id" : "deepseek-ai\/deepseek-v4-pro-0813",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 384000,
+      "name" : "DeepSeek V4 Pro 0813",
+      "provider" : "nvidia",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null
+      }
+    },
     "google\/gemma-3-4b-it" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -12812,66 +12991,6 @@
       "provider" : "nvidia",
       "reasoning" : false
     },
-    "meta\/llama-3.1-8b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 16000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "meta\/llama-3.1-8b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.1 8B Instruct",
-      "provider" : "nvidia",
-      "reasoning" : false
-    },
-    "meta\/llama-3.1-70b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "meta\/llama-3.1-70b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.1 70b Instruct",
-      "provider" : "nvidia",
-      "reasoning" : false
-    },
     "meta\/llama-3.2-11b-vision-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -12931,36 +13050,6 @@
       ],
       "maxTokens" : 8192,
       "name" : "Llama-3.2-90B-Vision-Instruct",
-      "provider" : "nvidia",
-      "reasoning" : false
-    },
-    "meta\/llama-3.3-70b-instruct" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "meta\/llama-3.3-70b-instruct",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "Llama 3.3 70b Instruct",
       "provider" : "nvidia",
       "reasoning" : false
     },
@@ -13179,67 +13268,6 @@
       "provider" : "nvidia",
       "reasoning" : false
     },
-    "nvidia\/llama-3.1-nemotron-nano-8b-v1" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/llama-3.1-nemotron-nano-8b-v1",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Llama 3.1 Nemotron Nano 8B v1",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "nvidia\/llama-3.1-nemotron-nano-vl-8b-v1" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 32768,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/llama-3.1-nemotron-nano-vl-8b-v1",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Llama 3.1 Nemotron Nano VL 8B v1",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
     "nvidia\/llama-3.1-nemotron-ultra-253b-v1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -13267,66 +13295,6 @@
       ],
       "maxTokens" : 16384,
       "name" : "Llama 3.1 Nemotron Ultra 253B",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "nvidia\/llama-3.3-nemotron-super-49b-v1" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/llama-3.3-nemotron-super-49b-v1",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Llama 3.3 Nemotron Super 49B v1",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "nvidia\/llama-3.3-nemotron-super-49b-v1.5" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/llama-3.3-nemotron-super-49b-v1.5",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 65536,
-      "name" : "Llama 3.3 Nemotron Super 49B v1.5",
       "provider" : "nvidia",
       "reasoning" : true
     },
@@ -13481,67 +13449,6 @@
       "provider" : "nvidia",
       "reasoning" : true
     },
-    "nvidia\/nemotron-nano-12b-v2-vl" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/nemotron-nano-12b-v2-vl",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Nemotron Nano 12B v2 VL",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "nvidia\/nvidia-nemotron-nano-9b-v2" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/nvidia-nemotron-nano-9b-v2",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "nvidia-nemotron-nano-9b-v2",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
     "openai\/gpt-oss-20b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -13629,37 +13536,6 @@
       ],
       "maxTokens" : 16384,
       "name" : "Laguna XS 2.1",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
-    "stepfun-ai\/step-3.7-flash" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "stepfun-ai\/step-3.7-flash",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "Step 3.7 Flash",
       "provider" : "nvidia",
       "reasoning" : true
     }
@@ -16437,39 +16313,6 @@
         "off" : null
       }
     },
-    "hy3-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 190000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "hy3-free",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Hy3 Free",
-      "provider" : "opencode",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "kimi-k2.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
@@ -16582,6 +16425,30 @@
         "off" : null,
         "xhigh" : null
       }
+    },
+    "ling-3.0-flash-fin-free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "ling-3.0-flash-fin-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Ling 3.0 Flash Fin Free",
+      "provider" : "opencode",
+      "reasoning" : true
     },
     "mimo-v2.5-free" : {
       "api" : "openai-completions",
@@ -16833,40 +16700,6 @@
       "name" : "Qwen3.6 Plus",
       "provider" : "opencode",
       "reasoning" : true
-    },
-    "x-preview-f-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "x-preview-f-free",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Ox Alpha Free (Unlimited)",
-      "provider" : "opencode",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
     }
   },
   "opencode-go" : {
@@ -17060,6 +16893,40 @@
         "xhigh" : null
       }
     },
+    "glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.25
+      },
+      "id" : "glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3-Flash (2x usage)",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "gpt-5.6-luna" : {
       "api" : "openai-responses",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
@@ -17134,22 +17001,55 @@
       },
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.0043750000000000004,
+        "cacheRead" : 0.035000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.017500000000000002,
-        "output" : 0.072499999999999995
+        "input" : 0.14,
+        "output" : 0.58
       },
       "id" : "hy3",
       "input" : [
         "text"
       ],
       "maxTokens" : 64000,
-      "name" : "Hy3 (8x usage)",
+      "name" : "Hy3",
       "provider" : "opencode-go",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "high" : "high",
         "low" : "low",
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "hy4-preview" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsStore" : false
+      },
+      "contextWindow" : 1024000,
+      "cost" : {
+        "cacheRead" : 0.042000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.834,
+        "output" : 2.501
+      },
+      "id" : "hy4-preview",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Hy4 preview",
+      "provider" : "opencode-go",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
         "max" : null,
         "medium" : null,
         "minimal" : null,
@@ -17398,40 +17298,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "ox-alpha-free" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsStore" : false
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "ox-alpha-free",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Ox Alpha Free (Unlimited)",
-      "provider" : "opencode-go",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "qwen3.6-plus" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
@@ -17507,6 +17373,26 @@
       "provider" : "opencode-go",
       "reasoning" : true
     },
+    "qwen3.8-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen\/go",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.016,
+        "cacheWrite" : 0.2,
+        "input" : 0.15,
+        "output" : 0.47
+      },
+      "id" : "qwen3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 Flash",
+      "provider" : "opencode-go",
+      "reasoning" : true
+    },
     "qwen3.8-max" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/opencode.ai\/zen\/go\/v1",
@@ -17530,7 +17416,16 @@
       "maxTokens" : 131072,
       "name" : "Qwen3.8 Max",
       "provider" : "opencode-go",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
     }
   },
   "openrouter" : {
@@ -17671,16 +17566,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0070000000000000001,
+        "cacheRead" : 0.01,
         "cacheWrite" : 0,
         "input" : 0.029999999999999999,
-        "output" : 0.074999999999999997
+        "output" : 0.16
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 393216,
       "name" : "DeepSeek V4 Flash Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -17703,10 +17598,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0.020833000000000001,
-        "input" : 0.375,
-        "output" : 1.875
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "~google\/gemini-flash-latest",
       "input" : [
@@ -17899,12 +17794,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.26,
+        "cacheRead" : 0.247,
         "cacheWrite" : 0,
-        "input" : 1.4,
-        "output" : 4.4
+        "input" : 1.1875,
+        "output" : 4.18
       },
       "id" : "~z-ai\/glm-latest",
       "input" : [
@@ -18957,43 +18852,20 @@
       "cost" : {
         "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
-        "input" : 0.22,
-        "output" : 0.85
+        "input" : 0.25,
+        "output" : 0.8
       },
       "id" : "arcee-ai\/trinity-large-thinking",
       "input" : [
         "text"
       ],
-      "maxTokens" : 235929,
+      "maxTokens" : 80000,
       "name" : "Arcee AI: Trinity Large Thinking",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
         "off" : null
       }
-    },
-    "arcee-ai\/virtuoso-large" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.75,
-        "output" : 1.2
-      },
-      "id" : "arcee-ai\/virtuoso-large",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 64000,
-      "name" : "Arcee AI: Virtuoso Large",
-      "provider" : "openrouter",
-      "reasoning" : false
     },
     "auto" : {
       "api" : "openai-completions",
@@ -19412,16 +19284,16 @@
       },
       "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.13,
+        "cacheRead" : 0.1345,
         "cacheWrite" : 0,
-        "input" : 0.26,
-        "output" : 0.38
+        "input" : 0.269,
+        "output" : 0.4
       },
       "id" : "deepseek\/deepseek-v3.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 147456,
+      "maxTokens" : 65536,
       "name" : "DeepSeek: DeepSeek V3.2",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19459,10 +19331,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.017721000000000001,
+        "cacheRead" : 0.015792,
         "cacheWrite" : 0,
-        "input" : 0.088606000000000004,
-        "output" : 0.177212
+        "input" : 0.078960000000000002,
+        "output" : 0.15792
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -19492,10 +19364,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.012,
+        "cacheRead" : 0.016,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
-        "output" : 0.12
+        "input" : 0.065000000000000002,
+        "output" : 0.18
       },
       "id" : "deepseek\/deepseek-v4-flash-0731",
       "input" : [
@@ -19503,6 +19375,39 @@
       ],
       "maxTokens" : 943718,
       "name" : "DeepSeek: DeepSeek V4 Flash 0731",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek\/deepseek-v4-flash-0731:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.14,
+        "output" : 0.28
+      },
+      "id" : "deepseek\/deepseek-v4-flash-0731:batch",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 943718,
+      "name" : "DeepSeek: DeepSeek V4 Flash 0731 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -19559,10 +19464,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.072499999999999995,
+        "cacheRead" : 0.034771000000000003,
         "cacheWrite" : 0,
-        "input" : 0.87,
-        "output" : 1.74
+        "input" : 0.417252,
+        "output" : 0.834504
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
@@ -19590,19 +19495,52 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048575,
+      "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.037400000000000003,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 1.122,
-        "output" : 3.366
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
         "text"
       ],
-      "maxTokens" : 943717,
+      "maxTokens" : 384000,
       "name" : "DeepSeek: DeepSeek V4 Pro 0813",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : "xhigh"
+      }
+    },
+    "deepseek\/deepseek-v4-pro-0813:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "requiresReasoningContentOnAssistantMessages" : true,
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.13,
+        "cacheWrite" : 0,
+        "input" : 1.32,
+        "output" : 3.96
+      },
+      "id" : "deepseek\/deepseek-v4-pro-0813:batch",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 943718,
+      "name" : "DeepSeek: DeepSeek V4 Pro 0813 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -20341,10 +20279,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0.020833000000000001,
-        "input" : 0.375,
-        "output" : 1.875
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.75,
+        "output" : 3.75
       },
       "id" : "google\/gemini-3.7-flash",
       "input" : [
@@ -20518,6 +20456,30 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "google\/gemma-4-31b-it:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.39,
+        "output" : 0.97
+      },
+      "id" : "google\/gemma-4-31b-it:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 235929,
+      "name" : "Google: Gemma 4 31B (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "google\/gemma-4-31b-it:free" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -20617,6 +20579,29 @@
       ],
       "maxTokens" : 32768,
       "name" : "Ling-3.0-flash",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
+    "inclusionai\/ling-3.0-flash-fin:free" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "inclusionai\/ling-3.0-flash-fin:free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32768,
+      "name" : "Ling 3.0 Flash Fin (free)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -20866,16 +20851,49 @@
       "cost" : {
         "cacheRead" : 0.040000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.35,
-        "output" : 1.5
+        "input" : 0.3,
+        "output" : 1.2
       },
       "id" : "meta\/muse-glimmer-30b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 117964,
+      "maxTokens" : 16384,
       "name" : "Meta: Muse Glimmer 30B",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "meta\/muse-glimmer-30b:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.35,
+        "output" : 1.5
+      },
+      "id" : "meta\/muse-glimmer-30b:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 117964,
+      "name" : "Meta: Muse Glimmer 30B (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -21235,6 +21253,29 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "mistralai\/codestral-2508:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.3,
+        "output" : 0.9
+      },
+      "id" : "mistralai\/codestral-2508:batch",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 204800,
+      "name" : "Mistral: Codestral 2508 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
     "mistralai\/devstral-2512" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21244,10 +21285,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.043999999999999997,
+        "cacheRead" : 0.040000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.44,
-        "output" : 2.2
+        "input" : 0.4,
+        "output" : 2
       },
       "id" : "mistralai\/devstral-2512",
       "input" : [
@@ -21303,6 +21344,30 @@
       ],
       "maxTokens" : 209715,
       "name" : "Mistral: Ministral 3 8B 2512",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
+    "mistralai\/ministral-8b-2512:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.15
+      },
+      "id" : "mistralai\/ministral-8b-2512:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 209715,
+      "name" : "Mistral: Ministral 3 8B 2512 (batch)",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -21400,6 +21465,30 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
+    "mistralai\/mistral-large-2512:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.050000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 1.5
+      },
+      "id" : "mistralai\/mistral-large-2512:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 209715,
+      "name" : "Mistral: Mistral Large 3 2512 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
     "mistralai\/mistral-medium-3" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21457,6 +21546,39 @@
         "xhigh" : null
       }
     },
+    "mistralai\/mistral-medium-3-5:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "mistralai\/mistral-medium-3-5:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 209715,
+      "name" : "Mistral: Mistral Medium 3.5 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
     "mistralai\/mistral-medium-3.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21478,6 +21600,30 @@
       ],
       "maxTokens" : 104857,
       "name" : "Mistral: Mistral Medium 3.1",
+      "provider" : "openrouter",
+      "reasoning" : false
+    },
+    "mistralai\/mistral-medium-3.1:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0.040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.4,
+        "output" : 2
+      },
+      "id" : "mistralai\/mistral-medium-3.1:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 104857,
+      "name" : "Mistral: Mistral Medium 3.1 (batch)",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -21584,6 +21730,39 @@
         "xhigh" : null
       }
     },
+    "mistralai\/mistral-small-2603:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.6
+      },
+      "id" : "mistralai\/mistral-small-2603:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 209715,
+      "name" : "Mistral: Mistral Small 4 (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
     "mistralai\/mixtral-8x22b-instruct" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21614,7 +21793,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 32000,
+      "contextWindow" : 32768,
       "cost" : {
         "cacheRead" : 0.01,
         "cacheWrite" : 0,
@@ -21625,7 +21804,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 25600,
+      "maxTokens" : 26214,
       "name" : "Mistral: Voxtral Small 24B 2507",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21760,9 +21939,9 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.19,
+        "cacheRead" : 0.18,
         "cacheWrite" : 0,
-        "input" : 0.67,
+        "input" : 0.66,
         "output" : 3.4
       },
       "id" : "moonshotai\/kimi-k2.7-code",
@@ -21772,33 +21951,6 @@
       ],
       "maxTokens" : 235929,
       "name" : "MoonshotAI: Kimi K2.7 Code",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
-    "moonshotai\/kimi-k2.7-code:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.19,
-        "cacheWrite" : 0,
-        "input" : 0.95,
-        "output" : 4
-      },
-      "id" : "moonshotai\/kimi-k2.7-code:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 235929,
-      "name" : "MoonshotAI: Kimi K2.7 Code (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -21826,6 +21978,39 @@
       ],
       "maxTokens" : 131072,
       "name" : "MoonshotAI: Kimi K3",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "moonshotai\/kimi-k3:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.3,
+        "cacheWrite" : 0,
+        "input" : 3,
+        "output" : 15
+      },
+      "id" : "moonshotai\/kimi-k3:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 943718,
+      "name" : "MoonshotAI: Kimi K3 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -21895,7 +22080,7 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.029999999999999999,
+        "cacheRead" : 0.025000000000000001,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
         "output" : 0.2
@@ -21904,7 +22089,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 235929,
+      "maxTokens" : 228000,
       "name" : "NVIDIA: Nemotron 3 Nano 30B A3B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -22004,18 +22189,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 512288,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.2,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 0.6,
-        "output" : 3.6
+        "input" : 0.5,
+        "output" : 2.2
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 461059,
+      "maxTokens" : 16384,
       "name" : "NVIDIA: Nemotron 3 Ultra",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -22205,28 +22390,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "openai\/gpt-3.5-turbo:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 16385,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0.25,
-        "output" : 0.75
-      },
-      "id" : "openai\/gpt-3.5-turbo:batch",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 4096,
-      "name" : "OpenAI: GPT-3.5 Turbo (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "openai\/gpt-4" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22294,29 +22457,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "openai\/gpt-4-turbo:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 5,
-        "output" : 15
-      },
-      "id" : "openai\/gpt-4-turbo:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 4096,
-      "name" : "OpenAI: GPT-4 Turbo (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "openai\/gpt-4.1" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22363,29 +22503,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "openai\/gpt-4.1-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1047576,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.2,
-        "output" : 0.8
-      },
-      "id" : "openai\/gpt-4.1-mini:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "OpenAI: GPT-4.1 Mini (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "openai\/gpt-4.1-nano" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22406,52 +22523,6 @@
       ],
       "maxTokens" : 32768,
       "name" : "OpenAI: GPT-4.1 Nano",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "openai\/gpt-4.1-nano:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1047576,
-      "cost" : {
-        "cacheRead" : 0.012500000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.050000000000000003,
-        "output" : 0.2
-      },
-      "id" : "openai\/gpt-4.1-nano:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "OpenAI: GPT-4.1 Nano (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "openai\/gpt-4.1:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1047576,
-      "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 4
-      },
-      "id" : "openai\/gpt-4.1:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 32768,
-      "name" : "OpenAI: GPT-4.1 (batch)",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -22593,52 +22664,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "openai\/gpt-4o-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.074999999999999997,
-        "output" : 0.3
-      },
-      "id" : "openai\/gpt-4o-mini:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "OpenAI: GPT-4o-mini (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "openai\/gpt-4o:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 128000,
-      "cost" : {
-        "cacheRead" : 0.625,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-4o:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 16384,
-      "name" : "OpenAI: GPT-4o (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "openai\/gpt-5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22671,32 +22696,6 @@
         "xhigh" : null
       }
     },
-    "openai\/gpt-5-codex:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.0625,
-        "cacheWrite" : 0,
-        "input" : 0.625,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-5-codex:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 Codex (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "off" : null
-      }
-    },
     "openai\/gpt-5-mini" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22717,38 +22716,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5 Mini",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : "minimal",
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "openai\/gpt-5-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.012500000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.125,
-        "output" : 1
-      },
-      "id" : "openai\/gpt-5-mini:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 Mini (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -22793,38 +22760,6 @@
         "xhigh" : null
       }
     },
-    "openai\/gpt-5-nano:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.0025000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.025000000000000001,
-        "output" : 0.2
-      },
-      "id" : "openai\/gpt-5-nano:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 Nano (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : "minimal",
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "openai\/gpt-5-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -22853,70 +22788,6 @@
         "max" : null,
         "medium" : null,
         "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "openai\/gpt-5-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 7.5,
-        "output" : 60
-      },
-      "id" : "openai\/gpt-5-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "openai\/gpt-5:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.0625,
-        "cacheWrite" : 0,
-        "input" : 0.625,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-5:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : "minimal",
         "off" : null,
         "xhigh" : null
       }
@@ -23037,38 +22908,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.1-Codex-Mini",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : null
-      }
-    },
-    "openai\/gpt-5.1:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.0625,
-        "cacheWrite" : 0,
-        "input" : 0.625,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-5.1:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.1 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -23203,70 +23042,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "openai\/gpt-5.2-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 10.5,
-        "output" : 84
-      },
-      "id" : "openai\/gpt-5.2-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.2 Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.2:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.087499999999999994,
-        "cacheWrite" : 0,
-        "input" : 0.875,
-        "output" : 7
-      },
-      "id" : "openai\/gpt-5.2:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.2 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "openai\/gpt-5.3-codex" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -23363,38 +23138,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "openai\/gpt-5.4-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.037499999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.375,
-        "output" : 2.25
-      },
-      "id" : "openai\/gpt-5.4-mini:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.4 Mini (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "openai\/gpt-5.4-nano" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -23415,38 +23158,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.4 Nano",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.4-nano:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 400000,
-      "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.625
-      },
-      "id" : "openai\/gpt-5.4-nano:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.4 Nano (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -23488,70 +23199,6 @@
         "medium" : "medium",
         "minimal" : null,
         "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.4-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 15,
-        "output" : 90
-      },
-      "id" : "openai\/gpt-5.4-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.4 Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.4:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.125,
-        "cacheWrite" : 0,
-        "input" : 1.25,
-        "output" : 7.5
-      },
-      "id" : "openai\/gpt-5.4:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.4 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
         "xhigh" : "xhigh"
       }
     },
@@ -23619,70 +23266,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "openai\/gpt-5.5-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 15,
-        "output" : 90
-      },
-      "id" : "openai\/gpt-5.5-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.5 Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.5:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 15
-      },
-      "id" : "openai\/gpt-5.5:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.5 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : null,
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "openai\/gpt-5.6-luna" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -23735,70 +23318,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.6 Luna Pro",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.6-luna-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.6
-      },
-      "id" : "openai\/gpt-5.6-luna-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Luna Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.6-luna:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.01,
-        "cacheWrite" : 0,
-        "input" : 0.1,
-        "output" : 0.6
-      },
-      "id" : "openai\/gpt-5.6-luna:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Luna (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -23875,70 +23394,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "openai\/gpt-5.6-sol-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-5.6-sol-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Sol Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.6-sol:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 1.25,
-        "input" : 1,
-        "output" : 5
-      },
-      "id" : "openai\/gpt-5.6-sol:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Sol (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "openai\/gpt-5.6-terra" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -23991,70 +23446,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "OpenAI: GPT-5.6 Terra Pro",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.6-terra-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 6
-      },
-      "id" : "openai\/gpt-5.6-terra-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Terra Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "openai\/gpt-5.6-terra:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1050000,
-      "cost" : {
-        "cacheRead" : 0.1,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 6
-      },
-      "id" : "openai\/gpt-5.6-terra:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "OpenAI: GPT-5.6 Terra (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -24196,6 +23587,37 @@
         "xhigh" : null
       }
     },
+    "openai\/gpt-oss-120b:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 131072,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.6
+      },
+      "id" : "openai\/gpt-oss-120b:batch",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 117964,
+      "name" : "OpenAI: gpt-oss-120b (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "openai\/gpt-oss-safeguard-20b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -24241,29 +23663,6 @@
       ],
       "maxTokens" : 100000,
       "name" : "OpenAI: o1",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/o1:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 3.75,
-        "cacheWrite" : 0,
-        "input" : 7.5,
-        "output" : 30
-      },
-      "id" : "openai\/o1:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o1 (batch)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -24343,59 +23742,6 @@
         "xhigh" : null
       }
     },
-    "openai\/o3-mini-high:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.275,
-        "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 2.2
-      },
-      "id" : "openai\/o3-mini-high:batch",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o3 Mini High (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "openai\/o3-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.275,
-        "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 2.2
-      },
-      "id" : "openai\/o3-mini:batch",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o3 Mini (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
     "openai\/o3-pro" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -24416,52 +23762,6 @@
       ],
       "maxTokens" : 100000,
       "name" : "OpenAI: o3 Pro",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/o3-pro:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 10,
-        "output" : 40
-      },
-      "id" : "openai\/o3-pro:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o3 Pro (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true
-    },
-    "openai\/o3:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.25,
-        "cacheWrite" : 0,
-        "input" : 1,
-        "output" : 4
-      },
-      "id" : "openai\/o3:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o3 (batch)",
       "provider" : "openrouter",
       "reasoning" : true
     },
@@ -24519,61 +23819,6 @@
         "off" : null,
         "xhigh" : null
       }
-    },
-    "openai\/o4-mini-high:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.1375,
-        "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 2.2
-      },
-      "id" : "openai\/o4-mini-high:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o4 Mini High (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
-    "openai\/o4-mini:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 200000,
-      "cost" : {
-        "cacheRead" : 0.1375,
-        "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 2.2
-      },
-      "id" : "openai\/o4-mini:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 100000,
-      "name" : "OpenAI: o4 Mini (batch)",
-      "provider" : "openrouter",
-      "reasoning" : true
     },
     "openrouter\/auto" : {
       "api" : "openai-completions",
@@ -25027,16 +24272,16 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0,
+        "cacheRead" : 0.017500000000000002,
         "cacheWrite" : 0,
-        "input" : 0.089999999999999997,
-        "output" : 0.55
+        "input" : 0.087499999999999994,
+        "output" : 0.35
       },
       "id" : "qwen\/qwen3-235b-a22b-2507",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 235929,
       "name" : "Qwen: Qwen3 235B A22B Instruct 2507",
       "provider" : "openrouter",
       "reasoning" : false
@@ -25237,16 +24482,16 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.070000000000000007,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.1,
+        "input" : 0.089999999999999997,
         "output" : 1.1
       },
       "id" : "qwen\/qwen3-next-80b-a3b-instruct",
       "input" : [
         "text"
       ],
-      "maxTokens" : 235929,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 Next 80B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -25335,19 +24580,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 262144,
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.13,
-        "output" : 0.52
+        "input" : 0.15,
+        "output" : 0.6
       },
       "id" : "qwen\/qwen3-vl-30b-a3b-instruct",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 32768,
+      "maxTokens" : 16384,
       "name" : "Qwen: Qwen3 VL 30B A3B Instruct",
       "provider" : "openrouter",
       "reasoning" : false
@@ -25478,6 +24723,30 @@
       "provider" : "openrouter",
       "reasoning" : true
     },
+    "qwen\/qwen3.5-9b:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 262144,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0.17,
+        "output" : 0.25
+      },
+      "id" : "qwen\/qwen3.5-9b:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 235929,
+      "name" : "Qwen: Qwen3.5-9B (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true
+    },
     "qwen\/qwen3.5-27b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -25537,15 +24806,15 @@
       "cost" : {
         "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.26,
-        "output" : 2.08
+        "input" : 0.29,
+        "output" : 2.4
       },
       "id" : "qwen\/qwen3.5-122b-a10b",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 235929,
+      "maxTokens" : 81920,
       "name" : "Qwen: Qwen3.5-122B-A10B",
       "provider" : "openrouter",
       "reasoning" : true
@@ -25681,8 +24950,8 @@
       "cost" : {
         "cacheRead" : 0.050000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 1
+        "input" : 0.1,
+        "output" : 0.9
       },
       "id" : "qwen\/qwen3.6-35b-a3b",
       "input" : [
@@ -25843,7 +25112,7 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1000000,
       "cost" : {
         "cacheRead" : 0.25,
         "cacheWrite" : 0,
@@ -25854,8 +25123,40 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 262144,
       "name" : "Qwen: Qwen3.8 2.4T A95B",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : null,
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "qwen\/qwen3.8-2.4t-a95b:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1010000,
+      "cost" : {
+        "cacheRead" : 0.5,
+        "cacheWrite" : 0,
+        "input" : 2.5,
+        "output" : 6.25
+      },
+      "id" : "qwen\/qwen3.8-2.4t-a95b:batch",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 909000,
+      "name" : "Qwen: Qwen3.8 2.4T A95B (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -25900,6 +25201,30 @@
         "off" : "none",
         "xhigh" : "xhigh"
       }
+    },
+    "qwen\/qwen3.8-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.016,
+        "cacheWrite" : 0.2,
+        "input" : 0.15,
+        "output" : 0.47
+      },
+      "id" : "qwen\/qwen3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen: Qwen3.8 Flash",
+      "provider" : "openrouter",
+      "reasoning" : true
     },
     "qwen\/qwen3.8-max" : {
       "api" : "openai-completions",
@@ -26070,39 +25395,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "stealth\/ox-alpha" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1048576,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "id" : "stealth\/ox-alpha",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 131072,
-      "name" : "Ox Alpha",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : null,
-        "minimal" : null,
-        "off" : null,
-        "xhigh" : null
-      }
-    },
     "stepfun\/step-3.5-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -26226,6 +25518,38 @@
         "xhigh" : null
       }
     },
+    "tencent\/hy4-preview" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.042000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.834,
+        "output" : 2.501
+      },
+      "id" : "tencent\/hy4-preview",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Tencent: Hy4 preview",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : null,
+        "minimal" : null,
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
     "thedrummer\/unslopnemo-12b" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -26258,9 +25582,9 @@
       },
       "contextWindow" : 524288,
       "cost" : {
-        "cacheRead" : 0.16,
+        "cacheRead" : 0.17,
         "cacheWrite" : 0,
-        "input" : 0.95,
+        "input" : 1,
         "output" : 4.05
       },
       "id" : "thinkingmachines\/inkling",
@@ -26268,7 +25592,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 471859,
       "name" : "Thinking Machines: Inkling",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -26303,6 +25627,39 @@
       ],
       "maxTokens" : 262144,
       "name" : "Thinking Machines: Inkling Small",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : "minimal",
+        "off" : "none",
+        "xhigh" : null
+      }
+    },
+    "thinkingmachines\/inkling-small:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 524288,
+      "cost" : {
+        "cacheRead" : 0.1,
+        "cacheWrite" : 0,
+        "input" : 0.5,
+        "output" : 1.2
+      },
+      "id" : "thinkingmachines\/inkling-small:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 471859,
+      "name" : "Thinking Machines: Inkling Small (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -26734,18 +26091,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 202752,
+      "contextWindow" : 198000,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.080000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2
+        "input" : 0.43,
+        "output" : 1.75
       },
       "id" : "z-ai\/glm-4.6",
       "input" : [
         "text"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 16384,
       "name" : "Z.ai: GLM 4.6",
       "provider" : "openrouter",
       "reasoning" : true
@@ -26873,18 +26230,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 202752,
+      "contextWindow" : 200000,
       "cost" : {
-        "cacheRead" : 0.234,
+        "cacheRead" : 0.1794,
         "cacheWrite" : 0,
-        "input" : 1.26,
-        "output" : 3.96
+        "input" : 0.966,
+        "output" : 3.036
       },
       "id" : "z-ai\/glm-5.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 182476,
+      "maxTokens" : 128000,
       "name" : "Z.ai: GLM 5.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -26909,38 +26266,6 @@
       ],
       "maxTokens" : 262144,
       "name" : "Z.ai: GLM 5.2",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "z-ai\/glm-5.2:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1048575,
-      "cost" : {
-        "cacheRead" : 0.26,
-        "cacheWrite" : 0,
-        "input" : 1.4,
-        "output" : 4.4
-      },
-      "id" : "z-ai\/glm-5.2:batch",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 943717,
-      "name" : "Z.ai: GLM 5.2 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -27005,6 +26330,72 @@
       ],
       "maxTokens" : 131072,
       "name" : "Z.ai: GLM 5.3",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "z-ai\/glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.25
+      },
+      "id" : "z-ai\/glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Z.ai: GLM 5.3 Flash",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "z-ai\/glm-5.3-flash:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048575,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "z-ai\/glm-5.3-flash:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 943717,
+      "name" : "Z.ai: GLM 5.3 Flash (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -27505,6 +26896,40 @@
       "provider" : "qwen-token-plan",
       "reasoning" : true
     },
+    "qwen3.8-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan.ap-southeast-1.maas.aliyuncs.com\/compatible-mode\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "qwen"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "qwen3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 Flash",
+      "provider" : "qwen-token-plan",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
+    },
     "qwen3.8-max" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/token-plan.ap-southeast-1.maas.aliyuncs.com\/compatible-mode\/v1",
@@ -28002,6 +27427,40 @@
       "name" : "Qwen3.7 Plus",
       "provider" : "qwen-token-plan-cn",
       "reasoning" : true
+    },
+    "qwen3.8-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/token-plan.cn-beijing.maas.aliyuncs.com\/compatible-mode\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "qwen"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "qwen3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Qwen3.8 Flash",
+      "provider" : "qwen-token-plan-cn",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "xhigh" : null
+      }
     },
     "qwen3.8-max" : {
       "api" : "openai-completions",
@@ -28911,6 +28370,73 @@
         "medium" : null,
         "minimal" : null
       }
+    },
+    "zai-org\/GLM-5.3" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.26,
+        "cacheWrite" : 0,
+        "input" : 1.4,
+        "output" : 4.4
+      },
+      "id" : "zai-org\/GLM-5.3",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 262144,
+      "name" : "GLM-5.3",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
+    },
+    "zai-org\/GLM-5.3-Flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.together.ai\/v1",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsReasoningEffort" : false,
+        "supportsStore" : false,
+        "supportsStrictMode" : false,
+        "thinkingFormat" : "together"
+      },
+      "contextWindow" : 1048575,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "zai-org\/GLM-5.3-Flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 400000,
+      "name" : "GLM-5.3-Flash",
+      "provider" : "together",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "low" : null,
+        "medium" : null,
+        "minimal" : null
+      }
     }
   },
   "vercel-ai-gateway" : {
@@ -29404,7 +28930,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.2,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -29414,7 +28940,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 131072,
+      "maxTokens" : 128000,
       "name" : "Qwen3.8 2.4T A95B",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -29424,10 +28950,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.11,
-        "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 3.3
+        "cacheRead" : 0.1,
+        "cacheWrite" : 0.625,
+        "input" : 0.5,
+        "output" : 3
       },
       "id" : "alibaba\/qwen3.8-27b",
       "input" : [
@@ -29436,6 +28962,26 @@
       ],
       "maxTokens" : 131072,
       "name" : "Qwen3.8 27B",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "alibaba\/qwen3.8-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 991000,
+      "cost" : {
+        "cacheRead" : 0.016,
+        "cacheWrite" : 0.2,
+        "input" : 0.16,
+        "output" : 0.47
+      },
+      "id" : "alibaba\/qwen3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Qwen 3.8 Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -30158,18 +29704,18 @@
     "deepseek\/deepseek-v4-pro" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1048600,
+      "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.14,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 1.74,
-        "output" : 3.48
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
         "text"
       ],
-      "maxTokens" : 1048600,
+      "maxTokens" : 384000,
       "name" : "DeepSeek V4 Pro",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -30487,6 +30033,44 @@
       ],
       "maxTokens" : 32000,
       "name" : "Ling 3.0 Flash",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "inclusionai\/ling-3.0-flash-fin" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "inclusionai\/ling-3.0-flash-fin",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32000,
+      "name" : "Ling 3.0 Flash Fin",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "inclusionai\/ling-3.0-flash-fin-free" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 256000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "inclusionai\/ling-3.0-flash-fin-free",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 32000,
+      "name" : "Ling 3.0 Flash Fin (Free)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -30875,7 +30459,7 @@
         "text"
       ],
       "maxTokens" : 131000,
-      "name" : "Minimax M2.7",
+      "name" : "MiniMax M2.7",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -30894,7 +30478,7 @@
         "text"
       ],
       "maxTokens" : 196608,
-      "name" : "Minimax M2.7 (Free)",
+      "name" : "MiniMax M2.7 (Free)",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -30920,7 +30504,7 @@
     "minimax\/minimax-m3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
+      "contextWindow" : 512000,
       "cost" : {
         "cacheRead" : 0.059999999999999998,
         "cacheWrite" : 0,
@@ -30932,7 +30516,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 1000000,
+      "maxTokens" : 512000,
       "name" : "MiniMax M3",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -31278,7 +30862,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.19,
+        "cacheRead" : 0.16,
         "cacheWrite" : 0,
         "input" : 0.95,
         "output" : 4
@@ -31415,10 +30999,10 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.050000000000000003,
+        "cacheRead" : 0.01,
         "cacheWrite" : 0,
         "input" : 0.050000000000000003,
-        "output" : 0.15
+        "output" : 0.2
       },
       "id" : "nvidia\/nemotron-3.5-lightning",
       "input" : [
@@ -33009,19 +32593,38 @@
     "tencent\/hy3" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 256000,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.033000000000000002,
+        "cacheRead" : 0.035000000000000003,
         "cacheWrite" : 0,
-        "input" : 0.132,
-        "output" : 0.528
+        "input" : 0.14,
+        "output" : 0.58
       },
       "id" : "tencent\/hy3",
       "input" : [
         "text"
       ],
-      "maxTokens" : 128000,
+      "maxTokens" : 262144,
       "name" : "Hy3",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "tencent\/hy4-preview" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1024000,
+      "cost" : {
+        "cacheRead" : 0.042000000000000003,
+        "cacheWrite" : 0,
+        "input" : 0.834,
+        "output" : 2.501
+      },
+      "id" : "tencent\/hy4-preview",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 64000,
+      "name" : "Tencent Hy4 Preview",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -33338,7 +32941,7 @@
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.26,
+        "cacheRead" : 0.14,
         "cacheWrite" : 0,
         "input" : 1.4,
         "output" : 4.4
@@ -33347,8 +32950,28 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 12800,
+      "maxTokens" : 1000000,
       "name" : "GLM 5.3",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "zai\/glm-5.3-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.029999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.15,
+        "output" : 0.5
+      },
+      "id" : "zai\/glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131000,
+      "name" : "GLM 5.3 Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
@@ -33879,6 +33502,79 @@
         "off" : null,
         "xhigh" : null
       }
+    },
+    "glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.z.ai\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.25
+      },
+      "id" : "glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3-Flash",
+      "provider" : "zai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "glm-5.3-highspeed" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.z.ai\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "glm-5.3-highspeed",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3 Highspeed",
+      "provider" : "zai",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     }
   },
   "zai-coding-cn" : {
@@ -34087,6 +33783,79 @@
       ],
       "maxTokens" : 131072,
       "name" : "GLM-5.3",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "glm-5.3-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.25
+      },
+      "id" : "glm-5.3-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3-Flash",
+      "provider" : "zai-coding-cn",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "glm-5.3-highspeed" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/open.bigmodel.cn\/api\/coding\/paas\/v4",
+      "compat" : {
+        "maxTokensField" : "max_tokens",
+        "supportsDeveloperRole" : false,
+        "supportsReasoningEffort" : true,
+        "supportsStore" : false,
+        "thinkingFormat" : "zai",
+        "zaiToolStream" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0,
+        "cacheWrite" : 0,
+        "input" : 0,
+        "output" : 0
+      },
+      "id" : "glm-5.3-highspeed",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "GLM-5.3 Highspeed",
       "provider" : "zai-coding-cn",
       "reasoning" : true,
       "thinkingLevelMap" : {


### PR DESCRIPTION
## Summary

- regenerate the regular bundled catalog from badlogic/pi-mono main at commit 853a80d26c90a14c1886f0ebb8ffaae133ca2185
- add 49 models, including GLM 5.3/GLM 5.3 Flash across multiple providers, Qwen 3.8 Flash, and new OpenRouter batch variants
- remove 58 models, primarily retired OpenRouter batch variants plus removed NVIDIA and Fireworks entries
- update metadata for 49 existing models, including pricing, compatibility flags, limits, and display metadata
- regenerate the Cursor catalog from GetUsableModels; it remains unchanged at 198 models
- resulting regular catalog: 39 providers and 1,291 models

## Validation

- jq validation for both bundled JSON catalogs
- git diff --check
- private/local endpoint scan
- credential marker scan
- swift test --filter GenerateModelsCoreTests (5 tests)
- swift test --filter ModelsCatalogTests (8 tests)
- swift test --filter Cursor (54 tests)
- swift test (1,356 tests in 198 suites)
