### PR TITLE
chore(kwwk): refresh model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -189,6 +189,206 @@
       "input" : 0,
       "output" : 0
     },
+    "id" : "claude-fable-5-1-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Low (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-max",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Max (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Medium (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-thinking-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Thinking (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-thinking-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Low Thinking (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-thinking-max",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Max Thinking (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-thinking-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Medium Thinking (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-thinking-xhigh",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Extra High Thinking (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "claude-fable-5-1-xhigh",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Claude Fable 5.1 1M Extra High (NO ZDR)",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
     "id" : "claude-fable-5-high",
     "input" : [
       "text",

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -104,6 +104,31 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic.claude-fable-5-1" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic.claude-fable-5-1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -818,6 +843,31 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Fable 5 (Global)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "global.anthropic.claude-fable-5-1" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "global.anthropic.claude-fable-5-1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1 (Global)",
       "provider" : "amazon-bedrock",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -2258,6 +2308,31 @@
         "xhigh" : "xhigh"
       }
     },
+    "us.anthropic.claude-fable-5-1" : {
+      "api" : "bedrock-converse-stream",
+      "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.275,
+        "cacheWrite" : 13.75,
+        "input" : 11,
+        "output" : 55
+      },
+      "id" : "us.anthropic.claude-fable-5-1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1 (US)",
+      "provider" : "amazon-bedrock",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0" : {
       "api" : "bedrock-converse-stream",
       "baseUrl" : "https:\/\/bedrock-runtime.us-east-1.amazonaws.com",
@@ -2843,6 +2918,35 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Fable 5",
+      "provider" : "anthropic",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "claude-fable-5-1" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/api.anthropic.com",
+      "compat" : {
+        "forceAdaptiveThinking" : true,
+        "supportsStrictTools" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "claude-fable-5-1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1",
       "provider" : "anthropic",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -7052,10 +7156,10 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 0.028000000000000001,
+        "cacheRead" : 0.0070000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.14,
-        "output" : 0.28
+        "input" : 0.22,
+        "output" : 0.66
       },
       "id" : "accounts\/fireworks\/models\/deepseek-v4-flash-0731",
       "input" : [
@@ -13307,36 +13411,6 @@
       "provider" : "nvidia",
       "reasoning" : true
     },
-    "nvidia\/nemotron-3-nano-30b-a3b" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
-      "compat" : {
-        "maxTokensField" : "max_tokens",
-        "supportsDeveloperRole" : false,
-        "supportsLongCacheRetention" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false,
-        "supportsStrictMode" : false
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0,
-        "cacheWrite" : 0,
-        "input" : 0,
-        "output" : 0
-      },
-      "headers" : {
-        "NVCF-POLL-SECONDS" : "3600"
-      },
-      "id" : "nvidia\/nemotron-3-nano-30b-a3b",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 131072,
-      "name" : "nemotron-3-nano-30b-a3b",
-      "provider" : "nvidia",
-      "reasoning" : true
-    },
     "nvidia\/nemotron-3-nano-omni-30b-a3b-reasoning" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/integrate.api.nvidia.com\/v1",
@@ -17448,7 +17522,7 @@
       },
       "contextWindow" : 1000000,
       "cost" : {
-        "cacheRead" : 1,
+        "cacheRead" : 0.25,
         "cacheWrite" : 12.5,
         "input" : 10,
         "output" : 50
@@ -17575,9 +17649,9 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.016,
+        "cacheRead" : 0.012999999999999999,
         "cacheWrite" : 0,
-        "input" : 0.059999999999999998,
+        "input" : 0.050000000000000003,
         "output" : 0.16
       },
       "id" : "~deepseek\/deepseek-v4-flash-latest",
@@ -17794,6 +17868,39 @@
         "minimal" : null,
         "off" : null,
         "xhigh" : "xhigh"
+      }
+    },
+    "~z-ai\/glm-flash-latest" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.014999999999999999,
+        "cacheWrite" : 0,
+        "input" : 0.074999999999999997,
+        "output" : 0.25
+      },
+      "id" : "~z-ai\/glm-flash-latest",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 131072,
+      "name" : "Z.ai: GLM Flash Latest",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
       }
     },
     "~z-ai\/glm-latest" : {
@@ -18115,6 +18222,39 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic\/claude-fable-5.1" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "cacheControlFormat" : "anthropic",
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-fable-5.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Anthropic: Claude Fable 5.1",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic\/claude-haiku-4.5" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -18382,39 +18522,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "anthropic\/claude-opus-4.7-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "cacheControlFormat" : "anthropic",
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 3,
-        "cacheWrite" : 37.5,
-        "input" : 30,
-        "output" : 150
-      },
-      "id" : "anthropic\/claude-opus-4.7-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Anthropic: Claude Opus 4.7 (Fast)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "anthropic\/claude-opus-4.7:batch" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -18481,39 +18588,6 @@
         "xhigh" : "xhigh"
       }
     },
-    "anthropic\/claude-opus-4.8-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "cacheControlFormat" : "anthropic",
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 1,
-        "cacheWrite" : 12.5,
-        "input" : 10,
-        "output" : 50
-      },
-      "id" : "anthropic\/claude-opus-4.8-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Anthropic: Claude Opus 4.8 (Fast)",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
     "anthropic\/claude-opus-4.8:batch" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -18568,39 +18642,6 @@
       ],
       "maxTokens" : 128000,
       "name" : "Claude Opus 5",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : "low",
-        "max" : "max",
-        "medium" : "medium",
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : "xhigh"
-      }
-    },
-    "anthropic\/claude-opus-5-fast" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "cacheControlFormat" : "anthropic",
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 1000000,
-      "cost" : {
-        "cacheRead" : 1,
-        "cacheWrite" : 12.5,
-        "input" : 10,
-        "output" : 50
-      },
-      "id" : "anthropic\/claude-opus-5-fast",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 128000,
-      "name" : "Claude Opus 5 (Fast)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -19193,18 +19234,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 161000,
+      "contextWindow" : 163840,
       "cost" : {
-        "cacheRead" : 0.55,
+        "cacheRead" : 0.13,
         "cacheWrite" : 0,
-        "input" : 0.55,
-        "output" : 1.65
+        "input" : 0.25,
+        "output" : 0.95
       },
       "id" : "deepseek\/deepseek-chat-v3.1",
       "input" : [
         "text"
       ],
-      "maxTokens" : 144900,
+      "maxTokens" : 32768,
       "name" : "DeepSeek: DeepSeek V3.1",
       "provider" : "openrouter",
       "reasoning" : true
@@ -19340,10 +19381,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.016184,
+        "cacheRead" : 0.017721000000000001,
         "cacheWrite" : 0,
-        "input" : 0.080920000000000006,
-        "output" : 0.16184
+        "input" : 0.088606000000000004,
+        "output" : 0.177212
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -19439,10 +19480,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.0070000000000000001,
+        "cacheRead" : 0.014,
         "cacheWrite" : 0,
-        "input" : 0.22,
-        "output" : 0.66
+        "input" : 0.44,
+        "output" : 1.32
       },
       "id" : "deepseek\/deepseek-v4-flash-vision-exp",
       "input" : [
@@ -19473,10 +19514,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.072499999999999995,
+        "cacheRead" : 0.086855000000000002,
         "cacheWrite" : 0,
-        "input" : 0.87,
-        "output" : 1.74
+        "input" : 1.04226,
+        "output" : 2.08452
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
@@ -19504,12 +19545,12 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.021999999999999999,
+        "cacheRead" : 0.037179999999999998,
         "cacheWrite" : 0,
-        "input" : 0.66,
-        "output" : 1.98
+        "input" : 1.1154,
+        "output" : 3.3462
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
@@ -20600,6 +20641,38 @@
         "xhigh" : null
       }
     },
+    "inception\/mercury-2.5-preview" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 260000,
+      "cost" : {
+        "cacheRead" : 0.0040000000000000001,
+        "cacheWrite" : 0,
+        "input" : 0.040000000000000001,
+        "output" : 0.15
+      },
+      "id" : "inception\/mercury-2.5-preview",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Inception: Mercury 2.5 Preview",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
     "inclusionai\/ling-3.0-flash" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -20841,19 +20914,19 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 131072,
+      "contextWindow" : 327680,
       "cost" : {
-        "cacheRead" : 0.055,
+        "cacheRead" : 0,
         "cacheWrite" : 0,
-        "input" : 0.11,
-        "output" : 0.34
+        "input" : 0.1,
+        "output" : 0.3
       },
       "id" : "meta-llama\/llama-4-scout",
       "input" : [
         "text",
         "image"
       ],
-      "maxTokens" : 8192,
+      "maxTokens" : 16384,
       "name" : "Meta: Llama 4 Scout",
       "provider" : "openrouter",
       "reasoning" : false
@@ -21271,29 +21344,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "mistralai\/codestral-2508:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 256000,
-      "cost" : {
-        "cacheRead" : 0.029999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.3,
-        "output" : 0.9
-      },
-      "id" : "mistralai\/codestral-2508:batch",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 204800,
-      "name" : "Mistral: Codestral 2508 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "mistralai\/devstral-2512" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21362,30 +21412,6 @@
       ],
       "maxTokens" : 209715,
       "name" : "Mistral: Ministral 3 8B 2512",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "mistralai\/ministral-8b-2512:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.014999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 0.15
-      },
-      "id" : "mistralai\/ministral-8b-2512:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 209715,
-      "name" : "Mistral: Ministral 3 8B 2512 (batch)",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -21480,30 +21506,6 @@
       ],
       "maxTokens" : 209715,
       "name" : "Mistral: Mistral Large 3 2512",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
-    "mistralai\/mistral-large-2512:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.050000000000000003,
-        "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 1.5
-      },
-      "id" : "mistralai\/mistral-large-2512:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 209715,
-      "name" : "Mistral: Mistral Large 3 2512 (batch)",
       "provider" : "openrouter",
       "reasoning" : false
     },
@@ -21621,30 +21623,6 @@
       "provider" : "openrouter",
       "reasoning" : false
     },
-    "mistralai\/mistral-medium-3.1:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 131072,
-      "cost" : {
-        "cacheRead" : 0.040000000000000001,
-        "cacheWrite" : 0,
-        "input" : 0.4,
-        "output" : 2
-      },
-      "id" : "mistralai\/mistral-medium-3.1:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 104857,
-      "name" : "Mistral: Mistral Medium 3.1 (batch)",
-      "provider" : "openrouter",
-      "reasoning" : false
-    },
     "mistralai\/mistral-nemo" : {
       "api" : "openai-completions",
       "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
@@ -21736,39 +21714,6 @@
       ],
       "maxTokens" : 209715,
       "name" : "Mistral: Mistral Small 4",
-      "provider" : "openrouter",
-      "reasoning" : true,
-      "thinkingLevelMap" : {
-        "high" : "high",
-        "low" : null,
-        "max" : null,
-        "medium" : null,
-        "minimal" : null,
-        "off" : "none",
-        "xhigh" : null
-      }
-    },
-    "mistralai\/mistral-small-2603:batch" : {
-      "api" : "openai-completions",
-      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
-      "compat" : {
-        "supportsDeveloperRole" : false,
-        "thinkingFormat" : "openrouter"
-      },
-      "contextWindow" : 262144,
-      "cost" : {
-        "cacheRead" : 0.014999999999999999,
-        "cacheWrite" : 0,
-        "input" : 0.15,
-        "output" : 0.6
-      },
-      "id" : "mistralai\/mistral-small-2603:batch",
-      "input" : [
-        "text",
-        "image"
-      ],
-      "maxTokens" : 209715,
-      "name" : "Mistral: Mistral Small 4 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -22207,18 +22152,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 262144,
+      "contextWindow" : 256000,
       "cost" : {
-        "cacheRead" : 0.1,
+        "cacheRead" : 0.1875,
         "cacheWrite" : 0,
-        "input" : 0.5,
-        "output" : 2.2
+        "input" : 0.625,
+        "output" : 3.125
       },
       "id" : "nvidia\/nemotron-3-ultra-550b-a55b",
       "input" : [
         "text"
       ],
-      "maxTokens" : 16384,
+      "maxTokens" : 32768,
       "name" : "NVIDIA: Nemotron 3 Ultra",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -25966,9 +25911,9 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1000000,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.25,
+        "cacheRead" : 0.2,
         "cacheWrite" : 0,
         "input" : 2,
         "output" : 6
@@ -25977,7 +25922,7 @@
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "Qwen: Qwen3.8 2.4T A95B",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -26000,10 +25945,10 @@
       },
       "contextWindow" : 1010000,
       "cost" : {
-        "cacheRead" : 0.5,
+        "cacheRead" : 0.25,
         "cacheWrite" : 0,
-        "input" : 2.5,
-        "output" : 6.25
+        "input" : 2,
+        "output" : 6
       },
       "id" : "qwen\/qwen3.8-2.4t-a95b:batch",
       "input" : [
@@ -26317,10 +26262,10 @@
       },
       "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.020625000000000001,
+        "cacheRead" : 0.033000000000000002,
         "cacheWrite" : 0,
-        "input" : 0.082500000000000004,
-        "output" : 0.33
+        "input" : 0.132,
+        "output" : 0.528
       },
       "id" : "tencent\/hy3",
       "input" : [
@@ -27109,16 +27054,16 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.221,
+        "cacheRead" : 0.1932,
         "cacheWrite" : 0,
-        "input" : 1.19,
-        "output" : 3.74
+        "input" : 0.966,
+        "output" : 3.036
       },
       "id" : "z-ai\/glm-5.2",
       "input" : [
         "text"
       ],
-      "maxTokens" : 262144,
+      "maxTokens" : 131072,
       "name" : "Z.ai: GLM 5.2",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -30006,6 +29951,34 @@
         "xhigh" : "xhigh"
       }
     },
+    "anthropic\/claude-fable-5.1" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "anthropic\/claude-fable-5.1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "anthropic\/claude-haiku-4.5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -30422,25 +30395,6 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
-    "deepseek\/deepseek-v3" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 163840,
-      "cost" : {
-        "cacheRead" : 0.135,
-        "cacheWrite" : 0,
-        "input" : 0.27,
-        "output" : 1.12
-      },
-      "id" : "deepseek\/deepseek-v3",
-      "input" : [
-        "text"
-      ],
-      "maxTokens" : 163840,
-      "name" : "DeepSeek V3 0324",
-      "provider" : "vercel-ai-gateway",
-      "reasoning" : false
-    },
     "deepseek\/deepseek-v3.1" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -30558,7 +30512,7 @@
     "deepseek\/deepseek-v4-flash-vision-exp" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
-      "contextWindow" : 1000000,
+      "contextWindow" : 1048576,
       "cost" : {
         "cacheRead" : 0.0070000000000000001,
         "cacheWrite" : 0,
@@ -30570,7 +30524,7 @@
         "text",
         "image"
       ],
-      "maxTokens" : 384000,
+      "maxTokens" : 1048576,
       "name" : "DeepSeek V4 Flash Vision Exp",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
@@ -33578,6 +33532,25 @@
       ],
       "maxTokens" : 131000,
       "name" : "MiMo V2.5 Pro",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "xiaomi\/mimo-v2.5-pro-ultraspeed" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.010800000000000001,
+        "cacheWrite" : 0,
+        "input" : 1.305,
+        "output" : 2.61
+      },
+      "id" : "xiaomi\/mimo-v2.5-pro-ultraspeed",
+      "input" : [
+        "text"
+      ],
+      "maxTokens" : 131072,
+      "name" : "MiMo V2.5 Pro UltraSpeed",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },


### PR DESCRIPTION
Regenerates both bundled catalogs per the README procedure:

- `models.json` from pi-mono `b8b873b` (2026-09-01)
- `cursor-models.json` from Cursor's `GetUsableModels` RPC

Notable changes: Claude Fable 5.1 added across Anthropic, Bedrock, OpenRouter and Cursor; Cursor gains GPT-5.6 Terra and Kimi K3 variants; a few OpenRouter batch/fast aliases removed upstream.

`swift test`: 1356 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CojZKg4deR73CeHrvY5cys