### PR TITLE
chore(kwwk): bump version to 0.1.51

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.50"
+    static let version = "0.1.51"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
Bump version to 0.1.51 ahead of tagging \`v0.1.51\`.

Since v0.1.50: model catalog refreshes (#132, #133) adding Claude Fable 5.1 and the latest Cursor models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CojZKg4deR73CeHrvY5cys