### PR TITLE
Add an opt-in host hook before natural run completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,13 @@ try await agent.prompt("Is it warmer in Tokyo or Oslo right now?")
 
 ### Hooks — audit, redact, short-circuit
 
+`beforeRunEnd` is an optional host completion policy on `AgentOptions` / `Agent`.
+After a natural stop and drained queues, it can return runtime messages to keep
+the same run going, or `[]` to finish. It receives the current `AgentContext`
+and cancellation handle. Cancellation, provider failures and hard turn limits
+remain terminal. No hook is installed by default; background task behavior is
+unchanged. Hosts that wait in the hook must bound that wait and honor cancellation.
+
 Every `AgentOptions` accepts hooks that fire at well-defined points. Use
 them to enforce policy without forking the loop:
 

--- a/Sources/KWWKAgent/Agent.swift
+++ b/Sources/KWWKAgent/Agent.swift
@@ -104,6 +104,7 @@ public struct AgentOptions: Sendable {
     public var convertToLlm: ConvertToLlmHook?
     public var transformContext: TransformContextHook?
     public var betweenTurns: BetweenTurnsHook?
+    public var beforeRunEnd: BeforeRunEndHook?
     /// Automatic context compaction. Enabled by default at 75% of the model's
     /// context window; pass `nil` to opt out of proactive compaction and
     /// provider-overflow recovery.
@@ -134,6 +135,7 @@ public struct AgentOptions: Sendable {
         convertToLlm: ConvertToLlmHook? = nil,
         transformContext: TransformContextHook? = nil,
         betweenTurns: BetweenTurnsHook? = nil,
+        beforeRunEnd: BeforeRunEndHook? = nil,
         autoCompact: AgentAutoCompactOptions? = AgentAutoCompactOptions(),
         compactionModel: Model? = nil,
         authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)? = nil
@@ -156,6 +158,7 @@ public struct AgentOptions: Sendable {
         self.convertToLlm = convertToLlm
         self.transformContext = transformContext
         self.betweenTurns = betweenTurns
+        self.beforeRunEnd = beforeRunEnd
         self.autoCompact = autoCompact
         self.compactionModel = compactionModel
         self.authResolver = authResolver
@@ -213,6 +216,7 @@ public final class Agent: @unchecked Sendable {
     private var _convertToLlm: ConvertToLlmHook?
     private var _transformContext: TransformContextHook?
     private var _betweenTurns: BetweenTurnsHook?
+    private var _beforeRunEnd: BeforeRunEndHook?
     private var _autoCompact: AgentAutoCompactOptions?
     private var _compactionModel: Model?
     private var _authResolver: (@Sendable (Model, String?) async throws -> ResolvedProviderAuth?)?
@@ -265,6 +269,10 @@ public final class Agent: @unchecked Sendable {
     public var betweenTurns: BetweenTurnsHook? {
         get { lock.withLock { _betweenTurns } }
         set { lock.withLock { _betweenTurns = newValue } }
+    }
+    public var beforeRunEnd: BeforeRunEndHook? {
+        get { lock.withLock { _beforeRunEnd } }
+        set { lock.withLock { _beforeRunEnd = newValue } }
     }
     public var autoCompact: AgentAutoCompactOptions? {
         get { lock.withLock { _autoCompact } }
@@ -347,6 +355,7 @@ public final class Agent: @unchecked Sendable {
         self._convertToLlm = options.convertToLlm
         self._transformContext = options.transformContext
         self._betweenTurns = options.betweenTurns
+        self._beforeRunEnd = options.beforeRunEnd
         self._autoCompact = options.autoCompact
         self._compactionModel = options.compactionModel
         self._authResolver = options.authResolver
@@ -737,6 +746,7 @@ extension Agent {
             convertToLlm: convertToLlm,
             transformContext: transformContext,
             betweenTurns: builtInBetweenTurnsHook(),
+            beforeRunEnd: beforeRunEnd,
             contextCompaction: builtInContextCompactionHook()
         )
         config.finalTextOnlyOnLastTurn = finalTextOnlyOnLastTurn

--- a/Sources/KWWKAgent/AgentLoop.swift
+++ b/Sources/KWWKAgent/AgentLoop.swift
@@ -45,6 +45,7 @@ public struct AgentLoopConfig: Sendable {
     public var convertToLlm: ConvertToLlmHook?
     public var transformContext: TransformContextHook?
     public var betweenTurns: BetweenTurnsHook?
+    public var beforeRunEnd: BeforeRunEndHook?
     public var contextCompaction: ContextCompactionHook?
 
     public init(
@@ -71,6 +72,7 @@ public struct AgentLoopConfig: Sendable {
         convertToLlm: ConvertToLlmHook? = nil,
         transformContext: TransformContextHook? = nil,
         betweenTurns: BetweenTurnsHook? = nil,
+        beforeRunEnd: BeforeRunEndHook? = nil,
         contextCompaction: ContextCompactionHook? = nil
     ) {
         self.model = model
@@ -96,6 +98,7 @@ public struct AgentLoopConfig: Sendable {
         self.convertToLlm = convertToLlm
         self.transformContext = transformContext
         self.betweenTurns = betweenTurns
+        self.beforeRunEnd = beforeRunEnd
         self.contextCompaction = contextCompaction
     }
 }
@@ -658,6 +661,19 @@ public enum AgentLoop {
             if !followUps.isEmpty {
                 pendingMessages = followUps
                 continue outer
+            }
+            if let limit = config.maxTurns, turnsExecuted >= limit { break }
+            if let hook = config.beforeRunEnd, cancellation?.isCancelled != true {
+                var messages = await hook(currentContext, cancellation)
+                try cancellation?.throwIfCancelled()
+                try Task.checkCancellation()
+                messages += await config.getRuntimeMessages()
+                messages += await config.getSteeringMessages()
+                messages += await config.getFollowUpMessages()
+                if !messages.isEmpty, cancellation?.isCancelled != true {
+                    pendingMessages = messages
+                    continue outer
+                }
             }
             break
         }

--- a/Sources/KWWKAgent/AgentTypes.swift
+++ b/Sources/KWWKAgent/AgentTypes.swift
@@ -555,6 +555,12 @@ public typealias TransformContextHook = @Sendable ([Message], CancellationHandle
 /// returns the loop resumes with the new context.
 public typealias BetweenTurnsHook = @Sendable (AgentContext, CancellationHandle?) async -> AgentContext?
 
+/// Optional host policy at natural run completion, after queued messages drain.
+/// Return runtime messages to continue the same run, or an empty array to finish.
+/// Errors, cancellation and hard turn limits bypass this hook. Hosts must honor
+/// cancellation and bound any waiting they perform here. Default: no policy.
+public typealias BeforeRunEndHook = @Sendable (AgentContext, CancellationHandle?) async -> [Message]
+
 public enum AgentContextCompactionTrigger: Sendable, Hashable {
     case preflight(pendingMessages: [Message])
     case proactive

--- a/Tests/KWWKAgentTests/BeforeRunEndTests.swift
+++ b/Tests/KWWKAgentTests/BeforeRunEndTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+@testable import KWWKAI
+
+private actor RetryAttemptCounter {
+    private var value = 0
+    func next() -> Int { value += 1; return value }
+    func snapshot() -> Int { value }
+}
+
+@Suite("Optional host completion policy")
+struct BeforeRunEndTests {
+    @Test("A host refusal resumes the same run and retains runtime context")
+    func continuesSameRun() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("attempt")), .message(fauxAssistantMessage("finished"))])
+        let calls = RetryAttemptCounter()
+        let starts = RetryAttemptCounter()
+        let ends = RetryAttemptCounter()
+        let agent = Agent(options: AgentOptions(initialState: AgentInitialState(model: faux.getModel()),
+            beforeRunEnd: { _, _ in
+                guard await calls.next() == 1 else { return [] }
+                return [.user(UserMessage(content: [.text(TextContent(text: "Wait for unfinished work."))], source: .runtime))]
+            }))
+        _ = agent.subscribe { event, _ in
+            if case .agentStart = event { _ = await starts.next() }
+            if case .agentEnd = event { _ = await ends.next() }
+        }
+        try await agent.prompt("work")
+        #expect(await starts.snapshot() == 1)
+        #expect(await ends.snapshot() == 1)
+        #expect(agent.state.messages.contains { if case .user(let message) = $0 { return message.source == .runtime }; return false })
+        #expect(await calls.snapshot() == 2)
+    }
+
+    @Test("An unset policy preserves natural completion")
+    func defaultUnchanged() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("finished"))])
+        let agent = Agent(initialState: AgentInitialState(model: faux.getModel()))
+        try await agent.prompt("work")
+        #expect(agent.beforeRunEnd == nil)
+        #expect(!agent.state.isStreaming)
+    }
+
+    @Test("Errors bypass the completion policy")
+    func failureBypassesPolicy() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("failed", stopReason: .aborted))])
+        let calls = RetryAttemptCounter()
+        let agent = Agent(options: AgentOptions(initialState: AgentInitialState(model: faux.getModel()),
+            beforeRunEnd: { _, _ in _ = await calls.next(); return [] }))
+        try await agent.prompt("work")
+        #expect(await calls.snapshot() == 0)
+    }
+
+    @Test("A hard turn cap cannot be extended by host policy")
+    func turnLimitWins() async throws {
+        let faux = await registerFauxProvider()
+        defer { faux.unregister() }
+        faux.setResponses([.message(fauxAssistantMessage("finished"))])
+        let calls = RetryAttemptCounter()
+        let agent = Agent(options: AgentOptions(initialState: AgentInitialState(model: faux.getModel()),
+            maxTurns: 1, beforeRunEnd: { _, _ in _ = await calls.next(); return [.user(UserMessage(text: "continue"))] }))
+        try await agent.prompt("work")
+        #expect(await calls.snapshot() == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Add an optional `beforeRunEnd` host hook so integrations can keep a naturally ending run open without changing kwwk's default task behavior.

- Invoke the hook only after normal runtime, steering, and follow-up queues have drained.
- Empty results allow completion; returned messages continue the same run.
- Recheck queued input and cancellation after the hook returns.
- Preserve hard turn limits, error/abort exits, and existing subagent terminal behavior. The default hook is nil.

AirBuild uses this seam to require an Agent with queued/running tasks to keep working, wait, or cancel its tasks. The policy itself remains outside kwwk.

## Validation

36 targeted tests passed across BeforeRunEndTests, AgentLoopPolicyTests, AgentQueuesTests, and AgentBackgroundTests, including same-run continuation, default behavior, queued input, and hard-limit/error boundaries.

## Rollout

Merge before [kwwk-bot #34](https://github.com/yellowplushq/kwwk-bot/pull/34) and [AirBuildEnvironment #135](https://github.com/yellowplushq/AirBuildEnvironment/pull/135). No deployment or default policy change is included.
