### PR TITLE
chore(kwwk): refresh model catalogs

### DIFF
--- a/Sources/KWWKAI/Resources/cursor-models.json
+++ b/Sources/KWWKAI/Resources/cursor-models.json
@@ -2419,6 +2419,66 @@
       "input" : 0,
       "output" : 0
     },
+    "id" : "gemini-3.8-flash-high",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.8 Flash High",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gemini-3.8-flash-low",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.8 Flash Low",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
+    "id" : "gemini-3.8-flash-medium",
+    "input" : [
+      "text",
+      "image"
+    ],
+    "maxTokens" : 64000,
+    "name" : "Gemini 3.8 Flash Medium",
+    "provider" : "cursor",
+    "reasoning" : false
+  },
+  {
+    "api" : "cursor-agent",
+    "baseUrl" : "https:\/\/api2.cursor.sh",
+    "contextWindow" : 200000,
+    "cost" : {
+      "cacheRead" : 0,
+      "cacheWrite" : 0,
+      "input" : 0,
+      "output" : 0
+    },
     "id" : "glm-5.2-high",
     "input" : [
       "text"

--- a/Sources/KWWKAI/Resources/models.json
+++ b/Sources/KWWKAI/Resources/models.json
@@ -7230,13 +7230,13 @@
       }
     },
     "accounts\/fireworks\/models\/glm-5p3" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference\/v1",
       "compat" : {
         "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -7252,16 +7252,25 @@
       "maxTokens" : 131072,
       "name" : "GLM 5.3",
       "provider" : "fireworks",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "accounts\/fireworks\/models\/glm-5p3-flash" : {
-      "api" : "anthropic-messages",
-      "baseUrl" : "https:\/\/api.fireworks.ai\/inference",
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/api.fireworks.ai\/inference\/v1",
       "compat" : {
         "sendSessionAffinityHeaders" : true,
-        "supportsCacheControlOnTools" : false,
-        "supportsEagerToolInputStreaming" : false,
-        "supportsLongCacheRetention" : false
+        "supportsDeveloperRole" : false,
+        "supportsLongCacheRetention" : false,
+        "supportsStore" : false
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -7278,7 +7287,16 @@
       "maxTokens" : 131072,
       "name" : "GLM 5.3 Flash",
       "provider" : "fireworks",
-      "reasoning" : true
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : null,
+        "max" : "max",
+        "medium" : null,
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
     },
     "accounts\/fireworks\/models\/gpt-oss-120b" : {
       "api" : "anthropic-messages",
@@ -7649,12 +7667,10 @@
   },
   "github-copilot" : {
     "claude-fable-5" : {
-      "api" : "openai-completions",
+      "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/api.individual.githubcopilot.com",
       "compat" : {
-        "supportsDeveloperRole" : false,
-        "supportsReasoningEffort" : false,
-        "supportsStore" : false
+        "forceAdaptiveThinking" : true
       },
       "contextWindow" : 1000000,
       "cost" : {
@@ -15139,6 +15155,34 @@
         "xhigh" : "xhigh"
       }
     },
+    "claude-fable-5-1" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/opencode.ai\/zen",
+      "compat" : {
+        "forceAdaptiveThinking" : true
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 12.5,
+        "input" : 10,
+        "output" : 50
+      },
+      "id" : "claude-fable-5-1",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Claude Fable 5.1",
+      "provider" : "opencode",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "max" : "max",
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
     "claude-haiku-4-5" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/opencode.ai\/zen",
@@ -17910,18 +17954,18 @@
         "supportsDeveloperRole" : false,
         "thinkingFormat" : "openrouter"
       },
-      "contextWindow" : 1048576,
+      "contextWindow" : 262144,
       "cost" : {
-        "cacheRead" : 0.234,
+        "cacheRead" : 0.1,
         "cacheWrite" : 0,
-        "input" : 1.17,
-        "output" : 3.96
+        "input" : 1.15,
+        "output" : 3.5
       },
       "id" : "~z-ai\/glm-latest",
       "input" : [
         "text"
       ],
-      "maxTokens" : 943718,
+      "maxTokens" : 235929,
       "name" : "Z.ai: GLM Latest",
       "provider" : "openrouter",
       "reasoning" : true,
@@ -18243,6 +18287,39 @@
       ],
       "maxTokens" : 128000,
       "name" : "Anthropic: Claude Fable 5.1",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : "max",
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : "xhigh"
+      }
+    },
+    "anthropic\/claude-fable-5.1:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "cacheControlFormat" : "anthropic",
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.125,
+        "cacheWrite" : 6.25,
+        "input" : 5,
+        "output" : 25
+      },
+      "id" : "anthropic\/claude-fable-5.1:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Anthropic: Claude Fable 5.1 (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -19381,10 +19458,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.017721000000000001,
+        "cacheRead" : 0.016799999999999999,
         "cacheWrite" : 0,
-        "input" : 0.088606000000000004,
-        "output" : 0.177212
+        "input" : 0.084000000000000005,
+        "output" : 0.168
       },
       "id" : "deepseek\/deepseek-v4-flash",
       "input" : [
@@ -19480,10 +19557,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.014,
+        "cacheRead" : 0.0070000000000000001,
         "cacheWrite" : 0,
-        "input" : 0.44,
-        "output" : 1.32
+        "input" : 0.22,
+        "output" : 0.66
       },
       "id" : "deepseek\/deepseek-v4-flash-vision-exp",
       "input" : [
@@ -19514,10 +19591,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.086855000000000002,
+        "cacheRead" : 0.085898000000000002,
         "cacheWrite" : 0,
-        "input" : 1.04226,
-        "output" : 2.08452
+        "input" : 1.030776,
+        "output" : 2.061552
       },
       "id" : "deepseek\/deepseek-v4-pro",
       "input" : [
@@ -19547,10 +19624,10 @@
       },
       "contextWindow" : 1024000,
       "cost" : {
-        "cacheRead" : 0.037179999999999998,
+        "cacheRead" : 0.021999999999999999,
         "cacheWrite" : 0,
-        "input" : 1.1154,
-        "output" : 3.3462
+        "input" : 0.66,
+        "output" : 1.98
       },
       "id" : "deepseek\/deepseek-v4-pro-0813",
       "input" : [
@@ -20362,10 +20439,10 @@
       },
       "contextWindow" : 1048576,
       "cost" : {
-        "cacheRead" : 0.018749999999999999,
-        "cacheWrite" : 0.020833000000000001,
-        "input" : 0.1875,
-        "output" : 0.9375
+        "cacheRead" : 0.037499999999999999,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.375,
+        "output" : 1.875
       },
       "id" : "google\/gemini-3.7-flash:batch",
       "input" : [
@@ -20374,6 +20451,72 @@
       ],
       "maxTokens" : 65536,
       "name" : "Google: Gemini 3.7 Flash (batch)",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "google\/gemini-3.8-flash" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "google\/gemini-3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.8 Flash",
+      "provider" : "openrouter",
+      "reasoning" : true,
+      "thinkingLevelMap" : {
+        "high" : "high",
+        "low" : "low",
+        "max" : null,
+        "medium" : "medium",
+        "minimal" : null,
+        "off" : null,
+        "xhigh" : null
+      }
+    },
+    "google\/gemini-3.8-flash:batch" : {
+      "api" : "openai-completions",
+      "baseUrl" : "https:\/\/openrouter.ai\/api\/v1",
+      "compat" : {
+        "supportsDeveloperRole" : false,
+        "thinkingFormat" : "openrouter"
+      },
+      "contextWindow" : 1048576,
+      "cost" : {
+        "cacheRead" : 0.037499999999999999,
+        "cacheWrite" : 0.041667000000000003,
+        "input" : 0.375,
+        "output" : 1.875
+      },
+      "id" : "google\/gemini-3.8-flash:batch",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Google: Gemini 3.8 Flash (batch)",
       "provider" : "openrouter",
       "reasoning" : true,
       "thinkingLevelMap" : {
@@ -29824,6 +29967,26 @@
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },
+    "alibaba\/qwen3.8-max-0902" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 991000,
+      "cost" : {
+        "cacheRead" : 0.25,
+        "cacheWrite" : 2.5,
+        "input" : 2,
+        "output" : 6
+      },
+      "id" : "alibaba\/qwen3.8-max-0902",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 128000,
+      "name" : "Qwen3.8 Max 0902",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
     "amazon\/nova-2-lite" : {
       "api" : "anthropic-messages",
       "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
@@ -30764,6 +30927,26 @@
       ],
       "maxTokens" : 65536,
       "name" : "Gemini 3.7 Flash",
+      "provider" : "vercel-ai-gateway",
+      "reasoning" : true
+    },
+    "google\/gemini-3.8-flash" : {
+      "api" : "anthropic-messages",
+      "baseUrl" : "https:\/\/ai-gateway.vercel.sh",
+      "contextWindow" : 1000000,
+      "cost" : {
+        "cacheRead" : 0.074999999999999997,
+        "cacheWrite" : 0,
+        "input" : 0.75,
+        "output" : 3.75
+      },
+      "id" : "google\/gemini-3.8-flash",
+      "input" : [
+        "text",
+        "image"
+      ],
+      "maxTokens" : 65536,
+      "name" : "Gemini 3.8 Flash",
       "provider" : "vercel-ai-gateway",
       "reasoning" : true
     },


### PR DESCRIPTION
## Summary

- regenerate the regular model catalog from `badlogic/pi-mono@e266507`
- refresh the Cursor catalog from the live `GetUsableModels` RPC
- add 6 regular-provider models and 3 Cursor Gemini 3.8 Flash variants
- update metadata for 9 existing regular-provider models

## Testing

- `swift test` (1356 tests in 198 suites)
- JSON structure, model counts, unique Cursor IDs, and `git diff --check`
