### PR TITLE
Load immutable skills roots from skills.index without rescanning files

### DIFF
--- a/Sources/KWWKAgent/Skills.swift
+++ b/Sources/KWWKAgent/Skills.swift
@@ -278,7 +278,7 @@ public enum Skills {
     /// recursively for `SKILL.md` files; root-level `.md` files are also loaded
     /// as skills. Missing directories are skipped silently. Duplicate skill
     /// names keep the first occurrence (earlier directories win).
-    public static func load(directories: [String]) -> (skills: [Skill], diagnostics: [SkillDiagnostic]) {
+    public static func load(directories: [String], useIndex: Bool = true) -> (skills: [Skill], diagnostics: [SkillDiagnostic]) {
         var skills: [Skill] = []
         var diagnostics: [SkillDiagnostic] = []
         var seenNames: Set<String> = []
@@ -289,6 +289,15 @@ public enum Skills {
             guard fm.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue else { continue }
             // Fresh matcher per root dir; rootDir == dir so prefixes are
             // relative to each root (pi parity).
+            let indexed = useIndex ? SkillsIndex.read(directory: dir) : nil
+            if let indexed, let entries = indexed.skills {
+                for skill in entries where seenNames.insert(skill.name).inserted {
+                    skills.append(skill)
+                }
+                diagnostics.append(contentsOf: indexed.diagnostics)
+                continue
+            }
+            if let indexed { diagnostics.append(contentsOf: indexed.diagnostics) }
             let result = loadFromDirectory(
                 dir,
                 includeRootFiles: true,

--- a/Sources/KWWKAgent/SkillsIndex.swift
+++ b/Sources/KWWKAgent/SkillsIndex.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// A publisher-owned index for an immutable skills root. No child paths are
+/// touched on read: publishers must replace files and index as one snapshot.
+/// Body is retained to preserve Skill's existing eager-body API for SDK users.
+enum SkillsIndex {
+    static let filename = "skills.index"
+    static let maximumBytes = 32 * 1024 * 1024
+
+    struct Document: Codable {
+        var version: Int
+        var skills: [Entry]
+        var diagnostics: [Diagnostic]
+    }
+    struct Entry: Codable {
+        var name: String
+        var description: String
+        var path: String
+        var body: String
+        var disableModelInvocation: Bool
+    }
+    struct Diagnostic: Codable {
+        var code: String
+        var message: String
+        var path: String
+    }
+    enum Invalid: Error { case format, path, tooLarge }
+
+    static func relative(_ path: String, root: URL) throws -> String {
+        let absolute = URL(fileURLWithPath: path).standardizedFileURL.path
+        let prefix = root.path + "/"
+        guard absolute.hasPrefix(prefix) else { throw Invalid.path }
+        let result = String(absolute.dropFirst(prefix.count))
+        try validate(result)
+        return result
+    }
+
+    static func validate(_ path: String) throws {
+        let parts = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !path.isEmpty, !path.contains("\\"), !path.contains("\0"),
+              parts.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." })
+        else { throw Invalid.path }
+    }
+
+    static func read(directory: String) -> (skills: [Skill]?, diagnostics: [SkillDiagnostic])? {
+        let root = URL(fileURLWithPath: directory).standardizedFileURL
+        let url = root.appendingPathComponent(filename)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        do {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            let data = try handle.read(upToCount: maximumBytes + 1) ?? Data()
+            guard data.count <= maximumBytes else { throw Invalid.tooLarge }
+            let doc = try JSONDecoder().decode(Document.self, from: data)
+            guard doc.version == 1 else { throw Invalid.format }
+            let skills = try doc.skills.map { entry in
+                try validate(entry.path)
+                guard !entry.name.isEmpty, !entry.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { throw Invalid.format }
+                return Skill(name: entry.name, description: entry.description,
+                             path: root.appendingPathComponent(entry.path).path,
+                             body: entry.body, disableModelInvocation: entry.disableModelInvocation)
+            }
+            let diagnostics = try doc.diagnostics.map { entry in
+                try validate(entry.path)
+                guard let code = SkillDiagnostic.Code(rawValue: entry.code) else { throw Invalid.format }
+                return SkillDiagnostic(code: code, message: entry.message,
+                                       path: root.appendingPathComponent(entry.path).path)
+            }
+            return (skills, diagnostics)
+        } catch {
+            return (nil, [.init(code: .invalidMetadata,
+                               message: "Invalid or unsupported skills.index; falling back to directory scanning",
+                               path: url.path)])
+        }
+    }
+}
+
+extension Skills {
+    /// Generate from the actual tree, never from an older index. Call only
+    /// while constructing a private snapshot, then publish the whole root.
+    public static func writeIndex(directory: String) throws {
+        let root = URL(fileURLWithPath: directory).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory), isDirectory.boolValue
+        else { throw SkillsIndex.Invalid.path }
+        let result = load(directories: [root.path], useIndex: false)
+        let doc = try SkillsIndex.Document(version: 1, skills: result.skills.map {
+            SkillsIndex.Entry(name: $0.name, description: $0.description,
+                              path: try SkillsIndex.relative($0.path, root: root), body: $0.body,
+                              disableModelInvocation: $0.disableModelInvocation)
+        }, diagnostics: result.diagnostics.map {
+            SkillsIndex.Diagnostic(code: $0.code.rawValue, message: $0.message,
+                                   path: try SkillsIndex.relative($0.path, root: root))
+        })
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(doc)
+        guard data.count <= SkillsIndex.maximumBytes else { throw SkillsIndex.Invalid.tooLarge }
+        try data.write(to: root.appendingPathComponent(SkillsIndex.filename), options: .atomic)
+    }
+}

--- a/Tests/KWWKAgentTests/SkillsIndexTests.swift
+++ b/Tests/KWWKAgentTests/SkillsIndexTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import KWWKAgent
+
+@Suite("Skills index")
+struct SkillsIndexTests {
+    private func fixture() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let skill = root.appendingPathComponent("example")
+        try FileManager.default.createDirectory(at: skill, withIntermediateDirectories: true)
+        try "---\nname: example\ndescription: Example skill\ndisable-model-invocation: true\n---\nBody".write(
+            to: skill.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        return root
+    }
+
+    @Test func roundTripWithoutReadingChildren() throws {
+        let root = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let expected = Skills.load(directories: [root.path])
+        try Skills.writeIndex(directory: root.path)
+        try FileManager.default.removeItem(at: root.appendingPathComponent("example"))
+        let indexed = Skills.load(directories: [root.path])
+        #expect(indexed.skills == expected.skills)
+        #expect(indexed.diagnostics == expected.diagnostics)
+        #expect(Skills.load(directories: [root.path], useIndex: false).skills.isEmpty)
+    }
+
+    @Test(arguments: ["../outside/SKILL.md", "/etc/passwd", "example/../../secret", "example\\SKILL.md", "example//SKILL.md"])
+    func unsafePathFallsBack(path: String) throws {
+        let root = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let expected = Skills.load(directories: [root.path]).skills
+        try Skills.writeIndex(directory: root.path)
+        let file = root.appendingPathComponent("skills.index")
+        var doc = try JSONDecoder().decode(SkillsIndex.Document.self, from: Data(contentsOf: file))
+        doc.skills[0].path = path
+        try JSONEncoder().encode(doc).write(to: file)
+        let result = Skills.load(directories: [root.path])
+        #expect(result.skills == expected)
+        #expect(result.diagnostics.contains { $0.path == file.path })
+    }
+
+    @Test(arguments: ["not json", "{\"version\":999,\"skills\":[],\"diagnostics\":[]}"])
+    func invalidIndexFallsBack(json: String) throws {
+        let root = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let expected = Skills.load(directories: [root.path]).skills
+        try json.write(to: root.appendingPathComponent("skills.index"), atomically: true, encoding: .utf8)
+        let result = Skills.load(directories: [root.path])
+        #expect(result.skills == expected)
+        #expect(!result.diagnostics.isEmpty)
+    }
+
+    @Test func relocationRegenerationAndPrecedence() throws {
+        let root = try fixture()
+        let other = try fixture()
+        defer { try? FileManager.default.removeItem(at: root); try? FileManager.default.removeItem(at: other) }
+        try Skills.writeIndex(directory: root.path)
+        let relocated = root.appendingPathComponent("moved")
+        try FileManager.default.createDirectory(at: relocated, withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: root.appendingPathComponent("skills.index"), to: relocated.appendingPathComponent("skills.index"))
+        #expect(Skills.load(directories: [relocated.path]).skills.first?.path == relocated.appendingPathComponent("example/SKILL.md").path)
+        let result = Skills.load(directories: [root.path, other.path])
+        #expect(result.skills.map(\.path) == [root.appendingPathComponent("example/SKILL.md").path])
+        try FileManager.default.removeItem(at: root.appendingPathComponent("example"))
+        try FileManager.default.removeItem(at: relocated)
+        try Skills.writeIndex(directory: root.path)
+        #expect(Skills.load(directories: [root.path]).skills.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Prefer a versioned skills.index in each explicitly selected skills root; valid indices avoid per-skill filesystem reads.
- Add Skills.writeIndex(directory:) using the existing scanner/parser. Preserve Skill fields, invocation flags, diagnostics and root precedence; paths are relative for relocation.
- Reject unsafe relative paths and oversized/unsupported indices. Missing indices use normal discovery; invalid indices emit a diagnostic and fall back.
- Publishers must atomically publish the complete immutable tree and index. Readers intentionally do not revalidate each child file.

## Verification
18 skills/index tests passed, covering round-trip without child files, malformed/unsupported index fallback, traversal rejection, relocation, regeneration and precedence.

## Scope
No automatic deployment or release. AirBuildEnvironment companion pins this commit and generates indices during projection and packaging.