### PR TITLE
chore(kwwk): bump version to 0.1.52

### DIFF
--- a/Sources/KWWKCli/Theme.swift
+++ b/Sources/KWWKCli/Theme.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Maintained by hand — no release tooling touches this file — so bump it
 /// alongside each tag. (`--help` does not print a version.)
 enum KWWKBuild {
-    static let version = "0.1.51"
+    static let version = "0.1.52"
 }
 
 /// Truecolor palette + text styling for the redesigned TUI chrome. The


### PR DESCRIPTION
## Summary

- bump the CLI version from `0.1.51` to `0.1.52`
- prepare a patch release containing the refreshed model catalogs from #135

## Testing

- `swift test` (1356 tests in 198 suites)
